### PR TITLE
Added Debug and Clone implementations

### DIFF
--- a/example/skel/src/lib.rs
+++ b/example/skel/src/lib.rs
@@ -118,7 +118,7 @@ pub extern "C" fn module_init(_type: i32, module_number: i32) -> i32 {
 #[no_mangle]
 pub extern "C" fn get_module() -> *mut ext_php_rs::php::module::ModuleEntry {
     let funct = FunctionBuilder::new("skeleton_version", skeleton_version)
-        .arg(Arg::new("a", DataType::Long))
+        .arg(Arg::new("a", DataType::Array))
         .arg(Arg::new("b", DataType::Double))
         .not_required()
         .arg(Arg::new("c", DataType::Double))
@@ -144,32 +144,14 @@ pub extern "C" fn get_module() -> *mut ext_php_rs::php::module::ModuleEntry {
 }
 
 #[no_mangle]
-pub extern "C" fn skeleton_version(execute_data: &mut ExecutionData, _retval: &mut Zval) {
-    let mut x = Arg::new("x", DataType::Long);
+pub extern "C" fn skeleton_version(execute_data: &mut ExecutionData, retval: &mut Zval) {
+    let mut x = Arg::new("x", DataType::Array);
     let mut y = Arg::new("y", DataType::Double);
     let mut z = Arg::new("z", DataType::Double);
 
-    let result = ArgParser::new(execute_data)
-        .arg(&mut x)
-        .arg(&mut y)
-        .not_required()
-        .arg(&mut z)
-        .parse();
-
-    if result.is_err() {
-        return;
-    }
-
-    throw(ClassEntry::exception(), "Hello!");
-
-    let result = format!(
-        "x: {}, y: {}, z: {}",
-        x.val::<ZendLong>().unwrap_or_default(),
-        y.val::<f64>().unwrap_or_default(),
-        z.val::<f64>().unwrap_or_default()
-    );
-
-    _retval.set_string(result);
+    parse_args!(execute_data, x, y; z);
+    dbg!(x);
+    retval.set_string("Hello");
 }
 
 #[no_mangle]

--- a/example/skel/test.php
+++ b/example/skel/test.php
@@ -1,5 +1,8 @@
 <?php
 
+var_dump(skeleton_version(['world' => 'hello', 1, 3],2.1123));
+die;
+
 var_dump(SKEL_TEST_CONST, SKEL_TEST_LONG_CONST);
 var_dump(test_array());
 die;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -131,3 +131,31 @@ macro_rules! parse_args {
         }
     }};
 }
+
+/// Throws an exception and returns from the current function.
+///
+/// Wraps the [`throw`] function by inserting a `return` statement after throwing the exception.
+///
+/// [`throw`]: crate::php::exceptions::throw
+///
+/// # Examples
+///
+/// ```
+/// use ext_php_rs::{throw, php::{class::ClassEntry, execution_data::ExecutionData, types::zval::Zval}};
+///
+/// pub extern "C" fn example_fn(execute_data: &mut ExecutionData, _: &mut Zval) {
+///     let something_wrong = true;
+///     if something_wrong {
+///         throw!(ClassEntry::exception(), "Something is wrong!");
+///     }
+///
+///     assert!(false); // This will not run.
+/// }
+/// ```
+#[macro_export]
+macro_rules! throw {
+    ($ex: expr, $reason: expr) => {
+        $crate::php::exceptions::throw($ex, $reason);
+        return;
+    };
+}

--- a/src/php/args.rs
+++ b/src/php/args.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 
 /// Represents an argument to a function.
+#[derive(Debug, Clone)]
 pub struct Arg<'a> {
     pub(crate) name: String,
     pub(crate) _type: DataType,

