### PR TITLE
Add get_id() and hash() methods on ZendObject

### DIFF
--- a/src/types/object.rs
+++ b/src/types/object.rs
@@ -196,6 +196,29 @@ impl ZendObject {
         T::from_zend_object(self)
     }
 
+    /// Returns an unique identifier for the object.
+    ///
+    /// The id is guaranteed to be unique for the lifetime of the object.
+    /// Once the object is destroyed, it may be reused for other objects.
+    /// This is equivalent to calling the [`spl_object_id`] PHP function.
+    ///
+    /// [`spl_object_id`]: https://www.php.net/manual/function.spl-object-id
+    #[inline]
+    pub fn get_id(&self) -> u32 {
+        self.handle
+    }
+
+    /// Returns an unique hash for the object.
+    ///
+    /// The hash is guaranteed to be unique for the lifetime of the object.
+    /// Once the object is destroyed, it may be reused for other objects.
+    /// This is equivalent to calling the [`spl_object_hash`] PHP function.
+    ///
+    /// [`spl_object_hash`]: https://www.php.net/manual/function.spl-object-hash.php
+    pub fn get_hash(&self) -> String {
+        format!("{:016x}0000000000000000", self.handle)
+    }
+
     /// Attempts to retrieve a reference to the object handlers.
     #[inline]
     unsafe fn handlers(&self) -> Result<&ZendObjectHandlers> {

--- a/src/types/object.rs
+++ b/src/types/object.rs
@@ -208,14 +208,14 @@ impl ZendObject {
         self.handle
     }
 
-    /// Returns an unique hash for the object.
+    /// Computes an unique hash for the object.
     ///
     /// The hash is guaranteed to be unique for the lifetime of the object.
     /// Once the object is destroyed, it may be reused for other objects.
     /// This is equivalent to calling the [`spl_object_hash`] PHP function.
     ///
     /// [`spl_object_hash`]: https://www.php.net/manual/function.spl-object-hash.php
-    pub fn get_hash(&self) -> String {
+    pub fn hash(&self) -> String {
         format!("{:016x}0000000000000000", self.handle)
     }
 


### PR DESCRIPTION
The `get_id` method is strictly equivalent to calling `spl_object_id()` with the object as parameter.

The `get_hash` method is strictly equivalent to calling `spl_object_hash()` with the object as parameter.