### PR TITLE
Replace unit errors with error enum

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,28 @@
+use std::{error::Error as ErrorTrait, fmt::Display};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum Error {
+    IncorrectArguments(u32, u32),
+    ZvalConversionError,
+    UnknownDatatype(u32),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::IncorrectArguments(n, expected) => write!(
+                f,
+                "Expected at least {} arguments, got {} arguments.",
+                expected, n
+            ),
+            Error::ZvalConversionError => {
+                write!(f, "Unable to convert from Zval to primitive type.")
+            }
+            Error::UnknownDatatype(dt) => write!(f, "Unknown datatype {}.", dt),
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,13 +1,31 @@
 use std::{error::Error as ErrorTrait, fmt::Display};
 
+use crate::php::enums::DataType;
+
+/// The main result type which is passed by the library.
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// The main error type which is passed by the library inside the custom
+/// [`Result`] type.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum Error {
+    /// An incorrect number of arguments was given to a PHP function.
+    ///
+    /// The type carries two integers - the first representing the minimum
+    /// number of arguments expected, and the second representing the number of
+    /// arguments that were received.
     IncorrectArguments(u32, u32),
-    ZvalConversionError,
-    UnknownDatatype(u32),
+
+    /// There was an error converting a Zval into a primitive type.
+    ///
+    /// The type carries the data type of the Zval.
+    ZvalConversion(DataType),
+
+    /// The type of the Zval is unknown.
+    ///
+    /// The type carries the integer representation of the type of Zval.
+    UnknownDatatype(u8),
 }
 
 impl Display for Error {
@@ -18,11 +36,14 @@ impl Display for Error {
                 "Expected at least {} arguments, got {} arguments.",
                 expected, n
             ),
-            Error::ZvalConversionError => {
-                write!(f, "Unable to convert from Zval to primitive type.")
-            }
+            Error::ZvalConversion(ty) => write!(
+                f,
+                "Could not convert Zval from type {} into primitive type.",
+                ty
+            ),
             Error::UnknownDatatype(dt) => write!(f, "Unknown datatype {}.", dt),
-            _ => unreachable!(),
         }
     }
 }
