### PR TITLE
Forward ClassEntry in create_object

### DIFF
--- a/src/builders/class.rs
+++ b/src/builders/class.rs
@@ -161,10 +161,10 @@ impl ClassBuilder {
     /// Panics if the class name associated with `T` is not the same as the
     /// class name specified when creating the builder.
     pub fn object_override<T: RegisteredClass>(mut self) -> Self {
-        extern "C" fn create_object<T: RegisteredClass>(_: *mut ClassEntry) -> *mut ZendObject {
+        extern "C" fn create_object<T: RegisteredClass>(ce: *mut ClassEntry) -> *mut ZendObject {
             // SAFETY: After calling this function, PHP will always call the constructor
             // defined below, which assumes that the object is uninitialized.
-            let obj = unsafe { ZendClassObject::<T>::new_uninit() };
+            let obj = unsafe { ZendClassObject::<T>::new_uninit(ce.as_ref()) };
             obj.into_raw().get_mut_zend_obj()
         }
 

--- a/src/types/class_object.rs
+++ b/src/types/class_object.rs
@@ -14,8 +14,8 @@ use crate::{
     convert::{FromZendObject, FromZendObjectMut, FromZval, FromZvalMut, IntoZval},
     error::{Error, Result},
     ffi::{
-        _zend_class_entry, ext_php_rs_zend_object_alloc, ext_php_rs_zend_object_release,
-        object_properties_init, zend_object, zend_object_std_init, zend_objects_clone_members,
+        ext_php_rs_zend_object_alloc, ext_php_rs_zend_object_release, object_properties_init,
+        zend_object, zend_object_std_init, zend_objects_clone_members,
     },
     flags::DataType,
     types::{ZendObject, Zval},

--- a/src/types/class_object.rs
+++ b/src/types/class_object.rs
@@ -14,11 +14,12 @@ use crate::{
     convert::{FromZendObject, FromZendObjectMut, FromZval, FromZvalMut, IntoZval},
     error::{Error, Result},
     ffi::{
-        ext_php_rs_zend_object_alloc, ext_php_rs_zend_object_release, object_properties_init,
-        zend_object, zend_object_std_init, zend_objects_clone_members, _zend_class_entry,
+        _zend_class_entry, ext_php_rs_zend_object_alloc, ext_php_rs_zend_object_release,
+        object_properties_init, zend_object, zend_object_std_init, zend_objects_clone_members,
     },
     flags::DataType,
-    types::{ZendObject, Zval}, zend::ClassEntry,
+    types::{ZendObject, Zval},
+    zend::ClassEntry,
 };
 
 /// Representation of a Zend class object in memory.
@@ -105,7 +106,7 @@ impl<T: RegisteredClass> ZendClassObject<T> {
     unsafe fn internal_new(val: Option<T>, ce: Option<&'static ClassEntry>) -> ZBox<Self> {
         let size = mem::size_of::<ZendClassObject<T>>();
         let meta = T::get_metadata();
-        let ce = ce.unwrap_or_else(||meta.ce()) as *const _ as *mut _;
+        let ce = ce.unwrap_or_else(|| meta.ce()) as *const _ as *mut _;
         let obj = ext_php_rs_zend_object_alloc(size as _, ce) as *mut ZendClassObject<T>;
         let obj = obj
             .as_mut()

--- a/src/types/class_object.rs
+++ b/src/types/class_object.rs
@@ -167,7 +167,7 @@ impl<T: RegisteredClass> ZendClassObject<T> {
             (ptr as *mut Self).as_mut()?
         };
 
-        if ptr.std.is_instance::<T>() {
+        if ptr.std.instance_of(T::get_metadata().ce()) {
             Some(ptr)
         } else {
             None

--- a/src/zend/handlers.rs
+++ b/src/zend/handlers.rs
@@ -52,13 +52,13 @@ impl ZendObjectHandlers {
     }
 
     unsafe extern "C" fn free_obj<T: RegisteredClass>(object: *mut ZendObject) {
-        let obj = object
+        object
             .as_mut()
             .and_then(|obj| ZendClassObject::<T>::from_zend_obj_mut(obj))
-            .expect("Invalid object pointer given for `free_obj`");
+            .map(|obj|ptr::drop_in_place(&mut obj.obj));
 
         // Manually drop the object as we don't want to free the underlying memory.
-        ptr::drop_in_place(&mut obj.obj);
+
 
         zend_object_std_dtor(object)
     }

--- a/src/zend/handlers.rs
+++ b/src/zend/handlers.rs
@@ -52,13 +52,13 @@ impl ZendObjectHandlers {
     }
 
     unsafe extern "C" fn free_obj<T: RegisteredClass>(object: *mut ZendObject) {
-        object
+        let obj = object
             .as_mut()
             .and_then(|obj| ZendClassObject::<T>::from_zend_obj_mut(obj))
-            .map(|obj|ptr::drop_in_place(&mut obj.obj));
+            .expect("Invalid object pointer given for `free_obj`");
 
         // Manually drop the object as we don't want to free the underlying memory.
-
+        ptr::drop_in_place(&mut obj.obj);
 
         zend_object_std_dtor(object)
     }


### PR DESCRIPTION
See #138

The `ce` should be taken from the `create_object`. From that point on, everything else can carry on just about normal. the only thing that needs to change is the sanity check to make sure the `ClassEntry` for the object passed to the object handlers is a child as well as the direct class.