### PR TITLE
Drop object contents rather than deallocating whole object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ cc = "1.0.67"
 
 [features]
 zts = []
+debug = []
+alloc = []
 
 [workspace]
 members = [

--- a/example/skel/Cargo.toml
+++ b/example/skel/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ext-php-rs = { path = "../../" }
+ext-php-rs = { path = "../../", features = ["alloc"] }
 
 [lib]
 name = "skel"

--- a/example/skel/src/allocator.rs
+++ b/example/skel/src/allocator.rs
@@ -1,6 +1,6 @@
 #![doc(hidden)]
 
-use ext_php_rs::bindings::{_efree, _emalloc};
+use ext_php_rs::php::alloc;
 use std::alloc::GlobalAlloc;
 
 /// Global allocator which uses the Zend memory management APIs to allocate memory.
@@ -19,28 +19,13 @@ impl PhpAllocator {
 
 unsafe impl GlobalAlloc for PhpAllocator {
     unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
-        let ptr = _emalloc(
-            layout.size() as _,
-            std::ptr::null_mut(),
-            0,
-            std::ptr::null_mut(),
-            0,
-        ) as *mut u8;
-
-        // eprintln!("allocating {} bytes at {:?}", layout.size(), ptr);
-
+        let ptr = alloc::emalloc(layout);
+        eprintln!("allocating {:?}: {} bytes", ptr, layout.size());
         ptr
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
-        // eprintln!("deallocating {} bytes at {:?}", layout.size(), ptr);
-
-        _efree(
-            ptr as *mut _,
-            std::ptr::null_mut(),
-            0,
-            std::ptr::null_mut(),
-            0,
-        )
+        eprintln!("freeing {:?}: {} bytes", ptr, layout.size());
+        alloc::efree(ptr)
     }
 }

--- a/example/skel/src/lib.rs
+++ b/example/skel/src/lib.rs
@@ -1,14 +1,7 @@
 mod allocator;
 
 use allocator::PhpAllocator;
-use ext_php_rs::{
-    php::{class::ClassEntry, exceptions::PhpException},
-    php_class,
-    prelude::*,
-};
-
-#[global_allocator]
-static GLOBAL: PhpAllocator = PhpAllocator::new();
+use ext_php_rs::{php_class, prelude::*};
 
 // #[php_function]
 // pub fn hello_world() -> String {
@@ -112,6 +105,9 @@ pub fn test_str(input: &str) -> &str {
 //         "Hello world".into(),
 //     ))
 // }
+
+#[global_allocator]
+static GLOBAL: PhpAllocator = PhpAllocator::new();
 
 #[php_class]
 #[property(test = 0)]

--- a/src/php/alloc.rs
+++ b/src/php/alloc.rs
@@ -1,0 +1,56 @@
+//! Functions relating to the Zend Memory Manager, used to allocate request-bound memory.
+
+use crate::bindings::{_efree, _emalloc};
+use std::{alloc::Layout, ffi::c_void};
+
+/// Uses the PHP memory allocator to allocate request-bound memory.
+///
+/// # Parameters
+///
+/// * `layout` - The layout of the requested memory.
+///
+/// # Returns
+///
+/// A pointer to the memory allocated.
+pub fn emalloc(layout: Layout) -> *mut u8 {
+    // TODO account for alignment
+    let size = layout.size();
+
+    (unsafe {
+        #[cfg(feature = "debug")]
+        {
+            _emalloc(size as _, std::ptr::null_mut(), 0, std::ptr::null_mut(), 0)
+        }
+        #[cfg(not(feature = "debug"))]
+        {
+            _emalloc(size as _)
+        }
+    }) as *mut u8
+}
+
+/// Frees a given memory pointer which was allocated through the PHP memory manager.
+///
+/// # Parameters
+///
+/// * `ptr` - The pointer to the memory to free.
+///
+/// # Safety
+///
+/// Caller must guarantee that the given pointer is valid (aligned and non-null) and
+/// was originally allocated through the Zend memory manager.
+pub unsafe fn efree(ptr: *mut u8) {
+    #[cfg(feature = "debug")]
+    {
+        _efree(
+            ptr as *mut c_void,
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null_mut(),
+            0,
+        )
+    }
+    #[cfg(not(feature = "debug"))]
+    {
+        _efree(ptr as *mut c_void)
+    }
+}

--- a/src/php/mod.rs
+++ b/src/php/mod.rs
@@ -1,5 +1,8 @@
 //! Objects relating to PHP and the Zend engine.
 
+#[cfg(feature = "alloc")]
+pub mod alloc;
+
 pub mod args;
 pub mod class;
 pub mod constants;

--- a/src/php/types/object.rs
+++ b/src/php/types/object.rs
@@ -8,6 +8,7 @@ use std::{
     marker::PhantomData,
     mem::MaybeUninit,
     ops::{Deref, DerefMut},
+    ptr,
     sync::atomic::{AtomicBool, Ordering},
 };
 
@@ -414,7 +415,7 @@ impl ZendObjectHandlers {
 
             // Cast to *mut u8 to work in byte offsets
             let ptr = (object as *mut u8).offset(0 - offset as isize) as *mut T;
-            let _ = Box::from_raw(ptr);
+            ptr::drop_in_place(ptr);
 
             match std_object_handlers.free_obj {
                 Some(free) => free(object),


### PR DESCRIPTION
The object memory is automatically deallocated, however, anything that
has been allocated on the heap (strings, vectors etc.) must be
deallocated while we are freeing the object.