### PR TITLE
fix more causes of clippy warnings

### DIFF
--- a/crates/macros/src/module.rs
+++ b/crates/macros/src/module.rs
@@ -55,8 +55,8 @@ pub fn parser(input: ItemFn) -> Result<TokenStream> {
     });
     let registered_classes_impls = state
         .classes
-        .iter()
-        .map(|(_, class)| generate_registered_class_impl(class))
+        .values()
+        .map(generate_registered_class_impl)
         .collect::<Result<Vec<_>>>()?;
     let describe_fn = generate_stubs(&state);
 
@@ -363,7 +363,7 @@ impl Describe for crate::constant::Constant {
 impl Describe for State {
     fn describe(&self) -> TokenStream {
         let functs = self.functions.iter().map(Describe::describe);
-        let classes = self.classes.iter().map(|(_, class)| class.describe());
+        let classes = self.classes.values().map(|class| class.describe());
         let constants = self.constants.iter().map(Describe::describe);
 
         quote! {


### PR DESCRIPTION
Clippy linting had more errors:

    error: iterating on a map's values
    Error:   --> crates/macros/src/module.rs:56:36
       |
    56 |       let registered_classes_impls = state
       |  ____________________________________^
    57 | |         .classes
    58 | |         .iter()
    59 | |         .map(|(_, class)| generate_registered_class_impl(class))
       | |________________________________________________________________^
       |
       = note: `-D clippy::iter-kv-map` implied by `-D warnings`
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#iter_kv_map
    help: try
       |
    56 ~     let registered_classes_impls = state
    57 +         .classes.values().map(|class| generate_registered_class_impl(class))
       |

    error: iterating on a map's values
    Error:    --> crates/macros/src/module.rs:366:23
        |
    366 |         let classes = self.classes.iter().map(|(_, class)| class.describe());
        |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `self.classes.values().map(|class| class.describe())`
        |
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#iter_kv_map

    error: could not compile `ext-php-rs-derive` due to 2 previous errors