### PR TITLE
Pass class object type to PHP when taking object parameter

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -312,4 +312,5 @@ const ALLOWED_BINDINGS: &[&str] = &[
     "_ZEND_SEND_MODE_SHIFT",
     "_ZEND_TYPE_NULLABLE_BIT",
     "ts_rsrc_id",
+    "_ZEND_TYPE_NAME_BIT",
 ];

--- a/docsrs_bindings.rs
+++ b/docsrs_bindings.rs
@@ -14,6 +14,7 @@
 
 pub const ZEND_DEBUG: u32 = 1;
 pub const ZEND_MM_ALIGNMENT: u32 = 8;
+pub const _ZEND_TYPE_NAME_BIT: u32 = 8388608;
 pub const _ZEND_TYPE_NULLABLE_BIT: u32 = 2;
 pub const HT_MIN_SIZE: u32 = 8;
 pub const IS_UNDEF: u32 = 0;

--- a/example/skel/src/lib.rs
+++ b/example/skel/src/lib.rs
@@ -117,8 +117,8 @@ pub fn test_str(input: &str) -> &str {
 //     ))
 // }
 
-#[global_allocator]
-static GLOBAL: PhpAllocator = PhpAllocator::new();
+// #[global_allocator]
+// static GLOBAL: PhpAllocator = PhpAllocator::new();
 
 #[php_class]
 #[property(test = 0)]

--- a/example/skel/test.php
+++ b/example/skel/test.php
@@ -1,5 +1,11 @@
 <?php
 
+include 'vendor/autoload.php';
+
+$ext = new ReflectionExtension('skel');
+
+dd($ext);
+
 $x = fn_once();
 $x();
 $x();

--- a/ext-php-rs-derive/src/class.rs
+++ b/ext-php-rs-derive/src/class.rs
@@ -75,6 +75,8 @@ pub fn parser(args: AttributeArgs, mut input: ItemStruct) -> Result<TokenStream>
         static #meta: ::ext_php_rs::php::types::object::ClassMetadata<#ident> = ::ext_php_rs::php::types::object::ClassMetadata::new();
 
         impl ::ext_php_rs::php::types::object::RegisteredClass for #ident {
+            const CLASS_NAME: &'static str = #class_name;
+
             fn get_metadata() -> &'static ::ext_php_rs::php::types::object::ClassMetadata<Self> {
                 &#meta
             }

--- a/src/php/args.rs
+++ b/src/php/args.rs
@@ -118,7 +118,8 @@ impl<'a> Arg<'a> {
                 self.as_ref,
                 self.variadic,
                 self.allow_null,
-            ),
+            )
+            .ok_or(Error::InvalidCString)?,
             default_value: match &self.default_value {
                 Some(val) => CString::new(val.as_str())?.into_raw(),
                 None => ptr::null(),
@@ -135,7 +136,7 @@ impl From<Arg<'_>> for _zend_expected_type {
             DataType::Double => _zend_expected_type_Z_EXPECTED_DOUBLE,
             DataType::String => _zend_expected_type_Z_EXPECTED_STRING,
             DataType::Array => _zend_expected_type_Z_EXPECTED_ARRAY,
-            DataType::Object => _zend_expected_type_Z_EXPECTED_OBJECT,
+            DataType::Object(_) => _zend_expected_type_Z_EXPECTED_OBJECT,
             DataType::Resource => _zend_expected_type_Z_EXPECTED_RESOURCE,
             _ => unreachable!(),
         };

