### PR TITLE
Remove uses of `unwrap`, improve library safety

### DIFF
--- a/ext-php-rs-derive/src/lib.rs
+++ b/ext-php-rs-derive/src/lib.rs
@@ -32,10 +32,12 @@ pub fn object_handler_derive(input: TokenStream) -> TokenStream {
                         #handlers = Some(::ext_php_rs::php::types::object::ZendObjectHandlers::init::<#name>());
                     }
 
+                    // The handlers unwrap can never fail - we check that it is none above.
+                    // Unwrapping the result from `new_ptr` is nessacary as C cannot handle results.
                     ::ext_php_rs::php::types::object::ZendClassObject::<#name>::new_ptr(
                         ce,
                         #handlers.unwrap()
-                    )
+                    ).expect("Failed to allocate memory for new Zend object.")
                 }
             }
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -36,6 +36,10 @@ pub enum Error {
     InvalidPointer,
     /// The given property name does not exist.
     InvalidProperty,
+    /// The string could not be converted into a C-string due to the presence of a NUL character.
+    InvalidCString,
+    /// Could not call the given function.
+    Callable,
 }
 
 impl Display for Error {
@@ -58,6 +62,11 @@ impl Display for Error {
             Error::InvalidScope => write!(f, "Invalid scope."),
             Error::InvalidPointer => write!(f, "Invalid pointer."),
             Error::InvalidProperty => write!(f, "Property does not exist on object."),
+            Error::InvalidCString => write!(
+                f,
+                "String given contains NUL-bytes which cannot be present in a C string."
+            ),
+            Error::Callable => write!(f, "Could not call given function."),
         }
     }
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1,5 +1,6 @@
 //! Helper functions useful for interacting with PHP and Zend.
 
+use crate::errors::{Error, Result};
 use std::ffi::CString;
 
 /// Takes a Rust string object, converts it into a C string
@@ -14,7 +15,7 @@ use std::ffi::CString;
 /// use std::ffi::CString;
 /// use ext_php_rs::functions::c_str;
 ///
-/// let mut ptr = c_str("Hello");
+/// let mut ptr = c_str("Hello").unwrap();
 ///
 /// unsafe {
 ///     assert_eq!(b'H', *ptr as u8);
@@ -28,9 +29,16 @@ use std::ffi::CString;
 ///     let _ = CString::from_raw(ptr as *mut i8);
 /// }
 /// ```
