### PR TITLE
Add Display impl for ZendObject

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -176,6 +176,7 @@ const ALLOWED_BINDINGS: &[&str] = &[
     "std_object_handlers",
     "zend_array_destroy",
     "zend_array_dup",
+    "zend_call_known_function",
     "zend_ce_argument_count_error",
     "zend_ce_arithmetic_error",
     "zend_ce_compile_error",

--- a/src/php/types/zval.rs
+++ b/src/php/types/zval.rs
@@ -461,6 +461,16 @@ impl Zval {
         unsafe { zval_ptr_dtor(self) };
         self.u1.type_info = ty.bits();
     }
+
+    /// Extracts some type from a `Zval`.
+    ///
+    /// This is a wrapper function around `TryFrom`.
+    pub fn extract<'a, T>(&'a self) -> Option<T>
+    where
+        T: FromZval<'a>,
+    {
+        FromZval::from_zval(self)
+    }
 }
 
 impl Debug for Zval {


### PR DESCRIPTION
Small PR that brings part of my work getting eval/compile support built.

Adds some basic support for capturing PHP exceptions, function calling, and convenience methods around converting from Zval to Rust types.

Which that groundwork in place, add a PHP equivalent implementation for Display.