--- a/src/php/class.rs
+++ b/src/php/class.rs
@@ -264,6 +264,11 @@ impl ClassBuilder {
     ///
     /// * `T` - The type which will override the Zend object. Must implement [`RegisteredClass`]
     /// which can be derived using the [`php_class`](crate::php_class) attribute macro.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the class name associated with `T` is not the same as the class name specified
+    /// when creating the builder.
     pub fn object_override<T: RegisteredClass>(mut self) -> Self {
         unsafe extern "C" fn create_object<T: RegisteredClass>(
             _: *mut ClassEntry,
@@ -272,6 +277,7 @@ impl ClassBuilder {
             (*ptr).get_mut_zend_obj()
         }
 
+        assert_eq!(self.name.as_str(), T::CLASS_NAME);
         self.object_override = Some(create_object::<T>);
         self
     }

--- a/src/php/enums.rs
+++ b/src/php/enums.rs
@@ -132,11 +132,12 @@ impl TryFrom<u32> for DataType {
         contains!(IS_TRUE, True);
         contains!(IS_FALSE, False);
         contains!(IS_NULL, Null);
-        contains!(IS_UNDEF, Undef);
 
         if (value & IS_OBJECT) == IS_OBJECT {
             return Ok(DataType::Object(None));
         }
+
+        contains!(IS_UNDEF, Undef);
 
         Err(Error::UnknownDatatype(value))
     }

--- a/src/php/function.rs
+++ b/src/php/function.rs
@@ -2,8 +2,8 @@
 
 use std::{ffi::CString, mem, os::raw::c_char, ptr};
 
-use crate::bindings::zend_function_entry;
 use crate::errors::Result;
+use crate::{bindings::zend_function_entry, errors::Error};
 
 use super::{
     args::{Arg, ArgInfo},
@@ -132,6 +132,7 @@ impl<'a> FunctionBuilder<'a> {
             type_: match self.retval {
                 Some(retval) => {
                     ZendType::empty_from_type(retval, self.ret_as_ref, false, self.ret_as_null)
+                        .ok_or(Error::InvalidCString)?
                 }
                 None => ZendType::empty(false, false),
             },

--- a/src/php/types/closure.rs
+++ b/src/php/types/closure.rs
@@ -151,6 +151,8 @@ impl Default for Closure {
 }
 
 impl RegisteredClass for Closure {
+    const CLASS_NAME: &'static str = "RustClosure";
+
     fn get_metadata() -> &'static super::object::ClassMetadata<Self> {
         &CLOSURE_META
     }

--- a/src/php/types/object.rs
+++ b/src/php/types/object.rs
@@ -195,7 +195,7 @@ impl<'a, T: RegisteredClass> ClassRef<'a, T> {
 }
 
 impl<'a, T: RegisteredClass> IntoZval for ClassRef<'a, T> {
-    const TYPE: DataType = DataType::Object;
+    const TYPE: DataType = DataType::Object(Some(T::CLASS_NAME));
 
     fn set_zval(self, zv: &mut Zval, _: bool) -> Result<()> {
         zv.set_object(&mut self.ptr.std);
@@ -326,7 +326,7 @@ impl<T: RegisteredClass + Debug> Debug for ClassObject<'_, T> {
 }
 
 impl<T: RegisteredClass> IntoZval for ClassObject<'_, T> {
-    const TYPE: DataType = DataType::Object;
+    const TYPE: DataType = DataType::Object(Some(T::CLASS_NAME));
 
     fn set_zval(self, zv: &mut Zval, _: bool) -> Result<()> {
         unsafe { zv.set_object(&mut (*self.into_raw()).std) };
@@ -336,7 +336,7 @@ impl<T: RegisteredClass> IntoZval for ClassObject<'_, T> {
 }
 
 impl<T: RegisteredClass> IntoZval for T {
-    const TYPE: DataType = DataType::Object;
+    const TYPE: DataType = DataType::Object(Some(T::CLASS_NAME));
 
     fn set_zval(self, zv: &mut Zval, persistent: bool) -> Result<()> {
         ClassObject::new(self).set_zval(zv, persistent)
@@ -344,7 +344,7 @@ impl<T: RegisteredClass> IntoZval for T {
 }
 
 impl<'a, T: RegisteredClass> FromZval<'a> for &'a T {
-    const TYPE: DataType = DataType::Object;
+    const TYPE: DataType = DataType::Object(Some(T::CLASS_NAME));
 
     fn from_zval(zval: &'a Zval) -> Option<Self> {
         let obj = zval.object()?;
@@ -360,7 +360,7 @@ impl<'a, T: RegisteredClass> FromZval<'a> for &'a T {
 }
 
 impl<'a, T: RegisteredClass> FromZval<'a> for &'a mut T {
-    const TYPE: DataType = DataType::Object;
+    const TYPE: DataType = DataType::Object(Some(T::CLASS_NAME));
 
     fn from_zval(zval: &'a Zval) -> Option<Self> {
         let obj = zval.object()?;
@@ -381,6 +381,9 @@ pub trait RegisteredClass: Default + Sized
 where
     Self: 'static,
 {
+    /// PHP class name of the registered class.
+    const CLASS_NAME: &'static str;
+
     /// Returns a reference to the class metadata, which stores the class entry and handlers.
     ///
     /// This must be statically allocated, and is usually done through the [`macro@php_class`]

--- a/src/php/types/zval.rs
+++ b/src/php/types/zval.rs
@@ -35,12 +35,14 @@ unsafe impl Sync for Zval {}
 impl<'a> Zval {
     /// Creates a new, empty zval.
     pub(crate) const fn new() -> Self {
+        // NOTE: Once the `Drop` implementation has been improved this can be public.
+        // At the moment, if we were to create a new zval with an array it wouldn't drop the array.
         Self {
             value: zend_value {
                 ptr: ptr::null_mut(),
             },
             u1: _zval_struct__bindgen_ty_1 {
-                type_info: DataType::Null as u32,
+                type_info: DataType::Null.as_u32(),
             },
             u2: _zval_struct__bindgen_ty_2 { next: 0 },
         }
@@ -197,22 +199,22 @@ impl<'a> Zval {
 
     /// Returns true if the zval is a long, false otherwise.
     pub fn is_long(&self) -> bool {
-        unsafe { self.u1.v.type_ == DataType::Long as u8 }
+        unsafe { self.u1.v.type_ as u32 == DataType::Long.as_u32() }
     }
 
     /// Returns true if the zval is null, false otherwise.
     pub fn is_null(&self) -> bool {
-        unsafe { self.u1.v.type_ == DataType::Null as u8 }
+        unsafe { self.u1.v.type_ as u32 == DataType::Null.as_u32() }
     }
 
     /// Returns true if the zval is true, false otherwise.
     pub fn is_true(&self) -> bool {
-        unsafe { self.u1.v.type_ == DataType::True as u8 }
+        unsafe { self.u1.v.type_ as u32 == DataType::True.as_u32() }
     }
 
     /// Returns true if the zval is false, false otherwise.
     pub fn is_false(&self) -> bool {
-        unsafe { self.u1.v.type_ == DataType::False as u8 }
+        unsafe { self.u1.v.type_ as u32 == DataType::False.as_u32() }
     }
 
     /// Returns true if the zval is a bool, false otherwise.
@@ -222,32 +224,32 @@ impl<'a> Zval {
 
     /// Returns true if the zval is a double, false otherwise.
     pub fn is_double(&self) -> bool {
-        unsafe { self.u1.v.type_ == DataType::Double as u8 }
+        unsafe { self.u1.v.type_ as u32 == DataType::Double.as_u32() }
     }
 
     /// Returns true if the zval is a string, false otherwise.
     pub fn is_string(&self) -> bool {
-        unsafe { self.u1.v.type_ == DataType::String as u8 }
+        unsafe { self.u1.v.type_ as u32 == DataType::String.as_u32() }
     }
 
     /// Returns true if the zval is a resource, false otherwise.
     pub fn is_resource(&self) -> bool {
-        unsafe { self.u1.v.type_ == DataType::Resource as u8 }
+        unsafe { self.u1.v.type_ as u32 == DataType::Resource.as_u32() }
     }
 
     /// Returns true if the zval is an array, false otherwise.
     pub fn is_array(&self) -> bool {
-        unsafe { self.u1.v.type_ == DataType::Array as u8 }
+        unsafe { self.u1.v.type_ as u32 == DataType::Array.as_u32() }
     }
 
     /// Returns true if the zval is an object, false otherwise.
     pub fn is_object(&self) -> bool {
-        unsafe { self.u1.v.type_ == DataType::Object as u8 }
+        unsafe { self.u1.v.type_ as u32 == DataType::Object(None).as_u32() }
     }
 
     /// Returns true if the zval is a reference, false otherwise.
     pub fn is_reference(&self) -> bool {
-        unsafe { self.u1.v.type_ == DataType::Reference as u8 }
+        unsafe { self.u1.v.type_ as u32 == DataType::Reference.as_u32() }
     }
 
     /// Returns true if the zval is callable, false otherwise.
@@ -319,9 +321,9 @@ impl<'a> Zval {
     /// * `val` - The value to set the zval as.
     pub fn set_bool<T: Into<bool>>(&mut self, val: T) {
         self.u1.type_info = if val.into() {
-            DataType::True as u32
+            DataType::True.as_u32()
         } else {
-            DataType::False as u32
+            DataType::False.as_u32()
         };
     }
 
@@ -395,7 +397,7 @@ impl Debug for Zval {
                 DataType::Double => field!(self.double()),
                 DataType::String | DataType::Mixed => field!(self.string()),
                 DataType::Array => field!(self.array()),
-                DataType::Object => field!(self.object()),
+                DataType::Object(_) => field!(self.object()),
                 DataType::Resource => field!(self.resource()),
                 DataType::Reference => field!(self.reference()),
                 DataType::Callable => field!(self.string()),


### PR DESCRIPTION
Previously, when returning or taking a class object the type would be `object`, rather than the actual class name.