### PR TITLE
Add php-scrypt as a example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Check out one of the example projects:
 - [opus-php](https://github.com/davidcole1340/opus-php) - Audio encoder for the
   Opus codec in PHP.
 - [tomlrs-php](https://github.com/jphenow/tomlrs-php) - TOML data format parser.
+- [php-scrypt](https://github.com/appwrite/php-scrypt) - PHP wrapper for the
+  scrypt password hashing algorithm.
 
 ## Contributions
 


### PR DESCRIPTION
Hey There 👋 

We at Appwrite recently created an extension using this library to fix an issue we had with the standard C-based php-scrypt by rewriting it in rust. Thanks to this library being so easy to use, we could get a working version in less than a day! 

We would love it if you could add it as an example project in this repository to give more examples of how to use this library.

Thank you for reviewing this pull request,
Bradley Schofield