### PR TITLE
Refactored ZendHashTable conversions

### DIFF
--- a/example/skel/test.php
+++ b/example/skel/test.php
@@ -1,6 +1,7 @@
 <?php
 
 var_dump(SKEL_TEST_CONST, SKEL_TEST_LONG_CONST);
+var_dump(test_array());
 die;
 
 $x = new TestClass();


### PR DESCRIPTION
We shouldn't really be returning Zval objects, rather references to Zval
objects. There is currently a memory leak with arrays that need to be
resolved.