### PR TITLE
Stop watching Cargo.lock for changes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -237,7 +237,6 @@ fn main() -> Result<()> {
     }
 
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=Cargo.lock");
 
     // docs.rs runners only have PHP 7.4 - use pre-generated bindings
     if env::var("DOCS_RS").is_ok() {


### PR DESCRIPTION
When loaded via Cargo, there's no Cargo.lock directly in this crate, so the lack of file existence causes unnecessary rebuilds every time.

Fixes #220.