### PR TITLE
feat(embed): correctly handle panic inside embed

### DIFF
--- a/src/embed/embed.c
+++ b/src/embed/embed.c
@@ -2,10 +2,14 @@
 
 // We actually use the PHP embed API to run PHP code in test
 // At some point we might want to use our own SAPI to do that
-void ext_php_rs_embed_callback(int argc, char** argv, void (*callback)(void *), void *ctx) {
+void* ext_php_rs_embed_callback(int argc, char** argv, void* (*callback)(void *), void *ctx) {
+  void *result;
+
   PHP_EMBED_START_BLOCK(argc, argv)
 
-  callback(ctx);
+  result = callback(ctx);
 
   PHP_EMBED_END_BLOCK()
+
+  return result;
 }

--- a/src/embed/embed.h
+++ b/src/embed/embed.h
@@ -1,4 +1,4 @@
 #include "zend.h"
 #include "sapi/embed/php_embed.h"
 
-void ext_php_rs_embed_callback(int argc, char** argv, void (*callback)(void *), void *ctx);
+void* ext_php_rs_embed_callback(int argc, char** argv, void* (*callback)(void *), void *ctx);

--- a/src/embed/ffi.rs
+++ b/src/embed/ffi.rs
@@ -10,7 +10,7 @@ extern "C" {
     pub fn ext_php_rs_embed_callback(
         argc: c_int,
         argv: *mut *mut c_char,
-        func: unsafe extern "C" fn(*const c_void),
+        func: unsafe extern "C" fn(*const c_void) -> *mut c_void,
         ctx: *const c_void,
-    );
+    ) -> *mut c_void;
 }


### PR DESCRIPTION
This correctly shutdown php runtime when there is a panic (like a failed test) inside the embed sapi, otherwise a panic would cause a segfault (since php runtime is not correctly shutdown)