### PR TITLE
ci: run clippy only on stable Rust channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           command: clippy
           args: --all -- -D warnings
+        if: matrix.rust == 'stable'
       - name: Build with docs stub
         if: "contains(matrix.os, 'ubuntu') && matrix.php == '8.1'"
         env:


### PR DESCRIPTION
~**Note:** This is _still a draft_, because it should only be merged after #158 was approved and merged.~

---

Sparked by the comments about nightly clippy breaking the build too often (see <https://github.com/davidcole1340/ext-php-rs/pull/151#issuecomment-1261151479>), this change will limit clippy to builds with a stable Rust version only.