### PR TITLE
Don't use symbolic links for git.

### DIFF
--- a/crates/cli/.gitignore
+++ b/crates/cli/.gitignore
@@ -1,1 +1,6 @@
-../../.gitignore
+/target
+Cargo.lock
+/.vscode
+/.idea
+/tmp
+expand.rs

--- a/crates/macros/.gitignore
+++ b/crates/macros/.gitignore
@@ -1,1 +1,6 @@
-../../.gitignore
+/target
+Cargo.lock
+/.vscode
+/.idea
+/tmp
+expand.rs


### PR DESCRIPTION
When I ran `git status` I got this message:

```
warning: unable to access 'crates/macros/.gitignore': Too many levels of symbolic links
warning: unable to access 'crates/cli/.gitignore': Too many levels of symbolic links
```

Since git 2.23 `.gitignore` that is a symbolic link is ignored. I made them explicit now (though I'm not sure they're even needed)