### PR TITLE
Add `ZBox<T>` to replace owned variants

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           LIBCLANG_PATH: ${{ runner.temp }}/llvm-${{ matrix.llvm }}/lib
           EXT_PHP_RS_TEST:
-        run: cargo build --release --features alloc,closure
+        run: cargo build --release --all-features
       - name: Test guide examples
         env:
           CARGO_PKG_NAME: mdbook-tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ regex = "1"
 cc = "1.0"
 
 [features]
-alloc = []
 closure = []
 
 [workspace]

--- a/build.rs
+++ b/build.rs
@@ -86,6 +86,7 @@ fn main() {
         .rustfmt_bindings(true)
         .no_copy("_zend_value")
         .no_copy("_zend_string")
+        .no_copy("_zend_array")
         .layout_tests(env::var("EXT_PHP_RS_TEST").is_ok());
 
     for binding in ALLOWED_BINDINGS.iter() {

--- a/example/skel/Cargo.toml
+++ b/example/skel/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ext-php-rs = { path = "../../", features = ["alloc", "closure"] }
+ext-php-rs = { path = "../../", features = ["closure"] }
 
 [lib]
 name = "skel"

--- a/ext-php-rs-derive/src/zval.rs
+++ b/ext-php-rs-derive/src/zval.rs
@@ -128,11 +128,13 @@ fn parse_struct(
     Ok(quote! {
         impl #into_impl_generics ::ext_php_rs::php::types::object::IntoZendObject for #ident #ty_generics #into_where_clause {
             fn into_zend_object(self) -> ::ext_php_rs::errors::Result<
-                ::ext_php_rs::php::types::object::OwnedZendObject
+                ::ext_php_rs::php::boxed::ZBox<
+                    ::ext_php_rs::php::types::object::ZendObject
+                >
             > {
                 use ::ext_php_rs::php::types::zval::IntoZval;
 
-                let mut obj = ::ext_php_rs::php::types::object::OwnedZendObject::new_stdclass();
+                let mut obj = ::ext_php_rs::php::types::object::ZendObject::new_stdclass();
                 #(#into_fields)*
                 ::ext_php_rs::errors::Result::Ok(obj)
             }

--- a/src/php/boxed.rs
+++ b/src/php/boxed.rs
@@ -18,6 +18,7 @@
 //! [`emalloc`]: super::alloc::efree
 
 use std::{
+    borrow::Borrow,
     fmt::Debug,
     mem::ManuallyDrop,
     ops::{Deref, DerefMut},
@@ -59,6 +60,7 @@ impl<T: ZBoxable> ZBox<T> {
 }
 
 impl<T: ZBoxable> Drop for ZBox<T> {
+    #[inline]
     fn drop(&mut self) {
         self.deref_mut().free()
     }
@@ -67,6 +69,7 @@ impl<T: ZBoxable> Drop for ZBox<T> {
 impl<T: ZBoxable> Deref for ZBox<T> {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         // SAFETY: All constructors ensure the contained pointer is well-aligned and dereferencable.
         unsafe { self.0.as_ref() }
@@ -74,6 +77,7 @@ impl<T: ZBoxable> Deref for ZBox<T> {
 }
 
 impl<T: ZBoxable> DerefMut for ZBox<T> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         // SAFETY: All constructors ensure the contained pointer is well-aligned and dereferencable.
         unsafe { self.0.as_mut() }
@@ -81,8 +85,23 @@ impl<T: ZBoxable> DerefMut for ZBox<T> {
 }
 
 impl<T: ZBoxable + Debug> Debug for ZBox<T> {
+    #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.deref().fmt(f)
+    }
+}
+
+impl<T: ZBoxable> Borrow<T> for ZBox<T> {
+    #[inline]
+    fn borrow(&self) -> &T {
+        self.deref()
+    }
+}
+
+impl<T: ZBoxable> AsRef<T> for ZBox<T> {
+    #[inline]
+    fn as_ref(&self) -> &T {
+        self
     }
 }
 

--- a/src/php/boxed.rs
+++ b/src/php/boxed.rs
@@ -88,14 +88,14 @@ impl<T: ZBoxable> DerefMut for ZBox<T> {
 impl<T: ZBoxable + Debug> Debug for ZBox<T> {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.deref().fmt(f)
+        (&**self).fmt(f)
     }
 }
 
 impl<T: ZBoxable> Borrow<T> for ZBox<T> {
     #[inline]
     fn borrow(&self) -> &T {
-        self.deref()
+        &**self
     }
 }
 

--- a/src/php/boxed.rs
+++ b/src/php/boxed.rs
@@ -53,9 +53,10 @@ impl<T: ZBoxable> ZBox<T> {
     ///
     /// The caller is responsible for managing the memory pointed to by the returned pointer, including
     /// freeing the memory.
-    pub fn into_raw(self) -> *mut T {
-        let this = ManuallyDrop::new(self);
-        this.0.as_ptr()
+    pub fn into_raw(self) -> &'static mut T {
+        let mut this = ManuallyDrop::new(self);
+        // SAFETY: All constructors ensure the contained pointer is well-aligned and dereferencable.
+        unsafe { this.0.as_mut() }
     }
 }
 

--- a/src/php/boxed.rs
+++ b/src/php/boxed.rs
@@ -1,0 +1,106 @@
+//! A pointer type for heap allocation using the Zend memory manager.
+//!
+//! Heap memory in PHP is usually request-bound and allocated inside [memory arenas], which are cleared
+//! at the start and end of a PHP request. Allocating and freeing memory that is allocated on the Zend
+//! heap is done through two separate functions [`efree`] and [`emalloc`].
+//!
+//! As such, most heap-allocated PHP types **cannot** be allocated on the stack, such as [`ZendStr`], which
+//! is a dynamically-sized type, and therefore must be allocated on the heap. A regular [`Box`] would not
+//! work in this case, as the memory needs to be freed from a separate function `zend_string_release`. The
+//! [`ZBox`] type provides a wrapper which calls the relevant release functions based on the type and what is
+//! inside the implementation of [`ZBoxable`].
+//!
+//! This type is not created directly, but rather through a function implemented on the downstream type. For
+//! example, [`ZendStr`] has a function `new` which returns a [`ZBox<ZendStr>`].
+//!
+//! [memory arenas]: https://en.wikipedia.org/wiki/Region-based_memory_management
+//! [`ZendStr`]: super::types::string::ZendStr
+//! [`emalloc`]: super::alloc::efree
+
+use std::{
+    fmt::Debug,
+    mem::ManuallyDrop,
+    ops::{Deref, DerefMut},
+    ptr::NonNull,
+};
+
+use super::alloc::efree;
+
+/// A pointer type for heap allocation using the Zend memory manager.
+///
+/// See the [module level documentation](../index.html) for more.
+pub struct ZBox<T: ZBoxable>(NonNull<T>);
+
+impl<T: ZBoxable> ZBox<T> {
+    /// Creates a new box from a given pointer.
+    ///
+    /// # Parameters
+    ///
+    /// * `ptr` - A non-null, well-aligned pointer to a `T`.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that `ptr` is non-null, well-aligned and pointing to a `T`.
+    pub unsafe fn from_raw(ptr: *mut T) -> Self {
+        Self(NonNull::new_unchecked(ptr))
+    }
+
+    /// Returns the pointer contained by the box, dropping the box in the process. The data pointed to by
+    /// the returned pointer is not released.
+    ///
+    /// # Safety
+    ///
+    /// The caller is responsible for managing the memory pointed to by the returned pointer, including
+    /// freeing the memory.
+    pub fn into_raw(self) -> *mut T {
+        let this = ManuallyDrop::new(self);
+        this.0.as_ptr()
+    }
+}
+
+impl<T: ZBoxable> Drop for ZBox<T> {
+    fn drop(&mut self) {
+        self.deref_mut().free()
+    }
+}
+
+impl<T: ZBoxable> Deref for ZBox<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: All constructors ensure the contained pointer is well-aligned and dereferencable.
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl<T: ZBoxable> DerefMut for ZBox<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: All constructors ensure the contained pointer is well-aligned and dereferencable.
+        unsafe { self.0.as_mut() }
+    }
+}
+
+impl<T: ZBoxable + Debug> Debug for ZBox<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.deref().fmt(f)
+    }
+}
+
+/// Implemented on types that can be heap allocated using the Zend memory manager. These types are stored
+/// inside a [`ZBox`] when heap-allocated, and the [`free`] method is called when the box is dropped.
+///
+/// # Safety
+///
+/// The default implementation of the [`free`] function uses the [`efree`] function to free the memory without
+/// calling any destructors.
+///
+/// The implementor must ensure that any time a pointer to the implementor is passed into a [`ZBox`] that the
+/// memory pointed to was allocated by the Zend memory manager.
+///
+/// [`free`]: #method.free
+pub unsafe trait ZBoxable {
+    /// Frees the memory pointed to by `self`, calling any destructors required in the process.
+    fn free(&mut self) {
+        unsafe { efree(self as *mut _ as *mut u8) };
+    }
+}

--- a/src/php/class.rs
+++ b/src/php/class.rs
@@ -9,7 +9,7 @@ use crate::{
         types::object::{ClassObject, ConstructorMeta, ConstructorResult, ZendObject},
     },
 };
-use std::{alloc::Layout, convert::TryInto, ffi::CString, fmt::Debug};
+use std::{alloc::Layout, convert::TryInto, ffi::CString, fmt::Debug, ops::DerefMut};
 
 use crate::bindings::{
     zend_class_entry, zend_declare_class_constant, zend_declare_property,
@@ -22,7 +22,7 @@ use super::{
     globals::ExecutorGlobals,
     types::{
         object::RegisteredClass,
-        string::ZendString,
+        string::ZendStr,
         zval::{IntoZval, Zval},
     },
 };
@@ -43,10 +43,10 @@ impl ClassEntry {
     /// not be found or the class table has not been initialized.
     pub fn try_find(name: &str) -> Option<&'static Self> {
         ExecutorGlobals::get().class_table()?;
-        let mut name = ZendString::new(name, false).ok()?;
+        let mut name = ZendStr::new(name, false).ok()?;
 
         unsafe {
-            crate::bindings::zend_lookup_class_ex(name.as_mut_zend_str(), std::ptr::null_mut(), 0)
+            crate::bindings::zend_lookup_class_ex(name.deref_mut(), std::ptr::null_mut(), 0)
                 .as_ref()
         }
     }
@@ -337,7 +337,7 @@ impl ClassBuilder {
     ///
     /// Returns an [`Error`] variant if the class could not be registered.
     pub fn build(mut self) -> Result<&'static mut ClassEntry> {
-        self.ptr.name = ZendString::new_interned(&self.name, true)?.into_inner();
+        self.ptr.name = ZendStr::new_interned(&self.name, true)?.into_raw();
 
         self.methods.push(FunctionEntry::end());
         let func = Box::into_raw(self.methods.into_boxed_slice()) as *const FunctionEntry;

--- a/src/php/class.rs
+++ b/src/php/class.rs
@@ -6,7 +6,7 @@ use crate::{
         exceptions::PhpException,
         execution_data::ExecutionData,
         function::FunctionBuilder,
-        types::object::{ClassObject, ConstructorMeta, ConstructorResult, ZendObject},
+        types::object::{ConstructorMeta, ConstructorResult, ZendClassObject, ZendObject},
     },
 };
 use std::{alloc::Layout, convert::TryInto, ffi::CString, fmt::Debug, ops::DerefMut};
@@ -277,8 +277,8 @@ impl ClassBuilder {
         extern "C" fn create_object<T: RegisteredClass>(_: *mut ClassEntry) -> *mut ZendObject {
             // SAFETY: After calling this function, PHP will always call the constructor defined below,
             // which assumes that the object is uninitialized.
-            let obj = unsafe { ClassObject::<T>::new_uninit() };
-            obj.into_inner().get_mut_zend_obj()
+            let obj = unsafe { ZendClassObject::<T>::new_uninit() };
+            obj.into_raw().get_mut_zend_obj()
         }
 
         extern "C" fn constructor<T: RegisteredClass>(ex: &mut ExecutionData, _: &mut Zval) {

--- a/src/php/execution_data.rs
+++ b/src/php/execution_data.rs
@@ -3,22 +3,15 @@
 
 use crate::bindings::{zend_execute_data, ZEND_MM_ALIGNMENT, ZEND_MM_ALIGNMENT_MASK};
 
-use super::{
-    args::ArgParser,
-    types::{
-        object::{RegisteredClass, ZendClassObject, ZendObject},
-        zval::Zval,
-    },
+use super::types::{
+    object::{RegisteredClass, ZendClassObject, ZendObject},
+    zval::Zval,
 };
 
 /// Execution data passed when a function is called from Zend.
 pub type ExecutionData = zend_execute_data;
 
 impl ExecutionData {
-    pub fn parser<T: RegisteredClass>(&mut self) -> (Option<&mut ZendClassObject<T>>, ArgParser) {
-        (self.get_object(), ArgParser::new(self))
-    }
-
     /// Attempts to retrieve a reference to the underlying class object of the Zend object.
     ///
     /// Returns a [`ZendClassObject`] if the execution data contained a valid object of type `T`,

--- a/src/php/execution_data.rs
+++ b/src/php/execution_data.rs
@@ -3,15 +3,22 @@
 
 use crate::bindings::{zend_execute_data, ZEND_MM_ALIGNMENT, ZEND_MM_ALIGNMENT_MASK};
 
-use super::types::{
-    object::{RegisteredClass, ZendClassObject, ZendObject},
-    zval::Zval,
+use super::{
+    args::ArgParser,
+    types::{
+        object::{RegisteredClass, ZendClassObject, ZendObject},
+        zval::Zval,
+    },
 };
 
 /// Execution data passed when a function is called from Zend.
 pub type ExecutionData = zend_execute_data;
 
 impl ExecutionData {
+    pub fn parser<T: RegisteredClass>(&mut self) -> (Option<&mut ZendClassObject<T>>, ArgParser) {
+        (self.get_object(), ArgParser::new(self))
+    }
+
     /// Attempts to retrieve a reference to the underlying class object of the Zend object.
     ///
     /// Returns a [`ZendClassObject`] if the execution data contained a valid object of type `T`,

--- a/src/php/mod.rs
+++ b/src/php/mod.rs
@@ -1,10 +1,8 @@
 //! Objects relating to PHP and the Zend engine.
 
-#[cfg(any(docs, feature = "alloc"))]
-#[cfg_attr(docs, doc(cfg(feature = "alloc")))]
 pub mod alloc;
-
 pub mod args;
+pub mod boxed;
 pub mod class;
 pub mod constants;
 pub mod enums;

--- a/src/php/pack.rs
+++ b/src/php/pack.rs
@@ -18,18 +18,13 @@ use crate::bindings::{ext_php_rs_zend_string_init, zend_string};
 /// [`unpack`]: https://www.php.net/manual/en/function.unpack.php
 pub unsafe trait Pack: Clone {
     /// Packs a given vector into a Zend binary string. Can be passed to PHP and then unpacked
-    /// using the [`unpack`] function. Note you should probably use the [`set_binary`] method on the
-    /// [`Zval`] struct instead of this function directly, as there is currently no way to set a
-    /// [`ZendString`] on a [`Zval`] directly.
+    /// using the [`unpack`] function.
     ///
     /// # Parameters
     ///
     /// * `vec` - The vector to pack into a binary string.
     ///
     /// [`unpack`]: https://www.php.net/manual/en/function.unpack.php
-    /// [`Zval`]: crate::php::types::zval::Zval
-    /// [`ZendString`]: crate::php::types::string::ZendString
-    /// [`set_binary`]: crate::php::types::zval::Zval#method.set_binary
     fn pack_into(vec: Vec<Self>) -> *mut zend_string;
 
     /// Unpacks a given Zend binary string into a Rust vector. Can be used to pass data from `pack`

--- a/src/php/types/object.rs
+++ b/src/php/types/object.rs
@@ -26,6 +26,7 @@ use crate::{
     },
     errors::{Error, Result},
     php::{
+        boxed::{ZBox, ZBoxable},
         class::ClassEntry,
         enums::DataType,
         exceptions::{PhpException, PhpResult},
@@ -44,99 +45,6 @@ use super::{
     zval::{FromZval, IntoZval, Zval},
 };
 
-/// A wrapper around [`ZendObject`] providing the correct [`Drop`] implementation required to not
-/// leak memory. Dereferences to [`ZendObject`].
-///
-/// This type differs from [`ClassObject`] in the fact that this type is not aware of any Rust type attached
-/// to the head of the [`ZendObject`]. It is possible to convert from a [`ClassObject`] to this type.
-pub struct OwnedZendObject(NonNull<ZendObject>);
-
-impl OwnedZendObject {
-    /// Creates a new [`ZendObject`], returned inside an [`OwnedZendObject`] wrapper.
-    ///
-    /// # Parameters
-    ///
-    /// * `ce` - The type of class the new object should be an instance of.
-    ///
-    /// # Panics
-    ///
-    /// Panics when allocating memory for the new object fails.
-    pub fn new(ce: &ClassEntry) -> Self {
-        // SAFETY: Using emalloc to allocate memory inside Zend arena. Casting `ce` to `*mut` is valid
-        // as the function will not mutate `ce`.
-        let ptr = unsafe { zend_objects_new(ce as *const _ as *mut _) };
-        Self(NonNull::new(ptr).expect("Failed to allocate Zend object"))
-    }
-
-    /// Creates a new `stdClass` instance, returned inside an [`OwnedZendObject`] wrapper.
-    ///
-    /// # Panics
-    ///
-    /// Panics if allocating memory for the object fails, or if the `stdClass` class entry has not been
-    /// registered with PHP yet.
-    pub fn new_stdclass() -> Self {
-        // SAFETY: This will be `NULL` until it is initialized. `as_ref()` checks for null,
-        // so we can panic if it's null.
-        Self::new(unsafe {
-            zend_standard_class_def
-                .as_ref()
-                .expect("`stdClass` class instance not initialized yet")
-        })
-    }
-
-    /// Consumes the [`OwnedZendObject`] wrapper, returning a mutable, static reference to the
-    /// underlying [`ZendObject`].
-    ///
-    /// It is the callers responsibility to free the underlying memory that the returned reference
-    /// points to.
-    pub fn into_inner(self) -> &'static mut ZendObject {
-        let mut this = ManuallyDrop::new(self);
-        unsafe { this.0.as_mut() }
-    }
-}
-
-impl Deref for OwnedZendObject {
-    type Target = ZendObject;
-
-    fn deref(&self) -> &Self::Target {
-        unsafe { self.0.as_ref() }
-    }
-}
-
-impl DerefMut for OwnedZendObject {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { self.0.as_mut() }
-    }
-}
-
-impl Drop for OwnedZendObject {
-    fn drop(&mut self) {
-        unsafe { ext_php_rs_zend_object_release(self.0.as_ptr()) }
-    }
-}
-
-impl Debug for OwnedZendObject {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        unsafe { self.0.as_ref() }.fmt(f)
-    }
-}
-
-impl IntoZval for OwnedZendObject {
-    const TYPE: DataType = DataType::Object(None);
-
-    fn set_zval(self, zv: &mut Zval, _: bool) -> Result<()> {
-        let obj = self.into_inner();
-
-        // We must decrement the refcounter on the object before inserting into the zval,
-        // as the reference counter will be incremented on add.
-
-        // NOTE(david): again is this needed, we increment in `set_object`.
-        obj.dec_count();
-        zv.set_object(obj);
-        Ok(())
-    }
-}
-
 pub type ZendObject = zend_object;
 pub type ZendObjectHandlers = zend_object_handlers;
 
@@ -153,6 +61,43 @@ pub enum PropertyQuery {
 }
 
 impl ZendObject {
+    /// Creates a new [`ZendObject`], returned inside an [`OwnedZendObject`] wrapper.
+    ///
+    /// # Parameters
+    ///
+    /// * `ce` - The type of class the new object should be an instance of.
+    ///
+    /// # Panics
+    ///
+    /// Panics when allocating memory for the new object fails.
+    pub fn new(ce: &ClassEntry) -> ZBox<Self> {
+        // SAFETY: Using emalloc to allocate memory inside Zend arena. Casting `ce` to `*mut` is valid
+        // as the function will not mutate `ce`.
+        unsafe {
+            let ptr = zend_objects_new(ce as *const _ as *mut _);
+            ZBox::from_raw(
+                ptr.as_mut()
+                    .expect("Failed to allocate memory for Zend object"),
+            )
+        }
+    }
+
+    /// Creates a new `stdClass` instance, returned inside an [`OwnedZendObject`] wrapper.
+    ///
+    /// # Panics
+    ///
+    /// Panics if allocating memory for the object fails, or if the `stdClass` class entry has not been
+    /// registered with PHP yet.
+    pub fn new_stdclass() -> ZBox<Self> {
+        // SAFETY: This will be `NULL` until it is initialized. `as_ref()` checks for null,
+        // so we can panic if it's null.
+        Self::new(unsafe {
+            zend_standard_class_def
+                .as_ref()
+                .expect("`stdClass` class instance not initialized yet")
+        })
+    }
+
     /// Attempts to retrieve the class name of the object.
     pub fn get_class_name(&self) -> Result<String> {
         unsafe {
@@ -282,11 +227,48 @@ impl ZendObject {
     }
 }
 
+unsafe impl ZBoxable for ZendObject {
+    fn free(&mut self) {
+        unsafe { ext_php_rs_zend_object_release(self) }
+    }
+}
+
+impl Debug for ZendObject {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut dbg = f.debug_struct(
+            self.get_class_name()
+                .unwrap_or_else(|_| "ZendObject".to_string())
+                .as_str(),
+        );
+
+        if let Ok(props) = self.get_properties() {
+            for (id, key, val) in props.iter() {
+                dbg.field(key.unwrap_or_else(|| id.to_string()).as_str(), val);
+            }
+        }
+
+        dbg.finish()
+    }
+}
+
 impl<'a> FromZval<'a> for &'a ZendObject {
     const TYPE: DataType = DataType::Object(None);
 
     fn from_zval(zval: &'a Zval) -> Option<Self> {
         zval.object()
+    }
+}
+
+impl IntoZval for ZBox<ZendObject> {
+    const TYPE: DataType = DataType::Object(None);
+
+    fn set_zval(mut self, zv: &mut Zval, _: bool) -> Result<()> {
+        // We must decrement the refcounter on the object before inserting into the zval,
+        // as the reference counter will be incremented on add.
+        // NOTE(david): again is this needed, we increment in `set_object`.
+        self.dec_count();
+        zv.set_object(self.into_raw());
+        Ok(())
     }
 }
 
@@ -310,7 +292,7 @@ pub trait FromZendObject<'a>: Sized {
 /// to determine the type of object which is produced.
 pub trait IntoZendObject {
     /// Attempts to convert `self` into a Zend object.
-    fn into_zend_object(self) -> Result<OwnedZendObject>;
+    fn into_zend_object(self) -> Result<ZBox<ZendObject>>;
 }
 
 impl FromZendObject<'_> for String {
@@ -346,24 +328,6 @@ impl FromZendObject<'_> for String {
                 class_name.expect("unable to determine class name"),
             );
         }
-    }
-}
-
-impl Debug for ZendObject {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut dbg = f.debug_struct(
-            self.get_class_name()
-                .unwrap_or_else(|_| "ZendObject".to_string())
-                .as_str(),
-        );
-
-        if let Ok(props) = self.get_properties() {
-            for (id, key, val) in props.iter() {
-                dbg.field(key.unwrap_or_else(|| id.to_string()).as_str(), val);
-            }
-        }
-
-        dbg.finish()
     }
 }
 
@@ -507,9 +471,9 @@ impl<T: RegisteredClass> ClassObject<T> {
 
     /// Converts the class object into an owned [`ZendObject`], removing any reference to
     /// the embedded struct type `T`.
-    pub fn into_owned_object(self) -> OwnedZendObject {
+    pub fn into_owned_object(self) -> ZBox<ZendObject> {
         let mut this = ManuallyDrop::new(self);
-        OwnedZendObject((&mut this.deref_mut().std).into())
+        unsafe { ZBox::from_raw(&mut this.std) }
     }
 }
 
@@ -1178,7 +1142,7 @@ impl<'a, T: RegisteredClass> FromZval<'a> for &'a T {
 // }
 
 impl<T: RegisteredClass> IntoZendObject for T {
-    fn into_zend_object(self) -> Result<OwnedZendObject> {
+    fn into_zend_object(self) -> Result<ZBox<ZendObject>> {
         Ok(ClassObject::new(self).into_owned_object())
     }
 }

--- a/src/php/types/object.rs
+++ b/src/php/types/object.rs
@@ -34,7 +34,6 @@ use crate::{
         flags::ZvalTypeFlags,
         function::FunctionBuilder,
         globals::ExecutorGlobals,
-        types::array::OwnedHashTable,
     },
 };
 
@@ -979,7 +978,7 @@ impl ZendObjectHandlers {
 
         let props = zend_std_get_properties(object)
             .as_mut()
-            .or_else(|| OwnedHashTable::new().into_inner().as_mut())
+            .or_else(|| Some(HashTable::new().into_raw()))
             .expect("Failed to get property hashtable");
 
         if let Err(e) = internal::<T>(object, props) {

--- a/src/php/types/zval.rs
+++ b/src/php/types/zval.rs
@@ -19,13 +19,7 @@ use crate::{
 
 use crate::php::{enums::DataType, flags::ZvalTypeFlags, types::long::ZendLong};
 
-use super::{
-    array::{HashTable, OwnedHashTable},
-    callable::Callable,
-    object::ZendObject,
-    rc::PhpRc,
-    string::ZendStr,
-};
+use super::{array::HashTable, callable::Callable, object::ZendObject, rc::PhpRc, string::ZendStr};
 
 /// Zend value. Represents most data types that are in the Zend engine.
 pub type Zval = zval;
@@ -421,7 +415,7 @@ impl Zval {
     /// # Parameters
     ///
     /// * `val` - The value to set the zval as.
-    pub fn set_array<T: TryInto<OwnedHashTable, Error = Error>>(&mut self, val: T) -> Result<()> {
+    pub fn set_array<T: TryInto<ZBox<HashTable>, Error = Error>>(&mut self, val: T) -> Result<()> {
         self.set_hashtable(val.try_into()?);
         Ok(())
     }
@@ -431,9 +425,9 @@ impl Zval {
     /// # Parameters
     ///
     /// * `val` - The value to set the zval as.
-    pub fn set_hashtable(&mut self, val: OwnedHashTable) {
+    pub fn set_hashtable(&mut self, val: ZBox<HashTable>) {
         self.change_type(ZvalTypeFlags::ArrayEx);
-        self.value.arr = val.into_inner();
+        self.value.arr = val.into_raw();
     }
 
     /// Sets the value of the zval as a pointer.

--- a/src/php/types/zval.rs
+++ b/src/php/types/zval.rs
@@ -14,14 +14,10 @@ use crate::{
         zend_value, zval, zval_ptr_dtor,
     },
     errors::{Error, Result},
-    php::{exceptions::PhpException, pack::Pack},
+    php::{boxed::ZBox, exceptions::PhpException, pack::Pack},
 };
 
-use crate::php::{
-    enums::DataType,
-    flags::ZvalTypeFlags,
-    types::{long::ZendLong, string::ZendString},
-};
+use crate::php::{enums::DataType, flags::ZvalTypeFlags, types::long::ZendLong};
 
 use super::{
     array::{HashTable, OwnedHashTable},
@@ -311,7 +307,7 @@ impl Zval {
     /// * `val` - The value to set the zval as.
     /// * `persistent` - Whether the string should persist between requests.
     pub fn set_string(&mut self, val: &str, persistent: bool) -> Result<()> {
-        self.set_zend_string(ZendString::new(val, persistent)?);
+        self.set_zend_string(ZendStr::new(val, persistent)?);
         Ok(())
     }
 
@@ -320,9 +316,9 @@ impl Zval {
     /// # Parameters
     ///
     /// * `val` - String content.
-    pub fn set_zend_string(&mut self, val: ZendString) {
+    pub fn set_zend_string(&mut self, val: ZBox<ZendStr>) {
         self.change_type(ZvalTypeFlags::StringEx);
-        self.value.str_ = val.into_inner();
+        self.value.str_ = val.into_raw();
     }
 
     /// Sets the value of the zval as a binary string, which is represented in Rust as a vector.
@@ -343,7 +339,7 @@ impl Zval {
     /// * `val` - The value to set the zval as.
     /// * `persistent` - Whether the string should persist between requests.
     pub fn set_interned_string(&mut self, val: &str, persistent: bool) -> Result<()> {
-        self.set_zend_string(ZendString::new_interned(val, persistent)?);
+        self.set_zend_string(ZendStr::new_interned(val, persistent)?);
         Ok(())
     }
 


### PR DESCRIPTION
Currently types which cannot be owned directly are owned through wrapper types,  such as `ZendString -> ZendStr`, `OwnedHashTable -> HashTable`, `ClassObject -> ZendObject`, since they are allocated using the Zend memory manager and cannot be stored in a box.

This PR introduces a new type `ZBox<T>` and a new trait `ZBoxable`. A type allocated using the Zend memory manager will implement `ZBoxable`, and can then be stored inside a `ZBox<T>`.

There are no 'safe' constructor methods on `ZBox`. These are to be implemented on the boxed types. For example, `ZendStr` has a function `from_c_str` which returns a `ZBox<ZendStr>`.