### PR TITLE
Add class constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+- Constructors that return `Self` can now be added to classes. [#83]
+  - `Default` is no longer required to be implemented on classes, however, a
+    constructor must be specified if you want to construct the class from PHP.
+  - Constructors can return `Self` or `Result<Self, E>`, where
+    `E: Into<PhpException>`.
+
+[#83]: https://github.com/davidcole1340/ext-php-rs/pull/83
+
 ## Version 0.5.1
 
 - `PhpException` no longer requires a lifetime [#80].

--- a/ext-php-rs-derive/src/class.rs
+++ b/ext-php-rs-derive/src/class.rs
@@ -14,6 +14,7 @@ pub struct Class {
     pub parent: Option<String>,
     pub interfaces: Vec<String>,
     pub methods: Vec<crate::method::Method>,
+    pub constructor: Option<crate::method::Method>,
     pub constants: Vec<crate::constant::Constant>,
     pub properties: HashMap<String, Property>,
 }

--- a/guide/src/macros/classes.md
+++ b/guide/src/macros/classes.md
@@ -4,15 +4,6 @@ Structs can be exported to PHP as classes with the `#[php_class]` attribute
 macro. This attribute derives the `RegisteredClass` trait on your struct, as
 well as registering the class to be registered with the `#[php_module]` macro.
 
-The implementation of `RegisteredClass` requires the implementation of `Default`
-on the struct. This is because the struct is initialized before the constructor
-is called, therefore it must have default values for all properties.
-
-Note that Rust struct properties **are not** PHP properties, so if you want the
-user to be able to access these, you must provide getters and/or setters.
-Properties are supported internally, however, they are not usable through the
-automatic macros. Support for properties is planned.
-
 ## Options
 
 The attribute takes some options to modify the output of the class:
@@ -33,21 +24,22 @@ placed underneath the `#[php_class]` attribute.
 
 You may also use the `#[prop]` attribute on a struct field to use the field as a
 PHP property. By default, the field will be accessible from PHP publically with
-the same name as the field. You can rename the property with options:
+the same name as the field. Property types must implement `IntoZval` and
+`FromZval`.
+
+You can rename the property with options:
 
 - `rename` - Allows you to rename the property, e.g.
   `#[prop(rename = "new_name")]`
 
 ## Example
 
-This example creates a PHP class `Human`, adding a PHP property `address` with
-an empty string as the default value.
+This example creates a PHP class `Human`, adding a PHP property `address`.
 
 ```rust
 # extern crate ext_php_rs;
 # use ext_php_rs::prelude::*;
 #[php_class]
-#[derive(Default)]
 pub struct Human {
     name: String,
     age: i32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,12 +256,21 @@ pub use ext_php_rs_derive::php_function;
 /// Methods can take a immutable or a mutable reference to `self`, but cannot consume `self`. They
 /// can also take no reference to `self` which indicates a static method.
 ///
+/// ## Constructors
+///
+/// You may add *one* constructor to the impl block. This method must be called `__construct` or be
+/// tagged with the `#[constructor]` attribute, and it will not be exported to PHP like a regular
+/// method.
+///
+/// The constructor method must not take a reference to `self` and must return `Self` or
+/// [`Result<Self, E>`][`Result`], where `E: Into<PhpException>`.
+///
 /// # Example
 ///
 /// ```no_run
 /// # use ext_php_rs::prelude::*;
 /// #[php_class]
-/// #[derive(Debug, Default)]
+/// #[derive(Debug)]
 /// pub struct Human {
 ///     name: String,
 ///     age: i32,
@@ -274,9 +283,8 @@ pub use ext_php_rs_derive::php_function;
 ///
 ///     #[optional(age)]
 ///     #[defaults(age = 0)]
-///     pub fn __construct(&mut self, name: String, age: i32) {
-///         self.name = name;
-///         self.age = age;
+///     pub fn __construct(name: String, age: i32) -> Self {
+///         Self { name, age }
 ///     }
 ///
 ///     pub fn get_name(&self) -> String {
@@ -340,9 +348,8 @@ pub use ext_php_rs_derive::php_module;
 
 /// Annotates a struct that will be exported to PHP as a class.
 ///
-/// The struct that this attribute is used on must implement [`Default`], as this is used to
-/// initialize the struct before the constructor is called. You may define a constructor with
-/// the [`macro@php_impl`] macro which can modify the properties of the struct.
+/// By default, the class cannot be constructed from PHP. You must add a constructor method in the
+/// [`macro@php_impl`] impl block to be able to construct the object from PHP.
 ///
 /// This attribute takes a set of optional arguments:
 ///
@@ -372,7 +379,6 @@ pub use ext_php_rs_derive::php_module;
 /// ```
 /// # use ext_php_rs::prelude::*;
 /// #[php_class]
-/// #[derive(Default)]
 /// pub struct Example {
 ///     x: i32,
 ///     y: String,
@@ -394,7 +400,6 @@ pub use ext_php_rs_derive::php_module;
 ///
 /// #[php_class(name = "Redis\\Exception\\RedisException")]
 /// #[extends(ClassEntry::exception())]
-/// #[derive(Default)]
 /// pub struct Example;
 ///
 /// #[php_function]

--- a/src/php/types/zval.rs
+++ b/src/php/types/zval.rs
@@ -172,7 +172,7 @@ impl Zval {
         }
     }
 
-    /// Returns the value of the zval if it is an object.
+    /// Returns a mutable reference to the object contained in the [`Zval`], if any.
     pub fn object_mut(&mut self) -> Option<&mut ZendObject> {
         if self.is_object() {
             unsafe { self.value.obj.as_mut() }


### PR DESCRIPTION
Constructor methods can now be specified. They are required if
you want to construct the class from PHP. This replaces the `Default`
implementation requirement on class objects.

Constructors can return `Self` or `Result<Self, E>` where `E: Into<PhpException>`.