+
+impl ErrorTrait for Error {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #[macro_use]
 pub mod macros;
 pub mod bindings;
+pub mod errors;
 pub mod functions;
 pub mod php;
 

--- a/src/php/enums.rs
+++ b/src/php/enums.rs
@@ -1,11 +1,14 @@
 //! Wrapper for enums introduced in C.
 
-use crate::bindings::{
-    IS_ARRAY, IS_CALLABLE, IS_CONSTANT_AST, IS_DOUBLE, IS_FALSE, IS_LONG, IS_NULL, IS_OBJECT,
-    IS_REFERENCE, IS_RESOURCE, IS_STRING, IS_TRUE, IS_UNDEF, IS_VOID,
-};
+use std::convert::TryFrom;
 
-use super::types::long::ZendLong;
+use crate::{
+    bindings::{
+        IS_ARRAY, IS_CALLABLE, IS_CONSTANT_AST, IS_DOUBLE, IS_FALSE, IS_LONG, IS_NULL, IS_OBJECT,
+        IS_REFERENCE, IS_RESOURCE, IS_STRING, IS_TRUE, IS_UNDEF, IS_VOID,
+    },
+    errors::{Error, Result},
+};
 
 /// Valid data types for PHP.
 #[derive(Clone, Copy, Debug)]
@@ -29,30 +32,27 @@ pub enum DataType {
     Void = IS_VOID,
 }
 
-impl From<ZendLong> for DataType {
-    fn from(_: ZendLong) -> Self {
-        Self::Long
-    }
-}
+impl TryFrom<u8> for DataType {
+    type Error = Error;
 
-impl From<bool> for DataType {
-    fn from(x: bool) -> Self {
-        if x {
-            Self::True
-        } else {
-            Self::False
+    fn try_from(value: u32) -> Result<Self> {
+        match value {
+            IS_UNDEF => Ok(DataType::Undef),
+            IS_NULL => Ok(DataType::Null),
+            IS_FALSE => Ok(DataType::False),
+            IS_TRUE => Ok(DataType::True),
+            IS_LONG => Ok(DataType::Long),
+            IS_DOUBLE => Ok(DataType::Double),
+            IS_STRING => Ok(DataType::String),
+            IS_ARRAY => Ok(DataType::Array),
+            IS_OBJECT => Ok(DataType::Object),
+            IS_RESOURCE => Ok(DataType::Resource),
+            IS_REFERENCE => Ok(DataType::Reference),
+            IS_CALLABLE => Ok(DataType::Callable),
+            IS_CONSTANT_AST => Ok(DataType::ConstantExpression),
+            IS_VOID => Ok(DataType::Void),
+
+            _ => Err(Error::UnknownDatatype(value)),
         }
-    }
-}
-
-impl From<f64> for DataType {
-    fn from(_: f64) -> Self {
-        Self::Double
-    }
-}
-
-impl From<String> for DataType {
-    fn from(_: String) -> Self {
-        Self::String
     }
 }

--- a/src/php/enums.rs
+++ b/src/php/enums.rs
@@ -1,6 +1,6 @@
 //! Wrapper for enums introduced in C.
 
-use std::convert::TryFrom;
+use std::{convert::TryFrom, fmt::Display};
 
 use crate::{
     bindings::{
@@ -35,8 +35,8 @@ pub enum DataType {
 impl TryFrom<u8> for DataType {
     type Error = Error;
 
-    fn try_from(value: u32) -> Result<Self> {
-        match value {
+    fn try_from(value: u8) -> Result<Self> {
+        match value as u32 {
             IS_UNDEF => Ok(DataType::Undef),
             IS_NULL => Ok(DataType::Null),
             IS_FALSE => Ok(DataType::False),
@@ -53,6 +53,27 @@ impl TryFrom<u8> for DataType {
             IS_VOID => Ok(DataType::Void),
 
             _ => Err(Error::UnknownDatatype(value)),
+        }
+    }
+}
+
+impl Display for DataType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DataType::Undef => write!(f, "Undefined"),
+            DataType::Null => write!(f, "Null"),
+            DataType::False => write!(f, "False"),
+            DataType::True => write!(f, "True"),
+            DataType::Long => write!(f, "Long"),
+            DataType::Double => write!(f, "Double"),
+            DataType::String => write!(f, "String"),
+            DataType::Array => write!(f, "Array"),
+            DataType::Object => write!(f, "Object"),
+            DataType::Resource => write!(f, "Resource"),
+            DataType::Reference => write!(f, "Reference"),
+            DataType::Callable => write!(f, "Callable"),
+            DataType::ConstantExpression => write!(f, "Constant Expression"),
+            DataType::Void => write!(f, "Void"),
         }
     }
 }

--- a/src/php/types/array.rs
+++ b/src/php/types/array.rs
@@ -135,7 +135,7 @@ impl ZendHashTable {
     /// # Returns
     ///
     /// * `Ok(())` - Key was successfully removed.
-    /// * `Err(())` - No key was removed, did not exist.
+    /// * `None` - No key was removed, did not exist.
     pub fn remove_index(&self, key: u64) -> Option<()> {
         let result = unsafe { zend_hash_index_del(self.ptr, key) };
 
@@ -191,7 +191,7 @@ impl ZendHashTable {
     ///
     /// # Returns
     ///
-    /// * `Some(Zval)` - The existing value in the hash table that was overriden.
+    /// * `Some(&Zval)` - The existing value in the hash table that was overriden.
     /// * `None` - The element was inserted.
     pub fn insert_at_index<V>(&mut self, key: u64, val: V) -> Option<&Zval>
     where

--- a/src/php/types/zval.rs
+++ b/src/php/types/zval.rs
@@ -372,8 +372,11 @@ macro_rules! try_from_zval {
             type Error = Error;
             fn try_from(value: &Zval) -> Result<Self> {
                 match value.$fn() {
-                    Some(v) => <$type>::try_from(v).map_err(|_| Error::ZvalConversionError),
-                    _ => Err(Error::ZvalConversionError),
+                    Some(v) => match <$type>::try_from(v) {
+                        Ok(v) => Ok(v),
+                        Err(_) => Err(Error::ZvalConversion(value.get_type()?)),
+                    },
+                    _ => Err(Error::ZvalConversion(value.get_type()?)),
                 }
             }
         }


### PR DESCRIPTION
- Provides a better debugging experience.
- Added `Zval::get_type() -> Result<DataType>`.