--- a/src/php/function.rs
+++ b/src/php/function.rs
@@ -40,6 +40,7 @@ pub type FunctionHandler = extern "C" fn(execute_data: &mut ExecutionData, retva
 type FunctionPointerHandler = extern "C" fn(execute_data: *mut ExecutionData, retval: *mut Zval);
 
 /// Builds a function to be exported as a PHP function.
+#[derive(Debug, Clone)]
 pub struct FunctionBuilder<'a> {
     function: FunctionEntry,
     args: Vec<Arg<'a>>,

--- a/src/php/module.rs
+++ b/src/php/module.rs
@@ -42,6 +42,7 @@ pub type InfoFunc = extern "C" fn(zend_module: *mut ModuleEntry);
 ///         .into_raw()
 /// }
 /// ```
+#[derive(Debug, Clone)]
 pub struct ModuleBuilder {
     module: ModuleEntry,
     functions: Vec<FunctionEntry>,

--- a/src/php/types/array.rs
+++ b/src/php/types/array.rs
@@ -4,6 +4,7 @@
 use std::{
     collections::HashMap,
     convert::{TryFrom, TryInto},
+    fmt::Debug,
     u64,
 };
 
@@ -224,6 +225,17 @@ impl ZendHashTable {
     pub(crate) fn into_ptr(mut self) -> *mut HashTable {
         self.free = false;
         self.ptr
+    }
+}
+
+impl Debug for ZendHashTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_map()
+            .entries(
+                self.into_iter()
+                    .map(|(k, k2, v)| (k2.unwrap_or_else(|| k.to_string()), v)),
+            )
+            .finish()
     }
 }
 

--- a/src/php/types/object.rs
+++ b/src/php/types/object.rs
@@ -2,6 +2,7 @@
 //! allowing users to store Rust data inside a PHP object.
 
 use std::{
+    fmt::Debug,
     mem,
     ops::{Deref, DerefMut},
 };
@@ -92,6 +93,12 @@ impl<T: Default> ZendClassObject<T> {
             let ptr = ptr.offset(0 - offset as isize);
             (ptr as *mut Self).as_mut()
         }
+    }
+}
+
+impl<T: Default + Debug> Debug for ZendClassObject<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.obj.fmt(f)
     }
 }
 

--- a/src/php/types/string.rs
+++ b/src/php/types/string.rs
@@ -2,6 +2,7 @@
 //! contains the length of the string, meaning the string can contain the NUL character.
 
 use core::slice;
+use std::fmt::Debug;
 
 use crate::{
     bindings::{ext_php_rs_zend_string_init, zend_string, zend_string_init_interned},
@@ -46,6 +47,13 @@ impl ZendString {
     {
         let str_ = str_.as_ref();
         unsafe { zend_string_init_interned.unwrap()(c_str(str_), str_.len() as u64, true) }
+    }
+}
+
+impl Debug for ZendString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s: String = self.into();
+        s.fmt(f)
     }
 }
 

--- a/src/php/types/zval.rs
+++ b/src/php/types/zval.rs
@@ -2,7 +2,7 @@
 //! determined by a property inside the struct. The content of the Zval is stored in a union.
 
 use core::slice;
-use std::{convert::TryFrom, ptr};
+use std::{convert::TryFrom, fmt::Debug, ptr};
 
 use crate::{
     bindings::{
@@ -362,6 +362,41 @@ impl<'a> Zval {
     {
         self.u1.type_info = DataType::Array as u32;
         self.value.arr = val.into().into_ptr();
+    }
+}
+
+impl Debug for Zval {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut dbg = f.debug_struct("Zval");
+        let ty = self.get_type();
+        dbg.field("type", &ty);
+
+        if let Ok(ty) = ty {
+            macro_rules! field {
+                ($value: expr) => {
+                    dbg.field("val", &$value)
+                };
+            }
+
+            match ty {
+                DataType::Undef => field!("Undefined"),
+                DataType::Null => field!("Null"),
+                DataType::False => field!(false),
+                DataType::True => field!(true),
+                DataType::Long => field!(self.long()),
+                DataType::Double => field!(self.double()),
+                DataType::String => field!(self.string()),
+                DataType::Array => field!(self.array()),
+                DataType::Object => field!(self.object()),
+                DataType::Resource => field!(self.resource()),
+                DataType::Reference => field!(self.reference()),
+                DataType::Callable => field!(self.string()),
+                DataType::ConstantExpression => field!("Constant Expression"),
+                DataType::Void => field!("Void"),
+            };
+        }
+
+        dbg.finish()
     }
 }
 


### PR DESCRIPTION
Most types did not have Debug and Clone implementations, as the Zend API has many unions which cannot implement Debug. Added `#[derive(Debug)]` implementations where possible and added expanded impls where not possible to derive.

Added `throw!()` to throw and return. Translates into the following:
```rs
throw(ClassEntry::exception(), "reason");
return;
```