### PR TITLE
Refactor `ZendHashTable` and `Zval`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -313,4 +313,6 @@ const ALLOWED_BINDINGS: &[&str] = &[
     "_ZEND_TYPE_NULLABLE_BIT",
     "ts_rsrc_id",
     "_ZEND_TYPE_NAME_BIT",
+    "zval_ptr_dtor",
+    "zend_refcounted_h",
 ];

--- a/example/skel/src/lib.rs
+++ b/example/skel/src/lib.rs
@@ -9,10 +9,11 @@ use ext_php_rs::{
         execution_data::ExecutionData,
         function::FunctionBuilder,
         types::{
+            array::OwnedHashTable,
             callable::Callable,
             closure::Closure,
             object::{ClassObject, ClassRef},
-            zval::Zval,
+            zval::{FromZval, IntoZval, Zval},
         },
     },
     php_class,
@@ -109,42 +110,7 @@ pub fn closure_count() -> Closure {
     }) as Box<dyn FnMut(i32) -> i32>)
 }
 
-// #[php_function]
-// pub fn test_zval(t: Zval) {
-// let mut z = Zval::new();
-// z.set_long(5);
-// z.set_double(100.5);
-// z.set_bool(false);
-// z.set_null();
-// z.set_string("Hello world", false).unwrap();
-// z.set_array(ZendHashTable::try_from(vec![1, 2, 3, 4, 5]).unwrap());
-// drop(dbg!(z));
-
-// let mut x = ZendHashTable::new();
-// dbg!(x.insert("test", "Hello world"));
-// dbg!(x.insert("test", 1234));
-// dbg!(x.insert("test", "ok test"));
-// }
-
-extern "C" fn test_zval(ex: &mut ExecutionData, retval: &mut Zval) {
-    let mut a = Arg::new("test", DataType::Array);
-
-    parse_args!(ex, a);
-    let zv = a.zval().unwrap();
-    let arr = zv.array().unwrap();
-    let mut new = arr.clone();
-
-    new.insert("hello", "a new fvalue");
-    dbg!(&arr);
-    dbg!(&new);
-}
-
 #[php_module]
 pub fn module(module: ModuleBuilder) -> ModuleBuilder {
-    module.function(
-        FunctionBuilder::new("test_zval", test_zval)
-            .arg(Arg::new("test", DataType::Array))
-            .build()
-            .unwrap(),
-    )
+    module
 }

--- a/example/skel/src/lib.rs
+++ b/example/skel/src/lib.rs
@@ -1,13 +1,17 @@
 mod allocator;
 
+use std::convert::TryFrom;
+
 use allocator::PhpAllocator;
 use ext_php_rs::{
     php::{
         exceptions::PhpException,
         types::{
+            array::ZendHashTable,
             callable::Callable,
             closure::Closure,
             object::{ClassObject, ClassRef},
+            zval::Zval,
         },
     },
     php_class,
@@ -208,6 +212,23 @@ pub fn closure_count() -> Closure {
         count += a;
         count
     }) as Box<dyn FnMut(i32) -> i32>)
+}
+
+#[php_function]
+pub fn test_zval() {
+    let mut z = Zval::new();
+    z.set_long(5);
+    z.set_double(100.5);
+    z.set_bool(false);
+    z.set_null();
+    z.set_string("Hello world", false).unwrap();
+    z.set_array(ZendHashTable::try_from(vec![1, 2, 3, 4, 5]).unwrap());
+    drop(dbg!(z));
+
+    let mut x = ZendHashTable::new();
+    dbg!(x.insert("test", "Hello world"));
+    dbg!(x.insert("test", 1234));
+    dbg!(x.insert("test", "ok test"));
 }
 
 #[php_module]

--- a/example/skel/src/lib.rs
+++ b/example/skel/src/lib.rs
@@ -1,13 +1,14 @@
 mod allocator;
 
