### PR TITLE
feat(zend): add helper for try catch and bailout in PHP

### DIFF
--- a/allowed_bindings.rs
+++ b/allowed_bindings.rs
@@ -261,5 +261,6 @@ bind! {
     zend_file_handle,
     zend_stream_init_filename,
     php_execute_script,
-    zend_register_module_ex
+    zend_register_module_ex,
+    _zend_bailout
 }

--- a/build.rs
+++ b/build.rs
@@ -248,6 +248,8 @@ fn main() -> Result<()> {
     for path in [
         manifest.join("src").join("wrapper.h"),
         manifest.join("src").join("wrapper.c"),
+        manifest.join("src").join("embed").join("embed.h"),
+        manifest.join("src").join("embed").join("embed.c"),
         manifest.join("allowed_bindings.rs"),
         manifest.join("windows_build.rs"),
         manifest.join("unix_build.rs"),

--- a/docsrs_bindings.rs
+++ b/docsrs_bindings.rs
@@ -790,6 +790,9 @@ pub struct _zend_class_entry__bindgen_ty_4__bindgen_ty_2 {
     pub module: *mut _zend_module_entry,
 }
 extern "C" {
+    pub fn _zend_bailout(filename: *const ::std::os::raw::c_char, lineno: u32) -> !;
+}
+extern "C" {
     pub static mut zend_interrupt_function:
         ::std::option::Option<unsafe extern "C" fn(execute_data: *mut zend_execute_data)>;
 }

--- a/src/embed/embed.c
+++ b/src/embed/embed.c
@@ -3,7 +3,7 @@
 // We actually use the PHP embed API to run PHP code in test
 // At some point we might want to use our own SAPI to do that
 void* ext_php_rs_embed_callback(int argc, char** argv, void* (*callback)(void *), void *ctx) {
-  void *result;
+  void *result = NULL;
 
   PHP_EMBED_START_BLOCK(argc, argv)
 

--- a/src/embed/ffi.rs
+++ b/src/embed/ffi.rs
@@ -10,7 +10,7 @@ extern "C" {
     pub fn ext_php_rs_embed_callback(
         argc: c_int,
         argv: *mut *mut c_char,
-        func: unsafe extern "C" fn(*const c_void) -> *mut c_void,
+        func: unsafe extern "C" fn(*const c_void) -> *const c_void,
         ctx: *const c_void,
     ) -> *mut c_void;
 }

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -111,7 +111,7 @@ impl Embed {
     ///    assert_eq!(foo.unwrap().string().unwrap(), "foo");
     /// });
     /// ```
-    pub fn run<R, F: Fn() -> R + RefUnwindSafe>(func: F) -> R
+    pub fn run<R, F: FnMut() -> R + RefUnwindSafe>(func: F) -> R
     where
         R: Default,
     {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -26,6 +26,12 @@ extern "C" {
     pub fn ext_php_rs_zend_object_alloc(obj_size: usize, ce: *mut zend_class_entry) -> *mut c_void;
     pub fn ext_php_rs_zend_object_release(obj: *mut zend_object);
     pub fn ext_php_rs_executor_globals() -> *mut zend_executor_globals;
+    pub fn ext_php_rs_zend_try_catch(
+        func: unsafe extern "C" fn(*const c_void) -> *const c_void,
+        ctx: *const c_void,
+        result: *mut *mut c_void,
+    ) -> bool;
+    pub fn ext_php_rs_zend_bailout();
 }
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -31,7 +31,7 @@ extern "C" {
         ctx: *const c_void,
         result: *mut *mut c_void,
     ) -> bool;
-    pub fn ext_php_rs_zend_bailout();
+    pub fn ext_php_rs_zend_bailout() -> !;
 }
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -39,3 +39,17 @@ zend_executor_globals *ext_php_rs_executor_globals() {
   return &executor_globals;
 #endif
 }
+
+bool ext_php_rs_zend_try_catch(void* (*callback)(void *), void *ctx, void **result) {
+  zend_try {
+    *result = callback(ctx);
+  } zend_catch {
+    return true;
+  } zend_end_try();
+
+  return false;
+}
+
+void ext_php_rs_zend_bailout() {
+  zend_bailout();
+}

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -31,3 +31,5 @@ const char *ext_php_rs_php_build_id();
 void *ext_php_rs_zend_object_alloc(size_t obj_size, zend_class_entry *ce);
 void ext_php_rs_zend_object_release(zend_object *obj);
 zend_executor_globals *ext_php_rs_executor_globals();
+bool ext_php_rs_zend_try_catch(void* (*callback)(void *), void *ctx, void **result);
+void ext_php_rs_zend_bailout();

--- a/src/zend/mod.rs
+++ b/src/zend/mod.rs
@@ -23,6 +23,7 @@ pub use globals::ExecutorGlobals;
 pub use handlers::ZendObjectHandlers;
 pub use ini_entry_def::IniEntryDef;
 pub use module::ModuleEntry;
+#[cfg(feature = "embed")]
 pub(crate) use try_catch::panic_wrapper;
 pub use try_catch::{bailout, try_catch};
 

--- a/src/zend/mod.rs
+++ b/src/zend/mod.rs
@@ -9,6 +9,7 @@ mod globals;
 mod handlers;
 mod ini_entry_def;
 mod module;
+mod try_catch;
 
 use crate::{error::Result, ffi::php_printf};
 use std::ffi::CString;
@@ -22,6 +23,8 @@ pub use globals::ExecutorGlobals;
 pub use handlers::ZendObjectHandlers;
 pub use ini_entry_def::IniEntryDef;
 pub use module::ModuleEntry;
+pub(crate) use try_catch::panic_wrapper;
+pub use try_catch::{bailout, try_catch};
 
 // Used as the format string for `php_printf`.
 const FORMAT_STR: &[u8] = b"%s\0";

--- a/src/zend/try_catch.rs
+++ b/src/zend/try_catch.rs
@@ -62,6 +62,7 @@ pub fn bailout() {
     }
 }
 
+#[cfg(feature = "embed")]
 #[cfg(test)]
 mod tests {
     use crate::embed::Embed;

--- a/src/zend/try_catch.rs
+++ b/src/zend/try_catch.rs
@@ -64,7 +64,7 @@ pub fn try_catch<R, F: FnMut() -> R + RefUnwindSafe>(func: F) -> Result<R, Catch
 ///
 /// When using this function you should ensure that all the memory allocated in the current scope is released
 ///
-pub unsafe fn bailout() {
+pub unsafe fn bailout() -> ! {
     ext_php_rs_zend_bailout();
 }
 
@@ -83,7 +83,10 @@ mod tests {
                     bailout();
                 }
 
-                assert!(false);
+                #[allow(unreachable_code)]
+                {
+                    assert!(false);
+                }
             });
 
             assert!(catch.is_err());
@@ -108,7 +111,10 @@ mod tests {
                 bailout();
             }
 
-            assert!(false);
+            #[allow(unreachable_code)]
+            {
+                assert!(false);
+            }
         });
     }
 

