### PR TITLE
fix: linter warnings

### DIFF
--- a/.github/actions/embed/Dockerfile
+++ b/.github/actions/embed/Dockerfile
@@ -10,6 +10,6 @@ ENV RUSTUP_HOME=/rust
 ENV CARGO_HOME=/cargo
 ENV PATH=/cargo/bin:/rust/bin:$PATH
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+RUN (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly --no-modify-path) && rustup default nightly
 
 ENTRYPOINT [ "/cargo/bin/cargo", "test", "--all", "--release", "--all-features", "--no-fail-fast" ]

--- a/build.rs
+++ b/build.rs
@@ -230,7 +230,7 @@ fn check_php_version(info: &PHPInfo) -> Result<()> {
 
     const PHP_83_API_VER: u32 = 20230831;
 
-    println!("cargo::rustc-check-cfg=cfg(php80, php81, php82, php83, php_zts, php_debug, docs)");
+    println!("cargo::rustc-check-cfg=cfg(php80, php81, php82, php83, php_zts, php_debug)");
     println!("cargo:rustc-cfg=php80");
 
     if (PHP_81_API_VER..PHP_82_API_VER).contains(&version) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
-#![cfg_attr(docs, feature(doc_cfg))]
+#![cfg_attr(doc, feature(doc_cfg))]
 #![cfg_attr(windows, feature(abi_vectorcall))]
 
 pub mod alloc;
@@ -20,8 +20,8 @@ pub mod flags;
 pub mod macros;
 pub mod boxed;
 pub mod class;
-#[cfg(any(docs, feature = "closure"))]
-#[cfg_attr(docs, doc(cfg(feature = "closure")))]
+#[cfg(any(doc, feature = "closure"))]
+#[cfg_attr(doc, doc(cfg(feature = "closure")))]
 pub mod closure;
 pub mod constant;
 pub mod describe;
@@ -39,8 +39,8 @@ pub mod zend;
 pub mod prelude {
 
     pub use crate::builders::ModuleBuilder;
-    #[cfg(any(docs, feature = "closure"))]
-    #[cfg_attr(docs, doc(cfg(feature = "closure")))]
+    #[cfg(any(doc, feature = "closure"))]
+    #[cfg_attr(doc, doc(cfg(feature = "closure")))]
     pub use crate::closure::Closure;
     pub use crate::exception::{PhpException, PhpResult};
     pub use crate::php_class;


### PR DESCRIPTION
When compiling the linter [complained ](https://github.com/jdrouet/ext-php-rs/actions/runs/10925975755/job/30328756324?pr=1#step:3:1490)that `php8x` was not defined. I fixed it using `rustc-check-cfg` as defined [here](https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html#cargorustc-check-cfg-for-buildrsbuild-script).

The compiler also [complained](https://github.com/jdrouet/ext-php-rs/actions/runs/10925975755/job/30328756324?pr=1#step:3:1384) that `cfg(docs)` was invalid. It's because it should be `cfg(doc)`. I updated that. After updating, the compiler mentioned that `feature(doc_cfg)` was only available in nightly so I update the embed Dockerfile to reflect that.