### PR TITLE
Add zval type coersion

### DIFF
--- a/src/php/types/zval.rs
+++ b/src/php/types/zval.rs
@@ -844,8 +844,8 @@ impl FromZval<'_> for bool {
         zval.bool()
             .or_else(|| zval.long().map(|l| l != 0))
             .or_else(|| zval.double().map(|d| d != 0.0))
-            .or_else(|| zval.str().map(|s| !(s.len() == 0 || s == "0") || s == "1"))
-            .or_else(|| zval.array().map(|arr| arr.len() != 0))
+            .or_else(|| zval.str().map(|s| !(s.is_empty() || s == "0") || s == "1"))
+            .or_else(|| zval.array().map(|arr| !arr.is_empty()))
             .or_else(|| if zval.is_null() { Some(false) } else { None })
     }
 }

--- a/src/php/types/zval.rs
+++ b/src/php/types/zval.rs
@@ -842,8 +842,8 @@ impl FromZval<'_> for bool {
     fn from_zval_coerce(zval: &Zval) -> Option<Self> {
         // https://www.php.net/manual/en/language.types.boolean.php#language.types.boolean.casting
         zval.bool()
-            .or_else(|| zval.long().map(|l| l != 0))
-            .or_else(|| zval.double().map(|d| d != 0.0))
+            .or_else(|| zval.long().map(|l| l > 0))
+            .or_else(|| zval.double().map(|d| d > 0.0))
             .or_else(|| zval.str().map(|s| !(s.is_empty() || s == "0") || s == "1"))
             .or_else(|| zval.array().map(|arr| !arr.is_empty()))
             .or_else(|| if zval.is_null() { Some(false) } else { None })


### PR DESCRIPTION
`Zval::string()` will no longer attempt to convert a long into a string. Instead, this is done through the new function on the `FromZval` trait: `from_zval_coerce`, which broadly follows PHP's [type juggling rules].

By default, downstream types do not have to implement this function, as its default is to call `from_zval` on the same type.

[type juggling rules]: https://www.php.net/manual/en/language.types.type-juggling.php