--- a/src/zend/try_catch.rs
+++ b/src/zend/try_catch.rs
@@ -1,0 +1,126 @@
+use crate::ffi::{ext_php_rs_zend_bailout, ext_php_rs_zend_try_catch};
+use std::ffi::c_void;
+use std::panic::{catch_unwind, resume_unwind, RefUnwindSafe};
+use std::ptr::null_mut;
+
+#[derive(Debug)]
+pub struct CatchError;
+
+pub(crate) unsafe extern "C" fn panic_wrapper<R, F: Fn() -> R + RefUnwindSafe>(
+    ctx: *const c_void,
+) -> *const c_void {
+    // we try to catch panic here so we correctly shutdown php if it happens
+    // mandatory when we do assert on test as other test would not run correctly
+    let panic = catch_unwind(|| (*(ctx as *const F))());
+
+    Box::into_raw(Box::new(panic)) as *mut c_void
+}
+
+/// PHP propose a try catch mechanism in C using setjmp and longjmp (bailout)
+/// It store the arg of setjmp into the bailout field of the global executor
+/// If a bailout is triggered, the executor will jump to the setjmp and restore the previous setjmp
+///
+/// try_catch allow to use this mechanism
+///
+/// # Returns
+///
+/// * `Ok(R)` - The result of the function
+/// * `Err(CatchError)` - A bailout occurred during the execution
+pub fn try_catch<R, F: Fn() -> R + RefUnwindSafe>(func: F) -> Result<R, CatchError> {
+    let mut panic_ptr = null_mut();
+    let has_bailout = unsafe {
+        ext_php_rs_zend_try_catch(
+            panic_wrapper::<R, F>,
+            &func as *const F as *const c_void,
+            (&mut panic_ptr) as *mut *mut c_void,
+        )
+    };
+
+    let panic = panic_ptr as *mut std::thread::Result<R>;
+
+    // can be null if there is a bailout
+    if panic.is_null() || has_bailout {
+        return Err(CatchError);
+    }
+
+    match unsafe { *Box::from_raw(panic as *mut std::thread::Result<R>) } {
+        Ok(r) => Ok(r),
+        Err(err) => {
+            // we resume the panic here so it can be catched correctly by the test framework
+            resume_unwind(err);
+        }
+    }
+}
+
+/// Trigger a bailout
+///
+/// This function will stop the execution of the current script
+/// and jump to the last try catch block
+pub fn bailout() {
+    unsafe {
+        ext_php_rs_zend_bailout();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::embed::Embed;
+    use crate::zend::{bailout, try_catch};
+
+    #[test]
+    fn test_catch() {
+        Embed::run(|| {
+            let catch = try_catch(|| {
+                bailout();
+                assert!(false);
+            });
+
+            assert!(catch.is_err());
+        });
+    }
+
+    #[test]
+    fn test_no_catch() {
+        Embed::run(|| {
+            let catch = try_catch(|| {
+                assert!(true);
+            });
+
+            assert!(catch.is_ok());
+        });
+    }
+
+    #[test]
+    fn test_bailout() {
+        Embed::run(|| {
+            bailout();
+
+            assert!(false);
+        });
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_panic() {
+        Embed::run(|| {
+            let _ = try_catch(|| {
+                panic!("should panic");
+            });
+        });
+    }
+
+    #[test]
+    fn test_return() {
+        let foo = Embed::run(|| {
+            let result = try_catch(|| {
+                return "foo";
+            });
+
+            assert!(result.is_ok());
+
+            result.unwrap()
+        });
+
+        assert_eq!(foo, "foo");
+    }
+}


### PR DESCRIPTION
This should allow extension to wrap their code under the try catch mechanism of PHP