-use std::convert::TryFrom;
-
-use allocator::PhpAllocator;
 use ext_php_rs::{
+    parse_args,
     php::{
+        args::Arg,
+        enums::DataType,
         exceptions::PhpException,
+        execution_data::ExecutionData,
+        function::FunctionBuilder,
         types::{
-            array::ZendHashTable,
             callable::Callable,
             closure::Closure,
             object::{ClassObject, ClassRef},
@@ -17,112 +18,6 @@ use ext_php_rs::{
     php_class,
     prelude::*,
 };
-
-// #[php_function]
-// pub fn hello_world() -> String {
-//     let call = Callable::try_from_name("strpos").unwrap();
-
-//     eprintln!("im callin");
-//     let val = call.try_call(vec![&"hello world", &"w"]);
-//     dbg!(val);
-//     "Ok".into()
-// }
-
-// #[php_const]
-// const SKEL_TEST_CONST: &str = "Test constant";
-// #[php_const]
-// const SKEL_TEST_LONG_CONST: i32 = 1234;
-
-// #[php_function(optional = "z")]
-// pub fn skeleton_version(x: ZendHashTable, y: f64, z: Option<f64>) -> String {
-//     dbg!(x, y, z);
-//     "Hello".into()
-// }
-
-// #[php_function(optional = "z")]
-// pub fn skeleton_array(
-//     arr: ZendHashTable,
-//     x: i32,
-//     y: f64,
-//     z: Option<f64>,
-// ) -> Result<ZendHashTable, String> {
-//     for (k, x, y) in arr.iter() {
-//         println!("{:?} {:?} {:?}", k, x, y.string());
-//     }
-
-//     dbg!(x, y, z);
-
-//     let mut new = ZendHashTable::new();
-//     new.insert("Hello", &"World")
-//         .map_err(|_| "Couldn't insert into hashtable")?;
-//     Ok(new)
-// }
-
-// #[php_function(optional = "i", defaults(i = 5))]
-// pub fn test_array(i: i32, b: Option<i32>) -> Vec<i32> {
-//     dbg!(i, b);
-//     vec![1, 2, 3, 4]
-// }
-
-// #[php_function(optional = "offset", defaults(offset = 0))]
-// pub fn rust_strpos(haystack: &str, needle: &str, offset: i64) -> Option<usize> {
-//     let haystack = haystack.chars().skip(offset as usize).collect::<String>();
-//     haystack.find(needle)
-// }
-
-// #[php_function]
-// pub fn example_exception() -> Result<i32, &'static str> {
-//     Err("Bad here")
-// }
-
-// #[php_function]
-// pub fn skel_unpack<'a>(
-//     mut arr: HashMap<String, String>,
-// ) -> Result<HashMap<String, String>, PhpException<'a>> {
-//     arr.insert("hello".into(), "not world".into());
-//     Ok(arr)
-// }
-
-// #[php_function]
-// pub fn test_extern() -> i32 {
-//     // let y = unsafe { strpos("hello", "e", None) };
-//     // dbg!(y);
-//     // let x = unsafe { test_func() };
-//     // dbg!(x.try_call(vec![]));
-//     0
-// }
-
-// #[php_function]
-// pub fn test_lifetimes<'a>() -> ZendHashTable<'a> {
-//     ZendHashTable::try_from(&HashMap::<String, String>::new()).unwrap()
-// }
-
-#[php_function]
-pub fn test_str(input: &str) -> &str {
-    input
-}
-
-// #[no_mangle]
-// pub extern "C" fn php_module_info(_module: *mut ModuleEntry) {
-//     info_table_start!();
-//     info_table_row!("skeleton extension", "enabled");
-//     info_table_end!();
-// }
-
-// #[php_class(name = "Redis\\Exception\\RedisClientException")]
-// #[extends(ClassEntry::exception())]
-// #[derive(Default)]
-// struct RedisException;
-
-// #[php_function]
-// pub fn test_exception() -> Result<i32, PhpException<'static>> {
-//     Err(PhpException::from_class::<RedisException>(
-//         "Hello world".into(),
-//     ))
-// }
-
-// #[global_allocator]
-// static GLOBAL: PhpAllocator = PhpAllocator::new();
 
 #[php_class]
 #[property(test = 0)]
@@ -214,24 +109,42 @@ pub fn closure_count() -> Closure {
     }) as Box<dyn FnMut(i32) -> i32>)
 }
 
-#[php_function]
-pub fn test_zval() {
-    let mut z = Zval::new();
-    z.set_long(5);
-    z.set_double(100.5);
-    z.set_bool(false);
-    z.set_null();
-    z.set_string("Hello world", false).unwrap();
-    z.set_array(ZendHashTable::try_from(vec![1, 2, 3, 4, 5]).unwrap());
-    drop(dbg!(z));
+// #[php_function]
+// pub fn test_zval(t: Zval) {
+// let mut z = Zval::new();
+// z.set_long(5);
+// z.set_double(100.5);
+// z.set_bool(false);
+// z.set_null();
+// z.set_string("Hello world", false).unwrap();
+// z.set_array(ZendHashTable::try_from(vec![1, 2, 3, 4, 5]).unwrap());
+// drop(dbg!(z));
 
-    let mut x = ZendHashTable::new();
-    dbg!(x.insert("test", "Hello world"));
-    dbg!(x.insert("test", 1234));
-    dbg!(x.insert("test", "ok test"));
+// let mut x = ZendHashTable::new();
+// dbg!(x.insert("test", "Hello world"));
+// dbg!(x.insert("test", 1234));
+// dbg!(x.insert("test", "ok test"));
+// }
+
+extern "C" fn test_zval(ex: &mut ExecutionData, retval: &mut Zval) {
+    let mut a = Arg::new("test", DataType::Array);
+
+    parse_args!(ex, a);
+    let zv = a.zval().unwrap();
+    let arr = zv.array().unwrap();
+    let mut new = arr.clone();
+
+    new.insert("hello", "a new fvalue");
+    dbg!(&arr);
+    dbg!(&new);
 }
 
 #[php_module]
 pub fn module(module: ModuleBuilder) -> ModuleBuilder {
-    module
+    module.function(
+        FunctionBuilder::new("test_zval", test_zval)
+            .arg(Arg::new("test", DataType::Array))
+            .build()
+            .unwrap(),
+    )
 }

--- a/example/skel/test.php
+++ b/example/skel/test.php
@@ -1,15 +1,16 @@
 <?php
 
-include 'vendor/autoload.php';
+test_zval();
+//include 'vendor/autoload.php';
 
-$ext = new ReflectionExtension('skel');
+//$ext = new ReflectionExtension('skel');
 
-dd($ext);
+//dd($ext);
 
-$x = fn_once();
-$x();
-$x();
+//$x = fn_once();
+//$x();
+//$x();
 
-// $x = get_closure();
+//// $x = get_closure();
 
-// var_dump($x(5));
+//// var_dump($x(5));

--- a/example/skel/test.php
+++ b/example/skel/test.php
@@ -1,6 +1,6 @@
 <?php
 
-test_zval();
+test_zval(['hello' => 'world']);
 //include 'vendor/autoload.php';
 
 //$ext = new ReflectionExtension('skel');

--- a/src/php/enums.rs
+++ b/src/php/enums.rs
@@ -107,15 +107,13 @@ impl TryFrom<ZvalTypeFlags> for DataType {
     }
 }
 
