### PR TITLE
Use configuration tags instead of features for flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,6 @@ regex = "1"
 cc = "1.0.67"
 
 [features]
-zts = []
-debug = []
-
 alloc = []
 closure = []
 

--- a/build.rs
+++ b/build.rs
@@ -124,11 +124,11 @@ fn main() {
     let configure = Configure::get();
 
     if configure.has_zts() {
-        println!("cargo:rustc-cfg=feature=\"zts\"");
+        println!("cargo:rustc-cfg=php_zts");
     }
 
     if configure.debug() {
-        println!("cargo:rustc-cfg=feature=\"debug\"");
+        println!("cargo:rustc-cfg=php_debug");
     }
 }
 

--- a/src/php/alloc.rs
+++ b/src/php/alloc.rs
@@ -17,11 +17,11 @@ pub fn emalloc(layout: Layout) -> *mut u8 {
     let size = layout.size();
 
     (unsafe {
-        #[cfg(feature = "debug")]
+        #[cfg(php_debug)]
         {
             _emalloc(size as _, std::ptr::null_mut(), 0, std::ptr::null_mut(), 0)
         }
-        #[cfg(not(feature = "debug"))]
+        #[cfg(not(php_debug))]
         {
             _emalloc(size as _)
         }
@@ -39,7 +39,7 @@ pub fn emalloc(layout: Layout) -> *mut u8 {
 /// Caller must guarantee that the given pointer is valid (aligned and non-null) and
 /// was originally allocated through the Zend memory manager.
 pub unsafe fn efree(ptr: *mut u8) {
-    #[cfg(feature = "debug")]
+    #[cfg(php_debug)]
     {
         _efree(
             ptr as *mut c_void,
@@ -49,7 +49,7 @@ pub unsafe fn efree(ptr: *mut u8) {
             0,
         )
     }
-    #[cfg(not(feature = "debug"))]
+    #[cfg(not(php_debug))]
     {
         _efree(ptr as *mut c_void)
     }

--- a/src/php/module.rs
+++ b/src/php/module.rs
@@ -81,9 +81,9 @@ impl ModuleBuilder {
                 info_func: None,
                 version: ptr::null(),
                 globals_size: 0,
-                #[cfg(not(feature = "zts"))]
+                #[cfg(not(php_zts))]
                 globals_ptr: ptr::null::<c_void>() as *mut c_void,
-                #[cfg(feature = "zts")]
+                #[cfg(php_zts)]
                 globals_id_ptr: ptr::null::<c_void>() as *mut crate::bindings::ts_rsrc_id,
                 globals_ctor: None,
                 globals_dtor: None,


### PR DESCRIPTION
e.g. PHP debug or ZTS mode are no longer features, but just simply
configuration flags.