### PR TITLE
fix causes of some clippy warnings

### DIFF
--- a/src/builders/module.rs
+++ b/src/builders/module.rs
@@ -56,8 +56,8 @@ impl ModuleBuilder {
             module: ModuleEntry {
                 size: mem::size_of::<ModuleEntry>() as u16,
                 zend_api: ZEND_MODULE_API_NO,
-                zend_debug: if PHP_DEBUG { 1 } else { 0 },
-                zts: if PHP_ZTS { 1 } else { 0 },
+                zend_debug: u8::from(PHP_DEBUG),
+                zts: u8::from(PHP_ZTS),
                 ini_entry: ptr::null(),
                 deps: ptr::null(),
                 name: ptr::null(),


### PR DESCRIPTION
Clippy linting had some errors:

    error: boolean to int conversion using if
    Error:   --> src/builders/module.rs:59:29
       |
    59 |                 zend_debug: if PHP_DEBUG { 1 } else { 0 },
       |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `u8::from(PHP_DEBUG)`
       |
       = note: `-D clippy::bool-to-int-with-if` implied by `-D warnings`
       = note: `PHP_DEBUG as u8` or `PHP_DEBUG.into()` can also be valid options
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_to_int_with_if

    error: boolean to int conversion using if
    Error:   --> src/builders/module.rs:60:22
       |
    60 |                 zts: if PHP_ZTS { 1 } else { 0 },
       |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `u8::from(PHP_ZTS)`
       |
       = note: `PHP_ZTS as u8` or `PHP_ZTS.into()` can also be valid options
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_to_int_with_if

    error: could not compile `ext-php-rs` due to 2 previous errors

This PR tries to fix those.