-impl TryFrom<u32> for DataType {
-    type Error = Error;
-
+impl From<u32> for DataType {
     #[allow(clippy::bad_bit_mask)]
-    fn try_from(value: u32) -> Result<Self> {
+    fn from(value: u32) -> Self {
         macro_rules! contains {
             ($c: ident, $t: ident) => {
                 if (value & $c) == $c {
-                    return Ok(DataType::$t);
+                    return DataType::$t;
                 }
             };
         }
@@ -134,12 +132,12 @@ impl TryFrom<u32> for DataType {
         contains!(IS_NULL, Null);
 
         if (value & IS_OBJECT) == IS_OBJECT {
-            return Ok(DataType::Object(None));
+            return DataType::Object(None);
         }
 
         contains!(IS_UNDEF, Undef);
 
-        Err(Error::UnknownDatatype(value))
+        DataType::Mixed
     }
 }
 

--- a/src/php/globals.rs
+++ b/src/php/globals.rs
@@ -2,7 +2,7 @@
 
 use crate::bindings::{_zend_executor_globals, ext_php_rs_executor_globals};
 
-use super::types::array::ZendHashTable;
+use super::types::array::HashTable;
 
 /// Stores global variables used in the PHP executor.
 pub type ExecutorGlobals = _zend_executor_globals;
@@ -17,11 +17,7 @@ impl ExecutorGlobals {
     }
 
     /// Attempts to retrieve the global class hash table.
-    pub fn class_table(&self) -> Option<ZendHashTable> {
-        if self.class_table.is_null() {
-            return None;
-        }
-
-        unsafe { ZendHashTable::from_ptr(self.class_table, false) }.ok()
+    pub fn class_table(&self) -> Option<&HashTable> {
+        unsafe { self.class_table.as_ref() }
     }
 }

--- a/src/php/types/array.rs
+++ b/src/php/types/array.rs
@@ -378,7 +378,7 @@ where
         for (idx, key, val) in zht.into_iter() {
             hm.insert(
                 key.unwrap_or_else(|| idx.to_string()),
-                V::from_zval(val).ok_or(Error::ZvalConversion(val.get_type()?))?,
+                V::from_zval(val).ok_or(Error::ZvalConversion(val.get_type()))?,
             );
         }
 
@@ -436,7 +436,7 @@ where
 
     fn try_from(ht: ZendHashTable<'a>) -> Result<Self> {
         ht.into_iter()
-            .map(|(_, _, v)| V::from_zval(v).ok_or(Error::ZvalConversion(v.get_type()?)))
+            .map(|(_, _, v)| V::from_zval(v).ok_or(Error::ZvalConversion(v.get_type())))
             .collect::<Result<Vec<_>>>()
     }
 }

--- a/src/php/types/array.rs
+++ b/src/php/types/array.rs
@@ -175,10 +175,16 @@ impl HashTable {
         Ok(())
     }
 
-    /// Returns an iterator over the hash table.
+    /// Returns an iterator over the key(s) and value contained inside the hashtable.
     #[inline]
     pub fn iter(&self) -> Iter {
         Iter::new(self)
+    }
+
+    /// Returns an iterator over the values contained inside the hashtable, as if it was a set or list.
+    #[inline]
+    pub fn values(&self) -> Values {
+        Values::new(self)
     }
 
     /// Clones the hash table, returning an [`OwnedHashTable`].
@@ -246,6 +252,35 @@ impl<'a> Iterator for Iter<'a> {
         Self: Sized,
     {
         self.ht.nNumUsed as usize
+    }
+}
+
+/// Immutable iterator which iterates over the values of the hashtable, as it was a set or list.
+pub struct Values<'a>(Iter<'a>);
+
+impl<'a> Values<'a> {
+    /// Creates a new iterator over a hashtables values.
+    ///
+    /// # Parameters
+    ///
+    /// * `ht` - The hashtable to iterate.
+    pub fn new(ht: &'a HashTable) -> Self {
+        Self(Iter::new(ht))
+    }
+}
+
+impl<'a> Iterator for Values<'a> {
+    type Item = &'a Zval;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(_, _, zval)| zval)
+    }
+
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.0.count()
     }
 }
 

--- a/src/php/types/array.rs
+++ b/src/php/types/array.rs
@@ -6,18 +6,20 @@ use std::{
     convert::{TryFrom, TryInto},
     ffi::CString,
     fmt::Debug,
-    marker::PhantomData,
+    ops::{Deref, DerefMut},
+    ptr::NonNull,
     u64,
 };
 
 use crate::{
     bindings::{
-        HashTable, _Bucket, _zend_new_array, zend_array_destroy, zend_array_dup, zend_hash_clean,
+        _Bucket, _zend_new_array, zend_array_destroy, zend_array_dup, zend_hash_clean,
         zend_hash_index_del, zend_hash_index_find, zend_hash_index_update,
         zend_hash_next_index_insert, zend_hash_str_del, zend_hash_str_find, zend_hash_str_update,
         HT_MIN_SIZE,
     },
     errors::{Error, Result},
+    php::enums::DataType,
 };
 
 use super::{
@@ -25,63 +27,13 @@ use super::{
     zval::{FromZval, IntoZval, Zval},
 };
 
-/// A PHP array, which internally is a hash table.
-pub struct ZendHashTable<'a> {
-    ptr: *mut HashTable,
-    free: bool,
-    phantom: PhantomData<&'a HashTable>,
-}
+/// PHP array, which is represented in memory as a hashtable.
+pub use crate::bindings::HashTable;
 
