### PR TITLE
fix binary slice lifetimes

### DIFF
--- a/src/binary_slice.rs
+++ b/src/binary_slice.rs
@@ -8,11 +8,7 @@ use crate::ffi::zend_string;
 
 use std::{ops::Deref, slice::from_raw_parts};
 
-use crate::{
-    convert::FromZval,
-    flags::DataType,
-    types::Zval,
-};
+use crate::{convert::FromZval, flags::DataType, types::Zval};
 
 /// Acts as a wrapper around `&[T]` where `T` implements [`PackSlice`].
 /// Primarily used for passing read-only binary data into Rust functions.

--- a/src/types/zval.rs
+++ b/src/types/zval.rs
@@ -130,21 +130,26 @@ impl Zval {
     ///
     /// [`pack`]: https://www.php.net/manual/en/function.pack.php
     pub fn binary<T: Pack>(&self) -> Option<Vec<T>> {
-        if self.is_string() {
-            // SAFETY: Type is string therefore we are able to take a reference.
-            Some(T::unpack_into(unsafe { self.value.str_.as_ref() }?))
-        } else {
-            None
-        }
+        self.zend_str().map(T::unpack_into)
     }
 
-    pub fn binary_slice<'a, T: PackSlice>(&self) -> Option<&'a [T]> {
-        if self.is_string() {
-            // SAFETY: Type is string therefore we are able to take a reference.
-            Some(T::unpack_into(unsafe { self.value.str_.as_ref() }?))
-        } else {
-            None
-        }
+    /// Returns the value of the zval if it is a string and can be unpacked into
+    /// a slice of a given type. Similar to the [`unpack`](https://www.php.net/manual/en/function.unpack.php)
+    /// in PHP, except you can only unpack one type.
+    ///
+    /// This function is similar to [`Zval::binary`] except that a slice is
+    /// returned instead of a vector, meaning the contents of the string is
+    /// not copied.
+    ///
+    /// # Safety
+    ///
+    /// There is no way to tell if the data stored in the string is actually of
+    /// the given type. The results of this function can also differ from
+    /// platform-to-platform due to the different representation of some
+    /// types on different platforms. Consult the [`pack`] function
+    /// documentation for more details.
+    pub fn binary_slice<T: PackSlice>(&self) -> Option<&[T]> {
+        self.zend_str().map(T::unpack_into)
     }
 
     /// Returns the value of the zval if it is a resource.


### PR DESCRIPTION
returned slice should have the same lifetime as the zend string (which will have the same lifetime as the Zval).