### PR TITLE
Allow passing `--yes` parameter to bypass prompts

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -40,7 +40,7 @@ SUBCOMMANDS:
             Generates stub PHP files for the extension
 
 $ cargo php install --help
-cargo-php-install 
+cargo-php-install
 
 Installs the extension in the current PHP installation.
 
@@ -71,8 +71,11 @@ OPTIONS:
         --release
             Whether to install the release version of the extension
 
+        --yes
+            Bypasses the confirmation prompt
+
 $ cargo php remove --help
-cargo-php-remove 
+cargo-php-remove
 
 Removes the extension in the current PHP installation.
 
@@ -97,8 +100,11 @@ OPTIONS:
             Path to the Cargo manifest of the extension. Defaults to the manifest in the directory
             the command is called
 
+        --yes
+            Bypasses the confirmation prompt
+
 $ cargo php stubs --help
-cargo-php-stubs 
+cargo-php-stubs
 
 Generates stub PHP files for the extension.
 
@@ -120,7 +126,7 @@ OPTIONS:
         --manifest <MANIFEST>
             Path to the Cargo manifest of the extension. Defaults to the manifest in the directory
             the command is called.
-            
+
             This cannot be provided alongside the `ext` option, as that option provides a direct
             path to the extension shared library.
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -105,6 +105,9 @@ struct Install {
     /// the directory the command is called.
     #[arg(long)]
     manifest: Option<PathBuf>,
+    /// Whether to bypass the install prompt.
+    #[clap(long)]
+    yes: bool,
 }
 
 #[derive(Parser)]
@@ -121,6 +124,9 @@ struct Remove {
     /// the directory the command is called.
     #[arg(long)]
     manifest: Option<PathBuf>,
+    /// Whether to bypass the remove prompt.
+    #[clap(long)]
+    yes: bool,
 }
 
 #[cfg(not(windows))]
@@ -172,7 +178,7 @@ impl Install {
             php_ini = Some(ini_path);
         }
 
-        if !Confirm::new()
+        if !self.yes && !Confirm::new()
             .with_prompt(format!(
                 "Are you sure you want to install the extension `{}`?",
                 artifact.name
@@ -305,7 +311,7 @@ impl Remove {
             bail!("Unable to find extension installed.");
         }
 
-        if !Confirm::new()
+        if !self.yes && !Confirm::new()
             .with_prompt(format!(
                 "Are you sure you want to remove the extension `{}`?",
                 artifact.name

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -178,12 +178,13 @@ impl Install {
             php_ini = Some(ini_path);
         }
 
-        if !self.yes && !Confirm::new()
-            .with_prompt(format!(
-                "Are you sure you want to install the extension `{}`?",
-                artifact.name
-            ))
-            .interact()?
+        if !self.yes
+            && !Confirm::new()
+                .with_prompt(format!(
+                    "Are you sure you want to install the extension `{}`?",
+                    artifact.name
+                ))
+                .interact()?
         {
             bail!("Installation cancelled.");
         }
@@ -311,12 +312,13 @@ impl Remove {
             bail!("Unable to find extension installed.");
         }
 
-        if !self.yes && !Confirm::new()
-            .with_prompt(format!(
-                "Are you sure you want to remove the extension `{}`?",
-                artifact.name
-            ))
-            .interact()?
+        if !self.yes
+            && !Confirm::new()
+                .with_prompt(format!(
+                    "Are you sure you want to remove the extension `{}`?",
+                    artifact.name
+                ))
+                .interact()?
         {
             bail!("Installation cancelled.");
         }

--- a/guide/src/cargo-php.md
+++ b/guide/src/cargo-php.md
@@ -84,7 +84,7 @@ personally recommend for use in Visual Studio Code).
 
 ```text
 $ cargo php stubs --help
-cargo-php-stubs 
+cargo-php-stubs
 
 Generates stub PHP files for the extension.
 
@@ -106,7 +106,7 @@ OPTIONS:
         --manifest <MANIFEST>
             Path to the Cargo manifest of the extension. Defaults to the manifest in the directory
             the command is called.
-            
+
             This cannot be provided alongside the `ext` option, as that option provides a direct
             path to the extension shared library.
 
@@ -130,7 +130,7 @@ so you are able to restore if you run into any issues.
 
 ```text
 $ cargo php install --help
-cargo-php-install 
+cargo-php-install
 
 Installs the extension in the current PHP installation.
 
@@ -164,6 +164,9 @@ OPTIONS:
 
         --release
             Whether to install the release version of the extension
+
+        --yes
+            Bypasses the confirmation prompt
 ```
 
 ## Extension Removal
@@ -175,7 +178,7 @@ from your `php.ini` if present.
 
 ```text
 $ cargo php remove --help
-cargo-php-remove 
+cargo-php-remove
 
 Removes the extension in the current PHP installation.
 
@@ -203,6 +206,9 @@ OPTIONS:
         --manifest <MANIFEST>
             Path to the Cargo manifest of the extension. Defaults to the manifest in the directory
             the command is called
+
+        --yes
+            Bypasses the confirmation prompt
 ```
 
 [`cargo-php`]: https://crates.io/crates/cargo-php


### PR DESCRIPTION
Makes this tool usable in automated builds such as Docker containers.

Addresses https://github.com/davidcole1340/ext-php-rs/issues/133