### PR TITLE
Added `#[php_extern]` macro

### DIFF
--- a/example/skel/src/allocator.rs
+++ b/example/skel/src/allocator.rs
@@ -1,6 +1,6 @@
 #![doc(hidden)]
 
-use crate::bindings::{_efree, _emalloc};
+use ext_php_rs::bindings::{_efree, _emalloc};
 use std::alloc::GlobalAlloc;
 
 /// Global allocator which uses the Zend memory management APIs to allocate memory.

--- a/example/skel/test.php
+++ b/example/skel/test.php
@@ -2,4 +2,9 @@
 
 include __DIR__.'/vendor/autoload.php';
 
-var_dump(hello_world(5));
+function test_func() {
+    return "Hello wqorld";
+}
+
+// var_dump(hello_world(5));
+var_dump(test_extern());

--- a/ext-php-rs-derive/src/extern_.rs
+++ b/ext-php-rs-derive/src/extern_.rs
@@ -1,0 +1,72 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{punctuated::Punctuated, ForeignItemFn, ItemForeignMod, ReturnType, Signature, Token};
+
+use crate::error::Result;
+
+pub fn parser(input: ItemForeignMod) -> Result<TokenStream> {
+    input
+        .items
+        .into_iter()
+        .map(|item| match item {
+            syn::ForeignItem::Fn(func) => parse_function(func),
+            _ => Err("Only `extern` functions are supported by PHP.".into()),
+        })
+        .collect::<Result<Vec<_>>>()
+        .map(|vec| quote! { #(#vec)* })
+}
+
+fn parse_function(mut func: ForeignItemFn) -> Result<TokenStream> {
+    let ForeignItemFn {
+        attrs, vis, sig, ..
+    } = &mut func;
+    sig.unsafety = Some(Default::default()); // Function must be unsafe.
+
+    let Signature { ident, .. } = &sig;
+
+    let name = ident.to_string();
+    let params = sig
+        .inputs
+        .iter()
+        .map(|input| match input {
+            syn::FnArg::Typed(arg) => {
+                let pat = &arg.pat;
+                Some(quote! { &#pat })
+            }
+            _ => None,
+        })
+        .collect::<Option<Punctuated<_, Token![,]>>>()
+        .ok_or("`self` parameters are not permitted inside `#[php_extern]` blocks.")?;
+    let ret = build_return(&name, &sig.output, params);
+
+    Ok(quote! {
+        #(#attrs)* #vis #sig {
+            use ::std::convert::TryInto;
+
+            let callable = ::ext_php_rs::php::types::callable::Callable::try_from_name(
+                #name
+            ).expect(concat!("Unable to find callable function `", #name, "`."));
+
+            #ret
+        }
+    })
+}
+
+fn build_return(
+    name: &str,
+    return_type: &ReturnType,
+    params: Punctuated<TokenStream, Token![,]>,
+) -> TokenStream {
+    match return_type {
+        ReturnType::Default => quote! {
+            callable.try_call(vec![ #params ]);
+        },
+        ReturnType::Type(_, _) => quote! {
+            callable
+                .try_call(vec![ #params ])
+                .ok()
+                .and_then(|zv| zv.try_into().ok())
+                .expect(concat!("Failed to call function `", #name, "`."))
+        },
+    }
+}

--- a/ext-php-rs-derive/src/lib.rs
+++ b/ext-php-rs-derive/src/lib.rs
@@ -1,6 +1,7 @@
 mod class;
 mod constant;
 mod error;
+mod extern_;
 mod function;
 mod impl_;
 mod method;
@@ -12,7 +13,9 @@ use std::{collections::HashMap, sync::Mutex};
 use constant::Constant;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
-use syn::{parse_macro_input, AttributeArgs, DeriveInput, ItemConst, ItemFn, ItemImpl};
+use syn::{
+    parse_macro_input, AttributeArgs, DeriveInput, ItemConst, ItemFn, ItemForeignMod, ItemImpl,
+};
 
 extern crate proc_macro;
 
@@ -90,6 +93,17 @@ pub fn php_const(_: TokenStream, input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemConst);
 
     match constant::parser(input) {
+        Ok(parsed) => parsed,
+        Err(e) => syn::Error::new(Span::call_site(), e).to_compile_error(),
+    }
+    .into()
+}
+
+#[proc_macro_attribute]
+pub fn php_extern(_: TokenStream, input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemForeignMod);
+
+    match extern_::parser(input) {
         Ok(parsed) => parsed,
         Err(e) => syn::Error::new(Span::call_site(), e).to_compile_error(),
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -37,7 +37,7 @@ macro_rules! info_table_row {
 macro_rules! _info_table_row {
     ($fn: ident, $($element: expr),*) => {
         unsafe {
-            $crate::bindings::$fn($crate::_info_table_row!(@COUNT; $($element),*) as i32, $(::std::ffi::CString::new($element).unwrap().into_raw()),*);
+            $crate::bindings::$fn($crate::_info_table_row!(@COUNT; $($element),*) as i32, $(::std::ffi::CString::new($element).unwrap().as_ptr()),*);
         }
     };
 

--- a/src/php/types/binary.rs
+++ b/src/php/types/binary.rs
@@ -1,7 +1,7 @@
 //! Types relating to binary data transmission between Rust and PHP.
 
 use std::{
-    convert::TryFrom,
+    convert::{TryFrom, TryInto},
     ops::{Deref, DerefMut},
 };
 
@@ -43,6 +43,10 @@ impl<T: Pack> DerefMut for Binary<T> {
     }
 }
 
+impl<'a, T: Pack> FromZval<'a> for Binary<T> {
+    const TYPE: DataType = DataType::String;
+}
+
 impl<T: Pack> TryFrom<&Zval> for Binary<T> {
     type Error = Error;
 
@@ -54,8 +58,12 @@ impl<T: Pack> TryFrom<&Zval> for Binary<T> {
     }
 }
 
-impl<'a, T: Pack> FromZval<'a> for Binary<T> {
-    const TYPE: DataType = DataType::String;
+impl<T: Pack> TryFrom<Zval> for Binary<T> {
+    type Error = Error;
+
+    fn try_from(value: Zval) -> Result<Self> {
+        (&value).try_into()
+    }
 }
 
 impl<T: Pack> IntoZval for Binary<T> {

--- a/src/php/types/callable.rs
+++ b/src/php/types/callable.rs
@@ -1,5 +1,7 @@
 //! Types related to callables in PHP (anonymous functions, functions, etc).
 
+use std::ops::Deref;
+
 use super::zval::{IntoZval, Zval};
 use crate::{
     bindings::_call_user_function_impl,
@@ -8,7 +10,32 @@ use crate::{
 
 /// Acts as a wrapper around a callable [`Zval`]. Allows the owner to call the [`Zval`] as if it
 /// was a PHP function through the [`try_call`](Callable::try_call) method.
-pub struct Callable<'a>(&'a Zval);
+#[derive(Debug)]
+pub struct Callable<'a>(OwnedZval<'a>);
+
+/// A container for a zval. Either contains a reference to a zval or an owned zval.
+#[derive(Debug)]
+enum OwnedZval<'a> {
+    Reference(&'a Zval),
+    Owned(Zval),
+}
+
+impl<'a> OwnedZval<'a> {
+    fn as_ref(&self) -> &Zval {
+        match self {
+            OwnedZval::Reference(zv) => *zv,
+            OwnedZval::Owned(zv) => zv,
+        }
+    }
+}
+
+impl<'a> Deref for OwnedZval<'a> {
+    type Target = Zval;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
 
 impl<'a> Callable<'a> {
     /// Attempts to create a new [`Callable`]. Should not need to be used directly, but through the
@@ -23,10 +50,37 @@ impl<'a> Callable<'a> {
     /// Returns an error if the [`Zval`] was not callable.
     pub fn new(callable: &'a Zval) -> Result<Self> {
         if callable.is_callable() {
-            Ok(Self(callable))
+            Ok(Self(OwnedZval::Reference(callable)))
         } else {
             Err(Error::Callable)
         }
+    }
+
+    /// Attempts to create a new [`Callable`] by taking ownership of a Zval. Returns a result
+    /// containing the callable if the zval was callable.
+    ///
+    /// # Parameters
+    ///
+    /// * `callable` - TThe underlying [`Zval`] that is callable.
+    pub fn new_owned(callable: Zval) -> Result<Self> {
+        if callable.is_callable() {
+            Ok(Self(OwnedZval::Owned(callable)))
+        } else {
+            Err(Error::Callable)
+        }
+    }
+
+    /// Attempts to create a new [`Callable`] from a function name. Returns a result containing the
+    /// callable if the function existed and was callable.
+    ///
+    /// # Parameters
+    ///
+    /// * `name` - Name of the callable function.
+    pub fn try_from_name(name: &str) -> Result<Self> {
+        let mut callable = Zval::new();
+        callable.set_string(name, false)?;
+
+        Self::new_owned(callable)
     }
 
     /// Attempts to call the callable with a list of arguments to pass to the function.
@@ -55,7 +109,7 @@ impl<'a> Callable<'a> {
         let result = unsafe {
             _call_user_function_impl(
                 std::ptr::null_mut(),
-                std::mem::transmute(self.0),
+                std::mem::transmute(self.0.as_ref()),
                 &mut retval,
                 len as _,
                 packed.as_ptr() as *mut _,


### PR DESCRIPTION
Adds ability to import PHP functions into Rust.