-pub fn c_str<S>(s: S) -> *const i8
+///
+/// # Errors
+///
+/// Returns an error if the given string contains a NUL byte, which for obvious reasons cannot be
+/// contained inside a C string.
+pub fn c_str<S>(s: S) -> Result<*const i8>
 where
     S: AsRef<str>,
 {
-    CString::into_raw(CString::new(s.as_ref()).unwrap())
+    Ok(CString::into_raw(
+        CString::new(s.as_ref()).map_err(|_| Error::InvalidCString)?,
+    ))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(clippy::unwrap_used)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -58,7 +58,7 @@ macro_rules! _info_table_row {
 #[macro_export]
 macro_rules! call_user_func {
     ($fn: expr, $($param: expr),*) => {
-        $fn.try_call(vec![$($param.into()),*])
+        $fn.try_call(vec![$(&$param),*])
     };
 }
 

--- a/src/php/types/string.rs
+++ b/src/php/types/string.rs
@@ -24,33 +24,36 @@ pub struct ZendString {
 }
 
 impl ZendString {
-    /// Creates a new Zend string.
+    /// Creates a new Zend string. Returns a result containin the string.
     ///
     /// # Parameters
     ///
     /// * `str_` - The string to create a Zend string from.
     /// * `persistent` - Whether the request should relive the request boundary.
-    pub fn new(str_: impl AsRef<str>, persistent: bool) -> Self {
+    pub fn new(str_: impl AsRef<str>, persistent: bool) -> Result<Self> {
         let str_ = str_.as_ref();
 
-        Self {
-            ptr: unsafe { ext_php_rs_zend_string_init(c_str(str_), str_.len() as _, persistent) },
+        Ok(Self {
+            ptr: unsafe { ext_php_rs_zend_string_init(c_str(str_)?, str_.len() as _, persistent) },
             free: true,
-        }
+        })
     }
 
-    /// Creates a new interned Zend string.
+    /// Creates a new interned Zend string. Returns a result containing the interned string.
     ///
     /// # Parameters
     ///
     /// * `str_` - The string to create a Zend string from.
-    pub fn new_interned(str_: impl AsRef<str>) -> Self {
+    #[allow(clippy::unwrap_used)]
+    pub fn new_interned(str_: impl AsRef<str>) -> Result<Self> {
         let str_ = str_.as_ref();
 
-        Self {
-            ptr: unsafe { zend_string_init_interned.unwrap()(c_str(str_), str_.len() as _, true) },
+        // Unwrap is OK here - `zend_string_init_interned` will be a valid function ptr by the time
+        // our extension is loaded.
+        Ok(Self {
+            ptr: unsafe { zend_string_init_interned.unwrap()(c_str(str_)?, str_.len() as _, true) },
             free: true,
-        }
+        })
     }
 
     /// Creates a new [`ZendString`] wrapper from a raw pointer to a [`zend_string`].

--- a/src/php/types/zval.rs
+++ b/src/php/types/zval.rs
@@ -369,7 +369,7 @@ impl<'a> Zval {
         self.value.obj = (val as *const ZendObject) as *mut ZendObject;
     }
 
-    /// Sets the value of the zval as an array. Returns nothng in a result on success.
+    /// Sets the value of the zval as an array.
     ///
     /// # Parameters
     ///

--- a/src/php/types/zval.rs
+++ b/src/php/types/zval.rs
@@ -147,26 +147,26 @@ impl<'a> Zval {
 
     /// Attempts to call the argument as a callable with a list of arguments to pass to the function.
     /// Note that a thrown exception inside the callable is not detectable, therefore you should
-    /// check if the return value is valid rather than unwrapping.
+    /// check if the return value is valid rather than unwrapping. Returns a result containing the
+    /// return value of the function, or an error.
     ///
     /// You should not call this function directly, rather through the [`call_user_func`] macro.
     ///
     /// # Parameters
     ///
     /// * `params` - A list of parameters to call the function with.
-    ///
-    /// # Returns
-    ///
-    /// * `Some(Zval)` - The result of the function call.
-    /// * `None` - The zval was not callable or the call failed.
-    pub fn try_call(&self, params: Vec<Zval>) -> Option<Zval> {
+    pub fn try_call(&self, params: Vec<&dyn IntoZval>) -> Result<Zval> {
         let mut retval = Zval::new();
         let len = params.len();
+        let params = params
+            .into_iter()
+            .map(|val| val.as_zval(false))
+            .collect::<Result<Vec<_>>>()?;
         let packed = Box::into_raw(params.into_boxed_slice()) as *mut Self;
         let ptr: *const Self = self;
 
         if !self.is_callable() {
-            return None;
+            return Err(Error::Callable);
         }
 
         let result = unsafe {
@@ -194,9 +194,9 @@ impl<'a> Zval {
         };
 
         if result < 0 {
-            None
+            Err(Error::Callable)
         } else {
-            Some(retval)
+            Ok(retval)
         }
     }
 
@@ -266,18 +266,20 @@ impl<'a> Zval {
         unsafe { zend_is_callable(ptr as *mut Self, 0, std::ptr::null_mut()) }
     }
 
-    /// Sets the value of the zval as a string.
+    /// Sets the value of the zval as a string. Returns nothing in a result when successful.
     ///
     /// # Parameters
     ///
     /// * `val` - The value to set the zval as.
-    pub fn set_string<S>(&mut self, val: S)
+    /// * `persistent` - Whether the string should persist between requests.
+    pub fn set_string<S>(&mut self, val: S, persistent: bool) -> Result<()>
     where
         S: AsRef<str>,
     {
-        let zend_str = ZendString::new(val, false);
+        let zend_str = ZendString::new(val, persistent)?;
         self.value.str_ = zend_str.release();
         self.u1.type_info = ZvalTypeFlags::StringEx.bits();
+        Ok(())
     }
 
     /// Sets the value of the zval as a binary string.
@@ -291,34 +293,19 @@ impl<'a> Zval {
         self.u1.type_info = ZvalTypeFlags::StringEx.bits();
     }
 
-    /// Sets the value of the zval as a persistent string.
-    /// This means that the zend string will persist between
-    /// request lifetime.
+    /// Sets the value of the zval as a interned string. Returns nothing in a result when successful.
     ///
     /// # Parameters
     ///
     /// * `val` - The value to set the zval as.
-    pub fn set_persistent_string<S>(&mut self, val: S)
+    pub fn set_interned_string<S>(&mut self, val: S) -> Result<()>
     where
         S: AsRef<str>,
     {
-        let zend_str = ZendString::new(val, true);
-        self.value.str_ = zend_str.release();
-        self.u1.type_info = ZvalTypeFlags::StringEx.bits();
-    }
-
-    /// Sets the value of the zval as a interned string.
-    ///
-    /// # Parameters
-    ///
-    /// * `val` - The value to set the zval as.
-    pub fn set_interned_string<S>(&mut self, val: S)
-    where
-        S: AsRef<str>,
-    {
-        let zend_str = ZendString::new_interned(val);
+        let zend_str = ZendString::new_interned(val)?;
         self.value.str_ = zend_str.release();
         self.u1.type_info = ZvalTypeFlags::InternedStringEx.bits();
+        Ok(())
     }
 
     /// Sets the value of the zval as a long.
@@ -355,6 +342,7 @@ impl<'a> Zval {
     }
 
     /// Sets the value of the zval as null.
+    ///
     /// This is the default of a zval.
     pub fn set_null(&mut self) {
         self.u1.type_info = ZvalTypeFlags::Null.bits();
@@ -381,17 +369,14 @@ impl<'a> Zval {
         self.value.obj = (val as *const ZendObject) as *mut ZendObject;
     }
 
-    /// Sets the value of the zval as an array.
+    /// Sets the value of the zval as an array. Returns nothng in a result on success.
     ///
     /// # Parameters
     ///
     /// * `val` - The value to set the zval as.
-    pub fn set_array<V>(&mut self, val: V)
-    where
-        V: Into<ZendHashTable>,
-    {
+    pub fn set_array(&mut self, val: ZendHashTable) {
         self.u1.type_info = ZvalTypeFlags::ArrayEx.bits();
-        self.value.arr = val.into().into_ptr();
+        self.value.arr = val.into_ptr();
     }
 
     /// Sets the reference count of the Zval.
@@ -435,10 +420,24 @@ impl Debug for Zval {
     }
 }
 
+/// Provides implementations for converting Rust primitive types into PHP zvals. Alternative to the
+/// built-in Rust [`From`] and [`TryFrom`] implementations, allowing the caller to specify whether
+/// the Zval contents will persist between requests.
+pub trait IntoZval {
+    /// Converts a Rust primitive type into a Zval. Returns a result containing the Zval if
+    /// successful.
+    ///
+    /// # Parameters
+    ///
+    /// * `persistent` - Whether the contents of the Zval will persist between requests.
+    fn as_zval(&self, persistent: bool) -> Result<Zval>;
+}
+
 macro_rules! try_from_zval {
     ($type: ty, $fn: ident) => {
         impl TryFrom<&Zval> for $type {
             type Error = Error;
+
             fn try_from(value: &Zval) -> Result<Self> {
                 match value.$fn() {
                     Some(v) => match <$type>::try_from(v) {
@@ -480,6 +479,14 @@ macro_rules! into_zval {
                 zv
             }
         }
+
+        impl IntoZval for $type {
+            fn as_zval(&self, _: bool) -> Result<Zval> {
+                let mut zv = Zval::new();
+                zv.$fn(*self);
+                Ok(zv)
+            }
+        }
     };
 }
 
@@ -497,6 +504,28 @@ into_zval!(f64, set_double);
 
 into_zval!(bool, set_bool);
 
-into_zval!(String, set_string);
-into_zval!(&String, set_string);
-into_zval!(&str, set_string);
+macro_rules! try_into_zval_str {
+    ($type: ty) => {
+        impl TryFrom<$type> for Zval {
+            type Error = Error;
+
+            fn try_from(value: $type) -> Result<Self> {
+                let mut zv = Self::new();
+                zv.set_string(value, false)?;
+                Ok(zv)
+            }
+        }
+
+        impl IntoZval for $type {
+            fn as_zval(&self, persistent: bool) -> Result<Zval> {
+                let mut zv = Zval::new();
+                zv.set_string(self, persistent)?;
+                Ok(zv)
+            }
+        }
+    };
+}
+
+try_into_zval_str!(String);
+try_into_zval_str!(&String);
+try_into_zval_str!(&str);


### PR DESCRIPTION
Some functions will now return `Result`s where previously things were unwrapped. Most things should stay the same, but you may have to insert some `.unwrap()` or `.expect()` calls in (or match if you really want to!)

Functions that have changed:

- `.build()` returns `Result` on `FunctionBuilder`, `ClassBuilder` and `ModuleBuilder`.
- `.property()` and `.constant()` return `Result` on `ClassBuilder`.
- `.register_constant()` returns `Result`.
- `.try_call()` on callables now return `Result` rather than `Option`.
- `throw()` and `throw_with_code()` now returns `Result`.
- `new()` and `new_interned()` on `ZendString` now returns a `Result`.

For `ZendHashTable`:

- `insert()`, `insert_at_index()` now returns a `Result<HashTableInsertResult>`, where `Err` failed, 
`Ok(Ok)` inserts successfully without overwrite, and `Ok(OkWithOverwrite(&Zval))` inserts successfully
with overwrite.
- `push()` now returns a `Result`.
- Converting from a `Vec` or `HashMap` to a `ZendHashTable` is fallible, so it now implementes `TryFrom` as
opposed to `From`.

For `Zval`:

- `set_string()` now returns a `Result`, and takes a second parameter (persistent).
- `set_persistent_string()` has now been removed in favour of `set_string()`.
- `set_interned_string()` also returns a `Result`.
- `set_array()` now only takes a `ZendHashTable`, you must convert your `Vec` or `HashMap`
by calling `try_into()` and handling the error.
