### PR TITLE
Remove lifetime from `PhpException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+- `PhpException` no longer requires a lifetime [#80].
+- Added `PhpException` and `PhpResult` to prelude [#80].
+
+[#80]: https://github.com/davidcole1340/ext-php-rs/pull/80
+
 ## Version 0.5.0
 
 ### Breaking changes

--- a/guide/src/macros/structs.md
+++ b/guide/src/macros/structs.md
@@ -75,7 +75,7 @@ pub struct RedisException;
 
 // Throw our newly created exception
 #[php_function]
-pub fn throw_exception() -> Result<i32, PhpException<'static>> {
+pub fn throw_exception() -> PhpResult<i32> {
     Err(PhpException::from_class::<RedisException>("Not good!".into()))
 }
 # #[php_module]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -95,7 +95,7 @@ impl From<NulError> for Error {
     }
 }
 
-impl<'a> From<Error> for PhpException<'a> {
+impl From<Error> for PhpException {
     fn from(err: Error) -> Self {
         Self::default(err.to_string())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,7 +398,7 @@ pub use ext_php_rs_derive::php_module;
 /// pub struct Example;
 ///
 /// #[php_function]
-/// pub fn throw_exception() -> Result<i32, PhpException<'static>> {
+/// pub fn throw_exception() -> Result<i32, PhpException> {
 ///     Err(PhpException::from_class::<Example>("Bad things happen".into()))
 /// }
 ///
@@ -439,6 +439,7 @@ pub use ext_php_rs_derive::php_startup;
 
 /// A module typically glob-imported containing the typically required macros and imports.
 pub mod prelude {
+    pub use crate::php::exceptions::{PhpException, PhpResult};
     pub use crate::php::module::ModuleBuilder;
     pub use crate::php::types::callable::Callable;
     #[cfg(any(docs, feature = "closure"))]

--- a/src/php/exceptions.rs
+++ b/src/php/exceptions.rs
@@ -69,13 +69,13 @@ impl PhpException {
     }
 }
 
-impl<'a> From<String> for PhpException {
+impl From<String> for PhpException {
     fn from(str: String) -> Self {
         Self::default(str)
     }
 }
 
-impl<'a> From<&str> for PhpException {
+impl From<&str> for PhpException {
     fn from(str: &str) -> Self {
         Self::default(str.into())
     }

--- a/src/php/exceptions.rs
+++ b/src/php/exceptions.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// Result type with the error variant as a [`PhpException`].
-pub type PhpResult<T = ()> = std::result::Result<T, PhpException<'static>>;
+pub type PhpResult<T = ()> = std::result::Result<T, PhpException>;
 
 /// Represents a PHP exception which can be thrown using the `throw()` function. Primarily used to
 /// return from a [`Result<T, PhpException>`] which can immediately be thrown by the `ext-php-rs`
@@ -25,13 +25,13 @@ pub type PhpResult<T = ()> = std::result::Result<T, PhpException<'static>>;
 /// can also be returned from these functions. You can also implement [`From<T>`] for your custom
 /// error type.
 #[derive(Debug)]
-pub struct PhpException<'a> {
+pub struct PhpException {
     message: String,
     code: i32,
-    ex: &'a ClassEntry,
+    ex: &'static ClassEntry,
 }
 
-impl<'a> PhpException<'a> {
+impl PhpException {
     /// Creates a new exception instance.
     ///
     /// # Parameters
@@ -39,7 +39,7 @@ impl<'a> PhpException<'a> {
     /// * `message` - Message to contain in the exception.
     /// * `code` - Integer code to go inside the exception.
     /// * `ex` - Exception type to throw.
-    pub fn new(message: String, code: i32, ex: &'a ClassEntry) -> Self {
+    pub fn new(message: String, code: i32, ex: &'static ClassEntry) -> Self {
         Self { message, code, ex }
     }
 
@@ -69,13 +69,13 @@ impl<'a> PhpException<'a> {
     }
 }
 
-impl<'a> From<String> for PhpException<'a> {
+impl<'a> From<String> for PhpException {
     fn from(str: String) -> Self {
         Self::default(str)
     }
 }
 
-impl<'a> From<&str> for PhpException<'a> {
+impl<'a> From<&str> for PhpException {
     fn from(str: &str) -> Self {
         Self::default(str.into())
     }

--- a/src/php/types/object.rs
+++ b/src/php/types/object.rs
@@ -26,7 +26,7 @@ use crate::{
     php::{
         class::ClassEntry,
         enums::DataType,
-        exceptions::PhpException,
+        exceptions::PhpResult,
         flags::ZvalTypeFlags,
         types::{array::OwnedHashTable, string::ZendString},
     },
@@ -649,7 +649,7 @@ impl ZendObjectHandlers {
             type_: c_int,
             cache_slot: *mut *mut c_void,
             rv: *mut Zval,
-        ) -> std::result::Result<*mut Zval, PhpException<'static>> {
+        ) -> PhpResult<*mut Zval> {
             let obj = object
                 .as_ref()
                 .and_then(|obj| ZendClassObject::<T>::from_zend_obj_ptr(obj))
@@ -696,7 +696,7 @@ impl ZendObjectHandlers {
             member: *mut zend_string,
             value: *mut Zval,
             cache_slot: *mut *mut c_void,
-        ) -> std::result::Result<*mut Zval, PhpException<'static>> {
+        ) -> PhpResult<*mut Zval> {
             let obj = object
                 .as_ref()
                 .and_then(|obj| ZendClassObject::<T>::from_zend_obj_ptr(obj))
@@ -734,7 +734,7 @@ impl ZendObjectHandlers {
         unsafe fn internal<T: RegisteredClass>(
             object: *mut zend_object,
             props: &mut HashTable,
-        ) -> std::result::Result<(), PhpException<'static>> {
+        ) -> PhpResult {
             let obj = object
                 .as_ref()
                 .and_then(|obj| ZendClassObject::<T>::from_zend_obj_ptr(obj))
@@ -779,7 +779,7 @@ impl ZendObjectHandlers {
             member: *mut zend_string,
             has_set_exists: c_int,
             cache_slot: *mut *mut c_void,
-        ) -> std::result::Result<c_int, PhpException<'static>> {
+        ) -> PhpResult<c_int> {
             let obj = object
                 .as_ref()
                 .and_then(|obj| ZendClassObject::<T>::from_zend_obj_ptr(obj))


### PR DESCRIPTION
All class entries are effectively static (module start to module end) so
it's just a hassle carrying the lifetime everywhere.

Closes #68 