### PR TITLE
Naively change the case of method identifiers to comply with PSR-1

### DIFF
--- a/ext-php-rs-derive/Cargo.toml
+++ b/ext-php-rs-derive/Cargo.toml
@@ -14,6 +14,7 @@ proc-macro = true
 [dependencies]
 syn = { version = "1.0.68", features = ["full", "extra-traits"] }
 darling = "0.12"
+ident_case = "1.0.1"
 quote = "1.0.9"
 proc-macro2 = "1.0.26"
 lazy_static = "1.4.0"

--- a/ext-php-rs-derive/src/impl_.rs
+++ b/ext-php-rs-derive/src/impl_.rs
@@ -111,7 +111,10 @@ pub fn parser(args: AttributeArgs, input: ItemImpl) -> Result<TokenStream> {
                     }
                 }
                 syn::ImplItem::Method(mut method) => {
-                    let (sig, method) = method::parser(&mut method, args.rename_methods.unwrap_or(RenameRule::Camel))?;
+                    let (sig, method) = method::parser(
+                        &mut method,
+                        args.rename_methods.unwrap_or(RenameRule::Camel),
+                    )?;
                     class.methods.push(method);
                     sig
                 }
@@ -207,9 +210,7 @@ mod tests {
 
     #[test]
     fn test_rename_php_methods() {
-        for &(original, camel, snake) in &[
-            ("get_name", "getName", "get_name"),
-        ] {
+        for &(original, camel, snake) in &[("get_name", "getName", "get_name")] {
             assert_eq!(camel, RenameRule::Camel.rename(original));
             assert_eq!(snake, RenameRule::Snake.rename(original));
         }

--- a/ext-php-rs-derive/src/lib.rs
+++ b/ext-php-rs-derive/src/lib.rs
@@ -93,10 +93,11 @@ pub fn php_startup(_: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
-pub fn php_impl(_: TokenStream, input: TokenStream) -> TokenStream {
+pub fn php_impl(args: TokenStream, input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(args as AttributeArgs);
     let input = parse_macro_input!(input as ItemImpl);
 
-    match impl_::parser(input) {
+    match impl_::parser(args, input) {
         Ok(parsed) => parsed,
         Err(e) => syn::Error::new(Span::call_site(), e).to_compile_error(),
     }

--- a/ext-php-rs-derive/src/method.rs
+++ b/ext-php-rs-derive/src/method.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, bail, Result};
+use ident_case::RenameRule;
 use quote::ToTokens;
 use std::collections::HashMap;
 
@@ -32,6 +33,29 @@ pub struct Method {
     pub output: Option<(String, bool)>,
     pub _static: bool,
     pub visibility: Visibility,
+}
+
+fn camel_case_identifier(field: &str) -> String {
+    match field {
+        "__construct" => "__construct".to_string(),
+        "__destruct" => "__destruct".to_string(),
+        "__call" => "__call".to_string(),
+        "__call_static" => "__callStatic".to_string(),
+        "__get" => "__get".to_string(),
+        "__set" => "__set".to_string(),
+        "__isset" => "__isset".to_string(),
+        "__unset" => "__unset".to_string(),
+        "__sleep" => "__sleep".to_string(),
+        "__wakeup" => "__wakeup".to_string(),
+        "__serialize" => "__serialize".to_string(),
+        "__unserialize" => "__unserialize".to_string(),
+        "__to_string" => "__toString".to_string(),
+        "__invoke" => "__invoke".to_string(),
+        "__set_state" => "__set_state".to_string(),
+        "__clone" => "__clone".to_string(),
+        "__debug_info" => "__debugInfo".to_string(),
+        field => RenameRule::CamelCase.apply_to_field(field),
+    }
 }
 
 pub fn parser(input: &mut ImplItemMethod) -> Result<(TokenStream, Method)> {
@@ -93,7 +117,7 @@ pub fn parser(input: &mut ImplItemMethod) -> Result<(TokenStream, Method)> {
     };
 
     let method = Method {
-        name: ident.to_string(),
+        name: camel_case_identifier(&ident.to_string()),
         ident: internal_ident.to_string(),
         args,
         optional,
@@ -245,5 +269,36 @@ impl Method {
             .map(|flag| quote! { ::ext_php_rs::php::flags::MethodFlags::#flag })
             .collect::<Punctuated<TokenStream, Token![|]>>()
             .to_token_stream()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::camel_case_identifier;
+
+    #[test]
+    fn test_rename_php_methods() {
+        for &(original, expected) in &[
+            ("__construct", "__construct"),
+            ("__destruct", "__destruct"),
+            ("__call", "__call"),
+            ("__call_static", "__callStatic"),
+            ("__get", "__get"),
+            ("__set", "__set"),
+            ("__isset", "__isset"),
+            ("__unset", "__unset"),
+            ("__sleep", "__sleep"),
+            ("__wakeup", "__wakeup"),
+            ("__serialize", "__serialize"),
+            ("__unserialize", "__unserialize"),
+            ("__to_string", "__toString"),
+            ("__invoke", "__invoke"),
+            ("__set_state", "__set_state"),
+            ("__clone", "__clone"),
+            ("__debug_info", "__debugInfo"),
+            ("get_name", "getName"),
+        ] {
+            assert_eq!(camel_case_identifier(original), expected);
+        }
     }
 }

--- a/ext-php-rs-derive/src/method.rs
+++ b/ext-php-rs-derive/src/method.rs
@@ -2,7 +2,10 @@ use anyhow::{anyhow, bail, Result};
 use quote::ToTokens;
 use std::collections::HashMap;
 
-use crate::{function, impl_::{ParsedAttribute, RenameRule, Visibility, parse_attribute}};
+use crate::{
+    function,
+    impl_::{parse_attribute, ParsedAttribute, RenameRule, Visibility},
+};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::{punctuated::Punctuated, FnArg, ImplItemMethod, Lit, Pat, Signature, Token, Type};
@@ -31,7 +34,10 @@ pub struct Method {
     pub visibility: Visibility,
 }
 
-pub fn parser(input: &mut ImplItemMethod, rename_rule: RenameRule) -> Result<(TokenStream, Method)> {
+pub fn parser(
+    input: &mut ImplItemMethod,
+    rename_rule: RenameRule,
+) -> Result<(TokenStream, Method)> {
     let mut defaults = HashMap::new();
     let mut optional = None;
     let mut visibility = Visibility::Public;
@@ -93,7 +99,7 @@ pub fn parser(input: &mut ImplItemMethod, rename_rule: RenameRule) -> Result<(To
 
     let name = identifier.unwrap_or_else(|| rename_rule.rename(ident.to_string()));
     let method = Method {
-        name, 
+        name,
         ident: internal_ident.to_string(),
         args,
         optional,


### PR DESCRIPTION
I'd be surprised if the patch will be taken in this form, but I'm willing to put the effort in to getting this in should there be interest.

Rust loves using snake_case for functions, but to comply with PSR-1, methods should be in camelCase. This patch tries to change the case of methods generated through the `php_impl` macro.

As for precedence for changing the case of identifiers via macros, both juniper and async-graphql do this.