### PR TITLE
fixes CI workflow configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        php: ['8.0', '8.1']
+        php: ["8.0", "8.1"]
         rust: [stable, nightly]
+        clang: ["14"]
         phpts: [ts, nts]
         exclude:
           # ext-php-rs requires nightly Rust when on Windows.
@@ -24,6 +25,8 @@ jobs:
             phpts: ts
           - os: ubuntu-latest
             phpts: ts
+    env:
+      CARGO_TERM_COLOR: always
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -34,59 +37,67 @@ jobs:
         env:
           phpts: ${{ matrix.phpts }}
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
           components: rustfmt, clippy
-      - name: Setup LLVM & Clang
+      - run: rustup show
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        # Uncomment the following if statement if caching nightly deps
+        # ends up causing too much cache invalidation.
+        # if: matrix.rust == 'stable'
+        with:
+          # increment this manually to force cache eviction
+          prefix-key: "v0-rust"
+      # LLVM & Clang
+      - name: Cache LLVM and Clang
+        id: cache-llvm
+        uses: actions/cache@v2
         if: "!contains(matrix.os, 'windows')"
+        with:
+          path: ${{ runner.temp }}/llvm-${{ matrix.clang }}
+          key: ${{ matrix.os }}-llvm-${{ matrix.clang }}
+      - name: Setup LLVM & Clang
         id: clang
         uses: KyleMayes/install-llvm-action@v1
+        if: "!contains(matrix.os, 'windows')"
         with:
-          version: '13.0'
-          directory: ${{ runner.temp }}/llvm
+          version: ${{ matrix.clang }}
+          directory: ${{ runner.temp }}/llvm-${{ matrix.clang }}
+          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
       - name: Configure Clang
         if: "!contains(matrix.os, 'windows')"
         run: |
-          echo "LIBCLANG_PATH=${{ runner.temp }}/llvm/lib" >> $GITHUB_ENV
+          echo "LIBCLANG_PATH=${{ runner.temp }}/llvm-${{ matrix.clang }}/lib" >> $GITHUB_ENV
           echo "LLVM_VERSION=${{ steps.clang.outputs.version }}" >> $GITHUB_ENV
+          echo "LLVM_CONFIG_PATH=${{ runner.temp }}/llvm-${{ matrix.clang }}/bin/llvm-config" >> $GITHUB_ENV
       - name: Configure Clang (macOS only)
         if: "contains(matrix.os, 'macos')"
         run: echo "SDKROOT=$(xcrun --show-sdk-path)" >> $GITHUB_ENV
+      # Build
       - name: Build
         env:
-          EXT_PHP_RS_TEST:
+          EXT_PHP_RS_TEST: ""
         run: cargo build --release --all-features --all
+      # Test & lint
       - name: Test inline examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --all --all-features
+        run: cargo test --release --all --all-features
       - name: Run rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
         if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest' && matrix.php == '8.1'
+        run: cargo fmt --all -- --check
       - name: Run clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all -- -D warnings
         if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest' && matrix.php == '8.1'
+        run: cargo clippy --all -- -D warnings
+      # Docs
       - name: Run rustdoc
-        uses: actions-rs/cargo@v1
-        with:
-          command: rustdoc
-          args: -- -D warnings
         if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest' && matrix.php == '8.1'
+        run: cargo rustdoc -- -D warnings
       - name: Build with docs stub
-        env:
-          DOCS_RS:
-        run:
-          cargo clean && cargo build
         if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest' && matrix.php == '8.1'
+        env:
+          DOCS_RS: ""
+        run: cargo clean && cargo build
   build-zts:
     name: Build with ZTS
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build and Lint
 on:
