### PR TITLE
Allow `ZendClassObject` as `self` parameter

### DIFF
--- a/crates/macros/src/function.rs
+++ b/crates/macros/src/function.rs
@@ -309,7 +309,7 @@ impl Arg {
     pub fn get_type_ident(&self) -> TokenStream {
         let ty: Type = syn::parse_str(&self.ty).unwrap();
         quote! {
-            <#ty as ::ext_php_rs::convert::FromZval>::TYPE
+            <#ty as ::ext_php_rs::convert::FromZvalMut>::TYPE
         }
     }
 

--- a/crates/macros/src/impl_.rs
+++ b/crates/macros/src/impl_.rs
@@ -83,6 +83,7 @@ pub enum ParsedAttribute {
         ty: PropAttrTy,
     },
     Constructor,
+    This,
 }
 
 #[derive(Default, Debug, FromMeta)]
@@ -138,9 +139,9 @@ pub fn parser(args: AttributeArgs, input: ItemImpl) -> Result<TokenStream> {
                         #constant
                     }
                 }
-                syn::ImplItem::Method(mut method) => {
+                syn::ImplItem::Method(method) => {
                     let parsed_method =
-                        method::parser(&mut method, args.rename_methods.unwrap_or_default())?;
+                        method::parser(method, args.rename_methods.unwrap_or_default())?;
                     if let Some((prop, ty)) = parsed_method.property {
                         let prop = match class.properties.entry(prop) {
                             Entry::Occupied(entry) => entry.into_mut(),
@@ -248,6 +249,7 @@ pub fn parse_attribute(attr: &Attribute) -> Result<ParsedAttribute> {
             }
         }
         "constructor" => ParsedAttribute::Constructor,
+        "this" => ParsedAttribute::This,
         attr => bail!("Invalid attribute `#[{}]`.", attr),
     })
 }

--- a/src/class.rs
+++ b/src/class.rs
@@ -9,19 +9,14 @@ use std::{
 
 use crate::{
     builders::FunctionBuilder,
-    convert::{FromZval, IntoZval},
     exception::PhpException,
     props::Property,
-    types::ZendClassObject,
     zend::{ClassEntry, ExecuteData, ZendObjectHandlers},
 };
 
 /// Implemented on Rust types which are exported to PHP. Allows users to get and
 /// set PHP properties on the object.
-pub trait RegisteredClass: Sized
-where
-    Self: 'static,
-{
+pub trait RegisteredClass: Sized + 'static {
     /// PHP class name of the registered class.
     const CLASS_NAME: &'static str;
 
@@ -36,54 +31,6 @@ where
     ///
     /// [`macro@php_class`]: crate::php_class
     fn get_metadata() -> &'static ClassMetadata<Self>;
-
-    /// Attempts to retrieve a property from the class object.
-    ///
-    /// # Parameters
-    ///
-    /// * `name` - The name of the property.
-    ///
-    /// # Returns
-    ///
-    /// Returns a given type `T` inside an option which is the value of the
-    /// zval, or [`None`] if the property could not be found.
-    ///
-    /// # Safety
-    ///
-    /// Caller must guarantee that the object the function is called on is
-    /// immediately followed by a [`ZendObject`], which is true when the
-    /// object was instantiated by PHP.
-    ///
-    /// [`ZendObject`]: crate::types::ZendObject
-    unsafe fn get_property<'a, T: FromZval<'a>>(&'a self, name: &str) -> Option<T> {
-        let obj = ZendClassObject::<Self>::from_obj_ptr(self)?;
-        obj.std.get_property(name).ok()
-    }
-
-    /// Attempts to set the value of a property on the class object.
-    ///
-    /// # Parameters
-    ///
-    /// * `name` - The name of the property to set.
-    /// * `value` - The value to set the property to.
-    ///
-    /// # Returns
-    ///
-    /// Returns nothing in an option if the property was successfully set.
-    /// Returns none if setting the value failed.
-    ///
-    /// # Safety
-    ///
-    /// Caller must guarantee that the object the function is called on is
-    /// immediately followed by a [`ZendObject`], which is true when the
-    /// object was instantiated by PHP.
-    ///
-    /// [`ZendObject`]: crate::types::ZendObject
-    unsafe fn set_property(&mut self, name: &str, value: impl IntoZval) -> Option<()> {
-        let obj = ZendClassObject::<Self>::from_obj_ptr(self)?;
-        obj.std.set_property(name, value).ok()?;
-        Some(())
-    }
 
     /// Returns a hash table containing the properties of the class.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ pub use ext_php_rs_derive::php_extern;
 /// }
 ///
 /// pub extern "C" fn _internal_php_hello(ex: &mut ExecuteData, retval: &mut Zval) {
-///     let mut name = Arg::new("name", <String as FromZval>::TYPE);
+///     let mut name = Arg::new("name", <String as FromZvalMut>::TYPE);
 ///     let parser = ex.parser()
 ///         .arg(&mut name)
 ///         .parse();

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -1,5 +1,7 @@
 //! Traits and types for interacting with reference counted PHP types.
 
+use std::fmt::Debug;
+
 use crate::{
     ffi::{zend_refcounted_h, zend_string},
     types::ZendObject,
@@ -7,6 +9,14 @@ use crate::{
 
 /// Object used to store Zend reference counter.
 pub type ZendRefcount = zend_refcounted_h;
+
+impl Debug for ZendRefcount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ZendRefcount")
+            .field("refcount", &self.refcount)
+            .finish()
+    }
+}
 
 /// Implemented on refcounted types.
 pub trait PhpRc {


### PR DESCRIPTION
Can now take `self` parameter as `ZendClassObject<T>`. Example:

```rust
#[php_impl]
impl Example {
  pub fn example(#[this] this: &mut ZendClassObject<Example>) {
    dbg!(this);
  }
}
```