### PR TITLE
Make `ClassMetadata: Send + Sync`

### DIFF
--- a/src/class.rs
+++ b/src/class.rs
@@ -85,7 +85,10 @@ pub struct ClassMetadata<T> {
     handlers: MaybeUninit<ZendObjectHandlers>,
     ce: AtomicPtr<ClassEntry>,
 
-    phantom: PhantomData<T>,
+    // `AtomicPtr` is used here because it is `Send + Sync`.
+    // fn() -> T could have been used but that is incompatible with const fns at
+    // the moment.
+    phantom: PhantomData<AtomicPtr<T>>,
 }
 
 impl<T> ClassMetadata<T> {


### PR DESCRIPTION
This wasn't the case because of `PhantomData<T>` inside the metadata.
Replacing this with `PhantomData<AtomicPtr<T>>` ensures that the
metadata will always be `Send + Sync`.