### PR TITLE
Support function args being passed by reference

### DIFF
--- a/crates/macros/src/function.rs
+++ b/crates/macros/src/function.rs
@@ -293,8 +293,8 @@ impl Arg {
                         }
                     });
 
-                // For for types that are `Option<&mut T>` to turn them into `Option<&T>`, marking the Arg as
-                // as "passed by reference".
+                // For for types that are `Option<&mut T>` to turn them into `Option<&T>`,
+                // marking the Arg as as "passed by reference".
                 let option = Some(seg)
                     .filter(|seg| seg.ident == "Option")
                     .and_then(|seg| {
@@ -311,11 +311,11 @@ impl Arg {
                                                     new_ref.mutability = None;
                                                     pass_by_ref = true;
                                                     Type::Reference(new_ref)
-                                                },
+                                                }
                                                 _ => ty.clone(),
                                             };
                                             GenericArgument::Type(_rtype)
-                                        },
+                                        }
                                         _ => ga.clone(),
                                     };
                                     new_ga.to_token_stream().to_string()
@@ -327,7 +327,7 @@ impl Arg {
 
                 let stringified = match result {
                     Some(result) if is_return => result,
-                    _ => match option  {
+                    _ => match option {
                         Some(result) => result,
                         None => path.to_token_stream().to_string(),
                     },

--- a/crates/macros/src/function.rs
+++ b/crates/macros/src/function.rs
@@ -343,18 +343,12 @@ impl Arg {
             }
             Type::Reference(ref_) => {
                 // Returning references is invalid, so let's just create our arg
-
-                // Change any `&mut T` into `&T` and set the `as_ref` attribute on the Arg
-                // to marked it as a "passed by ref" PHP argument.
-                let mut ref_ = ref_.clone();
-                let is_mutable_ref = ref_.mutability.is_some();
-                ref_.mutability = None;
                 Some(Arg::new(
                     name,
                     ref_.to_token_stream().to_string(),
                     false,
                     default,
-                    is_mutable_ref,
+                    ref_.mutability.is_some(),
                 ))
             }
             _ => None,

--- a/guide/src/types/bool.md
+++ b/guide/src/types/bool.md
@@ -45,3 +45,17 @@ pub fn test_bool(input: bool) -> String {
 var_dump(test_bool(true)); // string(4) "Yes!"
 var_dump(test_bool(false)); // string(3) "No!"
 ```
+
+## Rust example, taking by reference
+
+```rust,no_run
+# #![cfg_attr(windows, feature(abi_vectorcall))]
+# extern crate ext_php_rs;
+# use ext_php_rs::prelude::*;
+# use ext_php_rs::types;
+#[php_function]
+pub fn test_bool(input: &mut types::Zval) {
+    input.reference_mut().unwrap().set_bool(false);
+}
+# fn main() {}
+```


### PR DESCRIPTION
Currently it's not possible for a function to accept args by reference. This PR adds early support for doing so, by transforming any function args that are `&mut T` into args that are passed by reference. E.g.:

```
#[php_function]
fn my_function( arg: &mut Zval ) {
	arg.reference_mut().map( |zval| zval.set_bool(true) );
}
```