+  schedule:
+    # runs every monday at midnight
+    - cron: "0 0 * * 1"
   push:
     branches:
       - master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       # LLVM & Clang
       - name: Cache LLVM and Clang
         id: cache-llvm
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         if: "!contains(matrix.os, 'windows')"
         with:
           path: ${{ runner.temp }}/llvm-${{ matrix.clang }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
       - name: Cache LLVM and Clang
         id: cache-llvm
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ runner.temp }}/llvm-${{ matrix.clang }}
           key: ${{ matrix.os }}-llvm-${{ matrix.clang }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,9 @@
 name: Deploy documentation
 on:
   workflow_dispatch:
+  # runs every monday at midnight
+  schedule:
+    - cron: "0 0 * * 1"
   push:
     branches:
       - master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,28 +8,38 @@ on:
 jobs:
   docs:
     name: Build and Deploy
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"]
+        php: ["8.0"]
+        clang: ["14"]
+        mdbook: ["latest"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: ${{ matrix.php }}
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Cache LLVM and Clang
+        id: cache-llvm
+        uses: actions/cache@v2
         with:
-          toolchain: nightly 
-          override: true
+          path: ${{ runner.temp }}/llvm-${{ matrix.clang }}
+          key: ${{ matrix.os }}-llvm-${{ matrix.clang }}
       - name: Setup LLVM & Clang
         uses: KyleMayes/install-llvm-action@v1
         with:
-          version: 11.0
-          directory: ${{ runner.temp }}/llvm-11.0
+          version: ${{ matrix.clang }}
+          directory: ${{ runner.temp }}/llvm-${{ matrix.clang }}
+          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
       - name: Install mdbook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: latest
+          mdbook-version: ${{ matrix.mdbook }}
       - name: Build guide
         run: mdbook build guide
       - name: Publish docs

--- a/src/types/zval.rs
+++ b/src/types/zval.rs
@@ -117,8 +117,8 @@ impl Zval {
     }
 
     /// Returns the value of the zval if it is a string and can be unpacked into
-    /// a vector of a given type. Similar to the [`unpack`](https://www.php.net/manual/en/function.unpack.php)
-    /// in PHP, except you can only unpack one type.
+    /// a vector of a given type. Similar to the [`unpack`] function in PHP,
+    /// except you can only unpack one type.
     ///
     /// # Safety
     ///
@@ -129,13 +129,14 @@ impl Zval {
     /// documentation for more details.
     ///
     /// [`pack`]: https://www.php.net/manual/en/function.pack.php
+    /// [`unpack`]: https://www.php.net/manual/en/function.unpack.php
     pub fn binary<T: Pack>(&self) -> Option<Vec<T>> {
         self.zend_str().map(T::unpack_into)
     }
 
     /// Returns the value of the zval if it is a string and can be unpacked into
-    /// a slice of a given type. Similar to the [`unpack`](https://www.php.net/manual/en/function.unpack.php)
-    /// in PHP, except you can only unpack one type.
+    /// a slice of a given type. Similar to the [`unpack`] function in PHP,
+    /// except you can only unpack one type.
     ///
     /// This function is similar to [`Zval::binary`] except that a slice is
     /// returned instead of a vector, meaning the contents of the string is
@@ -148,6 +149,9 @@ impl Zval {
     /// platform-to-platform due to the different representation of some
     /// types on different platforms. Consult the [`pack`] function
     /// documentation for more details.
+    ///
+    /// [`pack`]: https://www.php.net/manual/en/function.pack.php
+    /// [`unpack`]: https://www.php.net/manual/en/function.unpack.php
     pub fn binary_slice<T: PackSlice>(&self) -> Option<&[T]> {
         self.zend_str().map(T::unpack_into)
     }


### PR DESCRIPTION
The latest runs were broken for some reason so I fixed it.
Here's a summary of what this PR does:

* upgrades LLVM to v14
* migrates from the unmaintained `action-rs/*` actions to [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain), using [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache/) as a cache layer.
* adds a cache layer for LLVM build
* adds a weekly cron schedule for all workflows
* fixes an issue in the docblocks