### PR TITLE
Implement IntoZvalDyn for Zval

### DIFF
--- a/src/builders/module.rs
+++ b/src/builders/module.rs
@@ -131,7 +131,8 @@ impl ModuleBuilder {
     /// This function can be useful if you need to do any final cleanup at the
     /// very end of a request, after all other resources have been released. For
     /// example, if your extension creates any persistent resources that last
-    /// beyond a single request, you could use this function to clean those up. # Arguments
+    /// beyond a single request, you could use this function to clean those up.
+    /// # Arguments
     ///
     /// * `func` - The function to be called when shutdown is requested.
     pub fn post_deactivate_function(mut self, func: extern "C" fn() -> i32) -> Self {

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -218,3 +218,14 @@ impl<T: IntoZval + Clone> IntoZvalDyn for T {
         Self::TYPE
     }
 }
+
+
+impl IntoZvalDyn for Zval {
+    fn as_zval(&self, _persistent: bool) -> Result<Zval> {
+        Ok(self.shallow_clone())
+    }
+
+    fn get_type(&self) -> DataType {
+        self.get_type()
+    }
+}

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -219,7 +219,6 @@ impl<T: IntoZval + Clone> IntoZvalDyn for T {
     }
 }
 
-
 impl IntoZvalDyn for Zval {
     fn as_zval(&self, _persistent: bool) -> Result<Zval> {
         Ok(self.shallow_clone())


### PR DESCRIPTION
When using call_user_func!() / Callable::try_call() it's currently not possible to use Zvals in the arguments which is unexepected. The simplest way is to add the trait to Zval's too.
