### PR TITLE
Create properties hashmap once instead of on each call

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = ["/.github", "/.crates", "/guide"]
 bitflags = "1.2.1"
 parking_lot = "0.11.2"
 cfg-if = "1.0"
+once_cell = "1.8.0"
 anyhow = { version = "1", optional = true }
 ext-php-rs-derive = { version = "=0.7.2", path = "./crates/macros" }
 


### PR DESCRIPTION
This adds `once_cell` as a dependency, however, it is used for both
handlers and properties. Better to be 'safe' than sorry ;)