-impl<'a> ZendHashTable<'a> {
-    /// Creates a new, empty, PHP associative array.
-    pub fn new() -> Self {
-        Self::with_capacity(HT_MIN_SIZE)
-    }
-
-    /// Creates a new, empty, PHP associative array with an initial size.
-    ///
-    /// # Parameters
-    ///
-    /// * `size` - The size to initialize the array with.
-    pub fn with_capacity(size: u32) -> Self {
-        // SAFETY: PHP allocater handles the creation of the
-        // array.
-        let ptr = unsafe { _zend_new_array(size) };
-        Self {
-            ptr,
-            free: true,
-            phantom: PhantomData,
-        }
-    }
-
-    /// Creates a new hash table wrapper.
-    /// This _will not_ be freed when it goes out of scope in Rust.
-    ///
-    /// # Parameters
-    ///
-    /// * `ptr` - The pointer of the actual hash table.
-    /// * `free` - Whether the pointer should be freed when the resulting [`ZendHashTable`]
-    /// goes out of scope.
-    ///
-    /// # Safety
-    ///
-    /// As a raw pointer is given this function is unsafe, you must ensure that the pointer is valid when calling
-    /// the function. A simple null check is done but this is not sufficient in most cases.
-    pub unsafe fn from_ptr(ptr: *mut HashTable, free: bool) -> Result<Self> {
-        if ptr.is_null() {
-            return Err(Error::InvalidPointer);
-        }
-
-        Ok(Self {
-            ptr,
-            free,
-            phantom: PhantomData,
-        })
-    }
-
+impl HashTable {
     /// Returns the current number of elements in the array.
     pub fn len(&self) -> usize {
-        unsafe { *self.ptr }.nNumOfElements as usize
+        self.nNumOfElements as usize
     }
 
     /// Returns whether the hash table is empty.
@@ -91,7 +43,7 @@ impl<'a> ZendHashTable<'a> {
 
     /// Clears the hash table, removing all values.
     pub fn clear(&mut self) {
-        unsafe { zend_hash_clean(self.ptr) }
+        unsafe { zend_hash_clean(self) }
     }
 
     /// Attempts to retrieve a value from the hash table with a string key.
@@ -104,9 +56,9 @@ impl<'a> ZendHashTable<'a> {
     ///
     /// * `Some(&Zval)` - A reference to the zval at the position in the hash table.
     /// * `None` - No value at the given position was found.
-    pub fn get(&self, key: &str) -> Option<&Zval> {
+    pub fn get(&self, key: &'_ str) -> Option<&Zval> {
         let str = CString::new(key).ok()?;
-        unsafe { zend_hash_str_find(self.ptr, str.as_ptr(), key.len() as _).as_ref() }
+        unsafe { zend_hash_str_find(self, str.as_ptr(), key.len() as _).as_ref() }
     }
 
     /// Attempts to retrieve a value from the hash table with an index.
@@ -120,7 +72,7 @@ impl<'a> ZendHashTable<'a> {
     /// * `Some(&Zval)` - A reference to the zval at the position in the hash table.
     /// * `None` - No value at the given position was found.
     pub fn get_index(&self, key: u64) -> Option<&Zval> {
-        unsafe { zend_hash_index_find(self.ptr, key).as_ref() }
+        unsafe { zend_hash_index_find(self, key).as_ref() }
     }
 
     /// Attempts to remove a value from the hash table with a string key.
@@ -133,10 +85,9 @@ impl<'a> ZendHashTable<'a> {
     ///
     /// * `Some(())` - Key was successfully removed.
     /// * `None` - No key was removed, did not exist.
-    pub fn remove<K>(&self, key: &str) -> Option<()> {
-        let result = unsafe {
-            zend_hash_str_del(self.ptr, CString::new(key).ok()?.as_ptr(), key.len() as _)
-        };
+    pub fn remove<K>(&mut self, key: &str) -> Option<()> {
+        let result =
+            unsafe { zend_hash_str_del(self, CString::new(key).ok()?.as_ptr(), key.len() as _) };
 
         if result < 0 {
             None
@@ -155,8 +106,8 @@ impl<'a> ZendHashTable<'a> {
     ///
     /// * `Ok(())` - Key was successfully removed.
     /// * `None` - No key was removed, did not exist.
-    pub fn remove_index(&self, key: u64) -> Option<()> {
-        let result = unsafe { zend_hash_index_del(self.ptr, key) };
+    pub fn remove_index(&mut self, key: u64) -> Option<()> {
+        let result = unsafe { zend_hash_index_del(self, key) };
 
         if result < 0 {
             None
@@ -179,7 +130,7 @@ impl<'a> ZendHashTable<'a> {
         let mut val = val.into_zval(false)?;
         unsafe {
             zend_hash_str_update(
-                self.ptr,
+                self,
                 CString::new(key)?.as_ptr(),
                 key.len() as u64,
                 &mut val,
@@ -201,7 +152,7 @@ impl<'a> ZendHashTable<'a> {
         V: IntoZval,
     {
         let mut val = val.into_zval(false)?;
-        unsafe { zend_hash_index_update(self.ptr, key, &mut val) };
+        unsafe { zend_hash_index_update(self, key, &mut val) };
         val.release();
         Ok(())
     }
@@ -217,7 +168,7 @@ impl<'a> ZendHashTable<'a> {
         V: IntoZval,
     {
         let mut val = val.into_zval(false)?;
-        unsafe { zend_hash_next_index_insert(self.ptr, &mut val) };
+        unsafe { zend_hash_next_index_insert(self, &mut val) };
         val.release();
 
         Ok(())
@@ -225,18 +176,18 @@ impl<'a> ZendHashTable<'a> {
 
     /// Returns an iterator over the hash table.
     #[inline]
-    pub fn iter(&self) -> Iter<'_> {
+    pub fn iter(&self) -> Iter {
         Iter::new(self)
     }
 
-    /// Converts the hash table into a raw pointer to be passed to Zend.
-    pub(crate) fn into_ptr(mut self) -> *mut HashTable {
-        self.free = false;
-        self.ptr
+    /// Clones the hash table, returning an [`OwnedHashTable`].
+    pub fn to_owned(&self) -> OwnedHashTable {
+        let ptr = unsafe { zend_array_dup(self as *const HashTable as *mut HashTable) };
+        unsafe { OwnedHashTable::from_ptr(ptr) }
     }
 }
 
-impl<'a> Debug for ZendHashTable<'a> {
+impl Debug for HashTable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_map()
             .entries(
@@ -247,108 +198,187 @@ impl<'a> Debug for ZendHashTable<'a> {
     }
 }
 
-impl<'a> Default for ZendHashTable<'a> {
+/// Immutable iterator upon a reference to a hashtable.
+pub struct Iter<'a> {
+    ht: &'a HashTable,
+    pos: Option<NonNull<_Bucket>>,
+    end: Option<NonNull<_Bucket>>,
+}
+
+impl<'a> Iter<'a> {
+    /// Creates a new iterator over a hashtable.
+    ///
+    /// # Parameters
+    ///
+    /// * `ht` - The hashtable to iterate.
+    pub fn new(ht: &'a HashTable) -> Self {
+        Self {
+            ht,
+            pos: NonNull::new(ht.arData),
+            end: NonNull::new(unsafe { ht.arData.offset(ht.nNumUsed as isize) }),
+        }
+    }
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = (u64, Option<String>, &'a Zval);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let pos = self.pos?;
+
+        if pos == self.end? {
+            return None;
+        }
+
+        let bucket = unsafe { pos.as_ref() };
+        let key = unsafe { ZendString::from_ptr(bucket.key, false) }
+            .and_then(|s| s.try_into())
+            .ok();
+
+        self.pos = NonNull::new(unsafe { pos.as_ptr().offset(1) });
+
+        Some((bucket.h, key, &bucket.val))
+    }
+
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.ht.nNumUsed as usize
+    }
+}
+
+/// A container used to 'own' a Zend hashtable. Dereferences to a reference to [`HashTable`].
+///
+/// When this struct is dropped, it will also destroy the internal hashtable, unless the `into_raw`
+/// function is used.
+pub struct OwnedHashTable {
+    ptr: NonNull<HashTable>,
+    drop: bool,
+}
+
+impl OwnedHashTable {
+    /// Creates a new, empty, PHP associative array.
+    pub fn new() -> Self {
+        Self::with_capacity(HT_MIN_SIZE)
+    }
+
+    /// Creates a new, empty, PHP associative array with an initial size.
+    ///
+    /// # Parameters
+    ///
+    /// * `size` - The size to initialize the array with.
+    pub fn with_capacity(size: u32) -> Self {
+        // SAFETY: PHP allocater handles the creation of the array.
+        unsafe {
+            let ptr = _zend_new_array(size);
+            Self::from_ptr(ptr)
+        }
+    }
+
+    /// Creates an owned hashtable from a hashtable pointer, which will be freed when the
+    /// resulting Rust object is dropped.
+    ///
+    /// # Parameters
+    ///
+    /// * `ptr` - Hashtable pointer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given pointer is null.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that the given pointer is a valid hashtable pointer, including
+    /// non-null and properly aligned.
+    pub unsafe fn from_ptr(ptr: *mut HashTable) -> Self {
+        Self {
+            ptr: NonNull::new(ptr).expect("Invalid hashtable pointer given"),
+            drop: true,
+        }
+    }
+
+    /// Returns the inner pointer to the hashtable, without destroying the
+    pub fn into_inner(mut self) -> *mut HashTable {
+        self.drop = false;
+        self.ptr.as_ptr()
+    }
+}
+
+impl Deref for OwnedHashTable {
+    type Target = HashTable;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: all constructors ensure a valid ptr is present
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl DerefMut for OwnedHashTable {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: all constructors ensure a valid, owned ptr is present
+        unsafe { self.ptr.as_mut() }
+    }
+}
+
+impl Debug for OwnedHashTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.deref().fmt(f)
+    }
+}
+
+impl Default for OwnedHashTable {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'a> Drop for ZendHashTable<'a> {
-    fn drop(&mut self) {
-        if self.free {
-            unsafe { zend_array_destroy(self.ptr) };
-        }
-    }
-}
-
-impl<'a> Clone for ZendHashTable<'a> {
+impl Clone for OwnedHashTable {
     fn clone(&self) -> Self {
-        // SAFETY: If this fails then `emalloc` failed - we are doomed anyway?
-        // `from_ptr()` checks if the ptr is null.
-        unsafe {
-            let ptr = zend_array_dup(self.ptr);
-            Self::from_ptr(ptr, true).expect("ZendHashTable cloning failed when duplicating array.")
-        }
+        self.deref().to_owned()
     }
 }
 
-impl<'a> IntoIterator for ZendHashTable<'a> {
-    type Item = (u64, Option<String>, &'a Zval);
-    type IntoIter = IntoIter<'a>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        Self::IntoIter::new(self)
+impl Drop for OwnedHashTable {
+    fn drop(&mut self) {
+        unsafe { zend_array_destroy(self.ptr.as_mut()) };
     }
 }
 
-macro_rules! build_iter {
-    ($name: ident, $ht: ty) => {
-        pub struct $name<'a> {
-            ht: $ht,
-            pos: *mut _Bucket,
-            end: *mut _Bucket,
-        }
+impl IntoZval for OwnedHashTable {
+    const TYPE: DataType = DataType::Array;
 
-        impl<'a> $name<'a> {
-            pub fn new(ht: $ht) -> Self {
-                let ptr = unsafe { *ht.ptr };
-                let pos = ptr.arData;
-                let end = unsafe { ptr.arData.offset(ptr.nNumUsed as isize) };
-                Self { ht, pos, end }
-            }
-        }
-
-        impl<'a> Iterator for $name<'a> {
-            type Item = (u64, Option<String>, &'a Zval);
-
-            fn next(&mut self) -> Option<Self::Item> {
-                // iterator complete
-                if self.pos == self.end {
-                    return None;
-                }
-
-                let result = if let Some(val) = unsafe { self.pos.as_ref() } {
-                    // SAFETY: We can ensure safety further by checking if it is null before
-                    // converting it to a reference (val.key.as_ref() returns None if ptr == null)
-                    let str_key = unsafe { ZendString::from_ptr(val.key, false) }
-                        .and_then(|s| s.try_into())
-                        .ok();
-
-                    Some((val.h, str_key, &val.val))
-                } else {
-                    None
-                };
-
-                self.pos = unsafe { self.pos.offset(1) };
-                result
-            }
-
-            fn count(self) -> usize
-            where
-                Self: Sized,
-            {
-                unsafe { *self.ht.ptr }.nNumOfElements as usize
-            }
-        }
-    };
+    fn set_zval(self, zv: &mut Zval, _: bool) -> Result<()> {
+        zv.set_hashtable(self);
+        Ok(())
+    }
 }
 
-build_iter!(Iter, &'a ZendHashTable<'a>);
-build_iter!(IntoIter, ZendHashTable<'a>);
+impl<'a> FromZval<'a> for &'a HashTable {
+    const TYPE: DataType = DataType::Array;
 
-impl<'a, V> TryFrom<ZendHashTable<'a>> for HashMap<String, V>
+    fn from_zval(zval: &'a Zval) -> Option<Self> {
+        zval.array()
+    }
+}
+
+///////////////////////////////////////////
+//// HashMap
+///////////////////////////////////////////
+
+impl<V> TryFrom<&HashTable> for HashMap<String, V>
 where
-    V: FromZval<'a>,
+    for<'a> V: FromZval<'a>,
 {
     type Error = Error;
 
-    fn try_from(zht: ZendHashTable<'a>) -> Result<Self> {
-        let mut hm = HashMap::with_capacity(zht.len());
+    fn try_from(value: &HashTable) -> Result<Self> {
+        let mut hm = HashMap::with_capacity(value.len());
 
-        for (idx, key, val) in zht.into_iter() {
+        for (idx, key, val) in value.iter() {
             hm.insert(
                 key.unwrap_or_else(|| idx.to_string()),
-                V::from_zval(val).ok_or(Error::ZvalConversion(val.get_type()))?,
+                V::from_zval(val).ok_or_else(|| Error::ZvalConversion(val.get_type()))?,
             );
         }
 
@@ -356,18 +386,19 @@ where
     }
 }
 
-impl<'a, K, V> TryFrom<HashMap<K, V>> for ZendHashTable<'a>
+impl<K, V> TryFrom<HashMap<K, V>> for OwnedHashTable
 where
     K: AsRef<str>,
     V: IntoZval,
 {
     type Error = Error;
 
-    fn try_from(hm: HashMap<K, V>) -> Result<Self> {
-        let mut ht =
-            ZendHashTable::with_capacity(hm.len().try_into().map_err(|_| Error::IntegerOverflow)?);
+    fn try_from(value: HashMap<K, V>) -> Result<Self> {
+        let mut ht = OwnedHashTable::with_capacity(
+            value.len().try_into().map_err(|_| Error::IntegerOverflow)?,
+        );
 
-        for (k, v) in hm.into_iter() {
+        for (k, v) in value.into_iter() {
             ht.insert(k.as_ref(), v)?;
         }
 
@@ -375,53 +406,64 @@ where
     }
 }
 
-/// Implementation converting a Rust HashTable into a ZendHashTable.
-impl<'a, 'b, K, V> TryFrom<&'a HashMap<K, V>> for ZendHashTable<'b>
+impl<K, V> IntoZval for HashMap<K, V>
 where
     K: AsRef<str>,
-    V: IntoZval + Clone,
-{
-    type Error = Error;
-
-    fn try_from(hm: &'a HashMap<K, V>) -> Result<Self> {
-        let mut ht =
-            ZendHashTable::with_capacity(hm.len().try_into().map_err(|_| Error::IntegerOverflow)?);
-
-        for (k, v) in hm.iter() {
-            ht.insert(k.as_ref(), v.clone())?;
-        }
-
-        Ok(ht)
-    }
-}
-
-/// Implementation for converting a reference to `ZendHashTable` into a `Vec` of given type.
-/// Will return an error type if one of the values inside the array cannot be converted into
-/// a type `T`.
-impl<'a, V> TryFrom<ZendHashTable<'a>> for Vec<V>
-where
-    V: FromZval<'a>,
-{
-    type Error = Error;
-
-    fn try_from(ht: ZendHashTable<'a>) -> Result<Self> {
-        ht.into_iter()
-            .map(|(_, _, v)| V::from_zval(v).ok_or(Error::ZvalConversion(v.get_type())))
-            .collect::<Result<Vec<_>>>()
-    }
-}
-
-impl<'a, V> TryFrom<Vec<V>> for ZendHashTable<'a>
-where
     V: IntoZval,
 {
+    const TYPE: DataType = DataType::Array;
+
+    fn set_zval(self, zv: &mut Zval, _: bool) -> Result<()> {
+        let arr = self.try_into()?;
+        zv.set_hashtable(arr);
+        Ok(())
+    }
+}
+
+impl<T> FromZval<'_> for HashMap<String, T>
+where
+    for<'a> T: FromZval<'a>,
+{
+    const TYPE: DataType = DataType::Array;
+
+    fn from_zval(zval: &Zval) -> Option<Self> {
+        zval.array().and_then(|arr| arr.try_into().ok())
+    }
+}
+
+///////////////////////////////////////////
+//// Vec
+///////////////////////////////////////////
+
+impl<T> TryFrom<&HashTable> for Vec<T>
+where
+    for<'a> T: FromZval<'a>,
+{
     type Error = Error;
 
-    fn try_from(vec: Vec<V>) -> Result<Self> {
-        let mut ht =
-            ZendHashTable::with_capacity(vec.len().try_into().map_err(|_| Error::IntegerOverflow)?);
+    fn try_from(value: &HashTable) -> Result<Self> {
+        let mut vec = Vec::with_capacity(value.len());
 
-        for val in vec.into_iter() {
+        for (_, _, val) in value.iter() {
+            vec.push(T::from_zval(val).ok_or_else(|| Error::ZvalConversion(val.get_type()))?);
+        }
+
+        Ok(vec)
+    }
+}
+
+impl<T> TryFrom<Vec<T>> for OwnedHashTable
+where
+    T: IntoZval,
+{
+    type Error = Error;
+
+    fn try_from(value: Vec<T>) -> Result<Self> {
+        let mut ht = OwnedHashTable::with_capacity(
+            value.len().try_into().map_err(|_| Error::IntegerOverflow)?,
+        );
+
+        for val in value.into_iter() {
             ht.push(val)?;
         }
 
@@ -429,20 +471,26 @@ where
     }
 }
 
-impl<'a, V> TryFrom<&Vec<V>> for ZendHashTable<'a>
+impl<T> IntoZval for Vec<T>
 where
-    V: IntoZval + Clone,
+    T: IntoZval,
 {
-    type Error = Error;
+    const TYPE: DataType = DataType::Array;
 
-    fn try_from(vec: &Vec<V>) -> Result<Self> {
-        let mut ht =
-            ZendHashTable::with_capacity(vec.len().try_into().map_err(|_| Error::IntegerOverflow)?);
+    fn set_zval(self, zv: &mut Zval, _: bool) -> Result<()> {
+        let arr = self.try_into()?;
+        zv.set_hashtable(arr);
+        Ok(())
+    }
+}
 
-        for val in vec.iter() {
-            ht.push(val.clone())?;
-        }
+impl<T> FromZval<'_> for Vec<T>
+where
+    for<'a> T: FromZval<'a>,
+{
+    const TYPE: DataType = DataType::Array;
 
-        Ok(ht)
+    fn from_zval(zval: &Zval) -> Option<Self> {
+        zval.array().and_then(|arr| arr.try_into().ok())
     }
 }

--- a/src/php/types/binary.rs
+++ b/src/php/types/binary.rs
@@ -56,7 +56,7 @@ impl<T: Pack> TryFrom<Zval> for Binary<T> {
     type Error = Error;
 
     fn try_from(value: Zval) -> Result<Self> {
-        Self::from_zval(&value).ok_or(Error::ZvalConversion(value.get_type()?))
+        Self::from_zval(&value).ok_or(Error::ZvalConversion(value.get_type()))
     }
 }
 

--- a/src/php/types/binary.rs
+++ b/src/php/types/binary.rs
@@ -56,7 +56,7 @@ impl<T: Pack> TryFrom<Zval> for Binary<T> {
     type Error = Error;
 
     fn try_from(value: Zval) -> Result<Self> {
-        Self::from_zval(&value).ok_or(Error::ZvalConversion(value.get_type()))
+        Self::from_zval(&value).ok_or_else(|| Error::ZvalConversion(value.get_type()))
     }
 }
 

--- a/src/php/types/mod.rs
+++ b/src/php/types/mod.rs
@@ -9,6 +9,7 @@ pub mod callable;
 pub mod closure;
 pub mod long;
 pub mod object;
+pub mod rc;
 pub mod string;
 pub mod zval;
 

--- a/src/php/types/object.rs
+++ b/src/php/types/object.rs
@@ -156,11 +156,6 @@ impl ZendObject {
     fn mut_ptr(&self) -> *mut Self {
         (self as *const Self) as *mut Self
     }
-
-    /// Increments the objects reference counter by 1.
-    pub(crate) fn refcount_inc(&mut self) {
-        self.gc.refcount += 1;
-    }
 }
 
 impl Debug for ZendObject {

--- a/src/php/types/object.rs
+++ b/src/php/types/object.rs
@@ -18,13 +18,14 @@ use crate::{
         zend_objects_clone_members, ZEND_ISEMPTY, ZEND_PROPERTY_EXISTS, ZEND_PROPERTY_ISSET,
     },
     errors::{Error, Result},
-    php::{class::ClassEntry, enums::DataType, types::string::ZendString},
+    php::{
+        class::ClassEntry,
+        enums::DataType,
+        types::{array::HashTable, string::ZendString},
+    },
 };
 
-use super::{
-    array::ZendHashTable,
-    zval::{FromZval, IntoZval, Zval},
-};
+use super::zval::{FromZval, IntoZval, Zval};
 
 pub type ZendObject = zend_object;
 pub type ZendObjectHandlers = zend_object_handlers;
@@ -134,12 +135,12 @@ impl ZendObject {
     }
 
     /// Attempts to retrieve the properties of the object. Returned inside a Zend Hashtable.
-    pub fn get_properties(&self) -> Result<ZendHashTable> {
+    pub fn get_properties(&self) -> Result<&HashTable> {
         unsafe {
-            ZendHashTable::from_ptr(
-                self.handlers()?.get_properties.ok_or(Error::InvalidScope)?(self.mut_ptr()),
-                false,
-            )
+            self.handlers()?
+                .get_properties
+                .and_then(|props| props(self.mut_ptr()).as_ref())
+                .ok_or(Error::InvalidScope)
         }
     }
 
@@ -167,7 +168,7 @@ impl Debug for ZendObject {
         );
 
         if let Ok(props) = self.get_properties() {
-            for (id, key, val) in props.into_iter() {
+            for (id, key, val) in props.iter() {
                 dbg.field(key.unwrap_or_else(|| id.to_string()).as_str(), val);
             }
         }
@@ -176,6 +177,7 @@ impl Debug for ZendObject {
     }
 }
 
+/// Wrapper struct used to return a reference to a PHP object.
 pub struct ClassRef<'a, T: RegisteredClass> {
     ptr: &'a mut ZendClassObject<T>,
 }

--- a/src/php/types/rc.rs
+++ b/src/php/types/rc.rs
@@ -1,0 +1,50 @@
+//! Utilities for interacting with refcounted PHP types.
+
+use crate::bindings::{zend_refcounted_h, zend_string};
+
+use super::object::ZendObject;
+
+/// Object used to store Zend reference counter.
+pub type ZendRefcount = zend_refcounted_h;
+
+/// Implemented on refcounted types.
+pub trait PhpRc {
+    /// Returns an immutable reference to the corresponding refcount object.
+    fn get_rc(&self) -> &ZendRefcount;
+
+    /// Returns a mutable reference to the corresponding refcount object.
+    fn get_rc_mut(&mut self) -> &mut ZendRefcount;
+
+    /// Returns the number of references to the object.
+    fn get_count(&self) -> u32 {
+        self.get_rc().refcount
+    }
+
+    /// Increments the reference counter by 1.
+    fn inc_count(&mut self) {
+        self.get_rc_mut().refcount += 1
+    }
+
+    /// Decrements the reference counter by 1.
+    fn dec_count(&mut self) {
+        self.get_rc_mut().refcount -= 1;
+    }
+}
+
+macro_rules! rc {
+    ($($t: ty),*) => {
+        $(
+            impl PhpRc for $t {
+                fn get_rc(&self) -> &ZendRefcount {
+                    &self.gc
+                }
+
+                fn get_rc_mut(&mut self) -> &mut ZendRefcount {
+                    &mut self.gc
+                }
+            }
+        )*
+    };
+}
+
+rc!(ZendObject, zend_string);

--- a/src/php/types/zval.rs
+++ b/src/php/types/zval.rs
@@ -498,6 +498,15 @@ pub trait IntoZval: Sized {
     fn set_zval(self, zv: &mut Zval, persistent: bool) -> Result<()>;
 }
 
+impl IntoZval for Zval {
+    const TYPE: DataType = DataType::Mixed;
+
+    fn set_zval(self, zv: &mut Zval, _: bool) -> Result<()> {
+        *zv = self;
+        Ok(())
+    }
+}
+
 /// An object-safe version of the [`IntoZval`] trait.
 ///
 /// This trait is automatically implemented on any type that implements both [`IntoZval`] and [`Clone`].


### PR DESCRIPTION
- `ZendHashTable` has been split into `&HashTable` and `OwnedHashTable`. `&HashTable` is to `OwnedHashTable` as `&str` is to `String`.
- The `Drop` implementation on `Zval` will properly drop the contents of the zval.