### PR TITLE
Add `try_from` into `FromZval` trait

### DIFF
--- a/example/skel/src/lib.rs
+++ b/example/skel/src/lib.rs
@@ -128,6 +128,11 @@ pub struct Test {
     pub test: String,
 }
 
+#[php_function]
+pub fn take_test(test: &Test) -> String {
+    test.test.clone()
+}
+
 #[php_class]
 #[derive(Default)]
 struct PhpFuture {
@@ -150,11 +155,9 @@ impl PhpFuture {
     }
 
     pub fn obj(&self) -> ClassObject<Test> {
-        let obj = ClassObject::new(Test {
+        ClassObject::new(Test {
             test: "Hello world from class entry :)".into(),
-        });
-
-        obj
+        })
     }
 
     pub fn return_self(&self) -> ClassRef<PhpFuture> {

--- a/src/php/args.rs
+++ b/src/php/args.rs
@@ -1,16 +1,12 @@
 //! Builder and objects relating to function and method arguments.
 
-use std::{
-    convert::{TryFrom, TryInto},
-    ffi::CString,
-    ptr,
-};
+use std::{ffi::CString, ptr};
 
 use super::{
     enums::DataType,
     execution_data::ExecutionData,
     types::{
-        zval::{IntoZvalDyn, Zval},
+        zval::{FromZval, IntoZvalDyn, Zval},
         ZendType,
     },
 };
@@ -85,8 +81,8 @@ impl<'a> Arg<'a> {
     /// Attempts to retrieve the value of the argument.
     /// This will be None until the ArgParser is used to parse
     /// the arguments.
-    pub fn val<T: TryFrom<&'a Zval>>(&self) -> Option<T> {
-        self.zval.and_then(|zv| zv.try_into().ok())
+    pub fn val<T: FromZval<'a>>(&self) -> Option<T> {
+        self.zval.and_then(|zv| T::from_zval(zv))
     }
 
     /// Attempts to return a reference to the arguments internal Zval.

--- a/src/php/types/binary.rs
+++ b/src/php/types/binary.rs
@@ -1,7 +1,7 @@
 //! Types relating to binary data transmission between Rust and PHP.
 
 use std::{
-    convert::{TryFrom, TryInto},
+    convert::TryFrom,
     iter::FromIterator,
     ops::{Deref, DerefMut},
 };
@@ -44,18 +44,11 @@ impl<T: Pack> DerefMut for Binary<T> {
     }
 }
 
-impl<'a, T: Pack> FromZval<'a> for Binary<T> {
+impl<T: Pack> FromZval<'_> for Binary<T> {
     const TYPE: DataType = DataType::String;
-}
 
-impl<T: Pack> TryFrom<&Zval> for Binary<T> {
-    type Error = Error;
-
-    fn try_from(value: &Zval) -> Result<Self> {
-        match value.binary() {
-            Some(b) => Ok(Binary(b)),
-            None => Err(Error::Callable),
-        }
+    fn from_zval(zval: &Zval) -> Option<Self> {
+        zval.binary().map(Binary)
     }
 }
 
@@ -63,7 +56,7 @@ impl<T: Pack> TryFrom<Zval> for Binary<T> {
     type Error = Error;
 
     fn try_from(value: Zval) -> Result<Self> {
-        (&value).try_into()
+        Self::from_zval(&value).ok_or(Error::ZvalConversion(value.get_type()?))
     }
 }
 


### PR DESCRIPTION
Allows generic implementations of the `FromZval` trait.
You can now take `&T` as a parameter, where `T: RegisteredClass`.