### PR TITLE
Fix builds on aarch64 Linux

### DIFF
--- a/src/binary.rs
+++ b/src/binary.rs
@@ -149,7 +149,7 @@ macro_rules! pack_impl {
             fn pack_into(vec: Vec<Self>) -> *mut zend_string {
                 let len = vec.len() * ($d as usize / 8);
                 let ptr = Box::into_raw(vec.into_boxed_slice());
-                unsafe { ext_php_rs_zend_string_init(ptr as *mut i8, len as _, false) }
+                unsafe { ext_php_rs_zend_string_init(ptr.cast(), len as _, false) }
             }
 
             fn unpack_into(s: &zend_string) -> Vec<Self> {

--- a/src/builders/function.rs
+++ b/src/builders/function.rs
@@ -105,7 +105,7 @@ impl<'a> FunctionBuilder<'a> {
 
         // argument header, retval etc
         args.push(ArgInfo {
-            name: self.n_req.unwrap_or(self.args.len()) as *const i8,
+            name: self.n_req.unwrap_or(self.args.len()) as *const _,
             type_: match self.retval {
                 Some(retval) => {
                     ZendType::empty_from_type(retval, self.ret_as_ref, false, self.ret_as_null)


### PR DESCRIPTION
Seems like `c_char` is different on AArch64 Linux (even though it's the same as x86 on AArch64 macOS).