### PR TITLE
feat(bindings): add bindings for cached function calls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
           key: ${{ matrix.os }}-llvm-${{ matrix.clang }}
       - name: Setup LLVM & Clang
         id: clang
-        uses: KyleMayes/install-llvm-action@v1
+        uses: KyleMayes/install-llvm-action@v2
         if: "!contains(matrix.os, 'windows')"
         with:
           version: ${{ matrix.clang }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           version: ${{ matrix.clang }}
           directory: ${{ runner.temp }}/llvm-${{ matrix.clang }}
+          arch: ${{ matrix.os == 'macos-latest' && 'arm64' || 'x64' }}
           cached: ${{ steps.cache-llvm.outputs.cache-hit }}
       - name: Configure Clang
         if: "!contains(matrix.os, 'windows')"

--- a/allowed_bindings.rs
+++ b/allowed_bindings.rs
@@ -56,6 +56,8 @@ bind! {
     std_object_handlers,
     zend_array_destroy,
     zend_array_dup,
+    zend_call_function,
+    zend_fcall_info_init,
     zend_call_known_function,
     zend_fetch_function_str,
     zend_hash_str_find_ptr_lc,


### PR DESCRIPTION
For my extension I need to perform a lot of callbacks.

Using fci (fcall_info) and fcc (fcall_info_cache) yielded ~10% performance improvement.

If I find the time Ill port it into this lib. For now I just added the bindings to be able to use them in my code directly.

You might need to check the `docrs_bindings.rs` as it seems there are more changes then there should be (maybe php version?). Mainly `u8` -> `u16`