### PR TITLE
Remove default-features=false from bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ bitflags = "1.2.1"
 ext-php-rs-derive = { version = "=0.0.5", path = "./ext-php-rs-derive" }
 
 [build-dependencies]
-bindgen = { version = ">= 0.57.0, < 0.58.1", default-features = false }
+bindgen = { version = ">= 0.57.0, < 0.58.1" }
 regex = "1"
 cc = "1.0.67"


### PR DESCRIPTION
Remove default-features=false from bindgen build dependency to fix failing builds with crates that have multiple different dependencies that both depend on bindgen.

See failed pipeline here for the error in question - https://gitlab.com/willbrowning/anonaddy-sequoia/-/jobs/1238041327

I believe this may be related to this issue - https://github.com/rust-lang/rust-bindgen/issues/2030