### PR TITLE
Fix alignment of class objects

### DIFF
--- a/src/php/execution_data.rs
+++ b/src/php/execution_data.rs
@@ -30,10 +30,8 @@ impl ExecutionData {
     /// 1. Contains an object.
     /// 2. The object was originally derived from `T`.
     pub unsafe fn get_object<T: RegisteredClass>(&self) -> Option<ClassObject<'static, T>> {
-        let ptr = self.This.object()? as *const ZendObject as *mut u8;
-        let offset = mem::size_of::<T>();
-        let ptr = ptr.offset(0 - offset as isize) as *mut ZendClassObject<T>;
-        Some(ClassObject::from_zend_class_object(&mut *ptr, false))
+        let ptr = ZendClassObject::<T>::from_zend_obj_ptr(self.This.object()?)?;
+        Some(ClassObject::from_zend_class_object(ptr, false))
     }
 
     /// Attempts to retrieve the 'this' object, which can be used in class methods

--- a/src/php/execution_data.rs
+++ b/src/php/execution_data.rs
@@ -1,8 +1,6 @@
 //! Functions for interacting with the execution data passed to PHP functions\
 //! introduced in Rust.
 
-use std::mem;
-
 use crate::{
     bindings::{zend_execute_data, ZEND_MM_ALIGNMENT, ZEND_MM_ALIGNMENT_MASK},
     errors::{Error, Result},


### PR DESCRIPTION
When there was padding between `obj` and `std`, this would be ignored by the library, leading to errors.