### PR TITLE
Add is_identical for zvals

### DIFF
--- a/allowed_bindings.rs
+++ b/allowed_bindings.rs
@@ -88,6 +88,7 @@ bind! {
     zend_hash_str_update,
     zend_internal_arg_info,
     zend_is_callable,
+    zend_is_identical,
     zend_long,
     zend_lookup_class_ex,
     zend_module_entry,

--- a/docsrs_bindings.rs
+++ b/docsrs_bindings.rs
@@ -835,6 +835,9 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn zend_is_identical(op1: *mut zval, op2: *mut zval) -> bool;
+}
+extern "C" {
     pub fn zend_is_true(op: *mut zval) -> ::std::os::raw::c_int;
 }
 pub type zend_op_array = _zend_op_array;

--- a/src/types/zval.rs
+++ b/src/types/zval.rs
@@ -11,8 +11,8 @@ use crate::{
     convert::{FromZval, FromZvalMut, IntoZval, IntoZvalDyn},
     error::{Error, Result},
     ffi::{
-        _zval_struct__bindgen_ty_1, _zval_struct__bindgen_ty_2, zend_is_callable, zend_resource,
-        zend_value, zval, zval_ptr_dtor,
+        _zval_struct__bindgen_ty_1, _zval_struct__bindgen_ty_2, zend_is_callable,
+        zend_is_identical, zend_resource, zend_value, zval, zval_ptr_dtor,
     },
     flags::DataType,
     flags::ZvalTypeFlags,
@@ -325,6 +325,18 @@ impl Zval {
     pub fn is_callable(&self) -> bool {
         let ptr: *const Self = self;
         unsafe { zend_is_callable(ptr as *mut Self, 0, std::ptr::null_mut()) }
+    }
+
+    /// Checks if the zval is identical to another one.
+    /// This works like `===` in php.
+    ///
+    /// # Parameters
+    ///
+    /// * `other` - The the zval to check identity against.
+    pub fn is_identical(&self, other: &Self) -> bool {
+        let self_p: *const Self = self;
+        let other_p: *const Self = other;
+        unsafe { zend_is_identical(self_p as *mut Self, other_p as *mut Self) }
     }
 
     /// Returns true if the zval contains a pointer, false otherwise.


### PR DESCRIPTION
I was missing the ability to compare two zvals with PHP's `===` operator. 
To allow for it, I exposed the `zend_is_identical` function that the Zend engine maps to the `===` token.