### PR TITLE
Explicit preparation phase without STATE

### DIFF
--- a/crates/cli/.gitignore
+++ b/crates/cli/.gitignore
@@ -1,1 +1,6 @@
-../../.gitignore
+/target
+Cargo.lock
+/.vscode
+/.idea
+/tmp
+expand.rs

--- a/crates/macros/.gitignore
+++ b/crates/macros/.gitignore
@@ -1,1 +1,6 @@
-../../.gitignore
+/target
+Cargo.lock
+/.vscode
+/.idea
+/tmp
+expand.rs

--- a/crates/macros/src/constant.rs
+++ b/crates/macros/src/constant.rs
@@ -15,6 +15,13 @@ pub struct Constant {
     pub value: String,
 }
 
+fn prepare(input: ItemConst) -> Result<TokenStream> {
+    Ok(quote! {
+        #[allow(dead_code)]
+        #input
+    })
+}
+
 pub fn parser(input: ItemConst) -> Result<TokenStream> {
     let mut state = STATE.lock();
 
@@ -28,10 +35,7 @@ pub fn parser(input: ItemConst) -> Result<TokenStream> {
         value: input.expr.to_token_stream().to_string(),
     });
 
-    Ok(quote! {
-        #[allow(dead_code)]
-        #input
-    })
+    prepare(input)
 }
 
 impl Constant {

--- a/crates/macros/src/function.rs
+++ b/crates/macros/src/function.rs
@@ -40,12 +40,7 @@ pub struct Function {
     pub output: Option<(String, bool)>,
 }
 
-pub fn parser(args: AttributeArgs, input: ItemFn) -> Result<TokenStream> {
-    let attr_args = match AttrArgs::from_list(&args) {
-        Ok(args) => args,
-        Err(e) => bail!("Unable to parse attribute arguments: {:?}", e),
-    };
-
+fn prepare(attr_args: AttrArgs, input: ItemFn) -> Result<(TokenStream, Function)> {
     let ItemFn { sig, .. } = &input;
     let Signature {
         ident,
@@ -89,20 +84,37 @@ pub fn parser(args: AttributeArgs, input: ItemFn) -> Result<TokenStream> {
         }
     };
 
-    let mut state = STATE.lock();
-
-    if state.built_module && !attr_args.ignore_module {
-        bail!("The `#[php_module]` macro must be called last to ensure functions are registered. To ignore this error, pass the `ignore_module` option into this attribute invocation: `#[php_function(ignore_module)]`");
-    }
+    let name = if let Some(name) = attr_args.name {
+        name
+    } else {
+        ident.to_string()
+    };
 
     let function = Function {
-        name: attr_args.name.unwrap_or_else(|| ident.to_string()),
+        name,
         docs: get_docs(&input.attrs),
         ident: internal_ident.to_string(),
         args,
         optional,
         output: return_type,
     };
+
+    Ok((func, function))
+}
+
+pub fn parser(args: AttributeArgs, input: ItemFn) -> Result<TokenStream> {
+    let attr_args = match AttrArgs::from_list(&args) {
+        Ok(args) => args,
+        Err(e) => bail!("Unable to parse attribute arguments: {:?}", e),
+    };
+    let ignore_module = attr_args.ignore_module;
+    let (func, function) = prepare(attr_args, input)?;
+
+    let mut state = STATE.lock();
+
+    if state.built_module && !ignore_module {
+        bail!("The `#[php_module]` macro must be called last to ensure functions are registered. To ignore this error, pass the `ignore_module` option into this attribute invocation: `#[php_function(ignore_module)]`");
+    }
 
     state.functions.push(function.clone());
 

--- a/crates/macros/src/function.rs
+++ b/crates/macros/src/function.rs
@@ -40,7 +40,7 @@ pub struct Function {
     pub output: Option<(String, bool)>,
 }
 
-pub fn parser(args: AttributeArgs, input: ItemFn) -> Result<(TokenStream, Function)> {
+pub fn parser(args: AttributeArgs, input: ItemFn) -> Result<TokenStream> {
     let attr_args = match AttrArgs::from_list(&args) {
         Ok(args) => args,
         Err(e) => bail!("Unable to parse attribute arguments: {:?}", e),
@@ -106,7 +106,7 @@ pub fn parser(args: AttributeArgs, input: ItemFn) -> Result<(TokenStream, Functi
 
     state.functions.push(function.clone());
 
-    Ok((func, function))
+    Ok(func)
 }
 
 fn build_args(

--- a/crates/macros/src/impl_.rs
+++ b/crates/macros/src/impl_.rs
@@ -5,6 +5,7 @@ use quote::quote;
 use std::collections::HashMap;
 use syn::{Attribute, AttributeArgs, ItemImpl, Lit, Meta, NestedMeta};
 
+use crate::class::Class;
 use crate::helpers::get_docs;
 use crate::{
     class::{Property, PropertyAttr},
@@ -94,10 +95,12 @@ pub enum PropAttrTy {
     Setter,
 }
 
-pub fn parser(args: AttributeArgs, input: ItemImpl) -> Result<TokenStream> {
-    let args = AttrArgs::from_list(&args)
-        .map_err(|e| anyhow!("Unable to parse attribute arguments: {:?}", e))?;
-
+// note: this takes a mutable argument as it mutates a class
+fn prepare(
+    args: AttrArgs,
+    input: ItemImpl,
+    classes: &mut HashMap<String, Class>,
+) -> Result<TokenStream> {
     let ItemImpl { self_ty, items, .. } = input;
     let class_name = self_ty.to_token_stream().to_string();
 
@@ -105,15 +108,7 @@ pub fn parser(args: AttributeArgs, input: ItemImpl) -> Result<TokenStream> {
         bail!("This macro cannot be used on trait implementations.");
     }
 
-    let mut state = crate::STATE.lock();
-
-    if state.startup_function.is_some() {
-        bail!(
-            "Impls must be declared before you declare your startup function and module function."
-        );
-    }
-
-    let class = state.classes.get_mut(&class_name).ok_or_else(|| {
+    let class = classes.get_mut(&class_name).ok_or_else(|| {
         anyhow!(
             "You must use `#[php_class]` on the struct before using this attribute on the impl."
         )
@@ -176,6 +171,21 @@ pub fn parser(args: AttributeArgs, input: ItemImpl) -> Result<TokenStream> {
     };
 
     Ok(output)
+}
+
+pub fn parser(args: AttributeArgs, input: ItemImpl) -> Result<TokenStream> {
+    let args = AttrArgs::from_list(&args)
+        .map_err(|e| anyhow!("Unable to parse attribute arguments: {:?}", e))?;
+
+    let mut state = crate::STATE.lock();
+
+    if state.startup_function.is_some() {
+        bail!(
+            "Impls must be declared before you declare your startup function and module function."
+        );
+    }
+
+    prepare(args, input, &mut state.classes)
 }
 
 pub fn parse_attribute(attr: &Attribute) -> Result<Option<ParsedAttribute>> {

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -69,7 +69,7 @@ pub fn php_function(args: TokenStream, input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemFn);
 
     match function::parser(args, input) {
-        Ok((parsed, _)) => parsed,
+        Ok(parsed) => parsed,
         Err(e) => syn::Error::new(Span::call_site(), e).to_compile_error(),
     }
     .into()

--- a/crates/macros/src/startup_function.rs
+++ b/crates/macros/src/startup_function.rs
@@ -61,7 +61,7 @@ pub fn parser(args: Option<AttributeArgs>, input: ItemFn) -> Result<TokenStream>
     Ok(func)
 }
 
-fn generate_class(name: &str, class: &Class) -> Result<TokenStream> {
+fn class_tokenstream(name: &str, class: &Class) -> Result<TokenStream> {
     let class_name = &class.class_name;
     let ident = Ident::new(name, Span::call_site());
     let methods = class.methods.iter().map(|method| {
@@ -179,7 +179,7 @@ fn build_classes(classes: &HashMap<String, Class>) -> Result<Vec<TokenStream>> {
             let meta = Ident::new(&format!("_{name}_META"), Span::call_site());
 
             let class_name = &class.class_name;
-            let generated = generate_class(name, class)?;
+            let generated = class_tokenstream(name, class)?;
 
             Ok(quote! {{
                 #generated

--- a/crates/macros/src/startup_function.rs
+++ b/crates/macros/src/startup_function.rs
@@ -61,120 +61,128 @@ pub fn parser(args: Option<AttributeArgs>, input: ItemFn) -> Result<TokenStream>
     Ok(func)
 }
 
+fn generate_class(name: &str, class: &Class) -> Result<TokenStream> {
+    let class_name = &class.class_name;
+    let ident = Ident::new(name, Span::call_site());
+    let methods = class.methods.iter().map(|method| {
+        let builder = method.get_builder(&ident);
+        let flags = method.get_flags();
+        quote! { .method(#builder.unwrap(), #flags) }
+    });
+    let constants = class.constants.iter().map(|constant| {
+        let name = &constant.name;
+        let val = constant.val_tokens();
+        quote! { .constant(#name, #val).unwrap() }
+    });
+    let parent = {
+        if let Some(parent) = &class.parent {
+            let expr: Expr = syn::parse_str(parent)
+                .map_err(|_| anyhow!("Invalid expression given for `{}` parent", class_name))?;
+            Some(quote! { .extends(#expr) })
+        } else {
+            None
+        }
+    };
+    let interfaces = class
+        .interfaces
+        .iter()
+        .map(|interface| {
+            let expr: Expr = syn::parse_str(interface).map_err(|_| {
+                anyhow!(
+                    "Invalid expression given for `{}` interface: `{}`",
+                    class_name,
+                    interface
+                )
+            })?;
+            Ok(quote! { .implements(#expr) })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    // TODO(david): register properties for reflection (somehow)
+    // let properties = class
+    //     .properties
+    //     .iter()
+    //     .map(|(name, (default, flags))| {
+    //         let default_expr: Expr = syn::parse_str(default).map_err(|_| {
+    //             anyhow!(
+    //                 "Invalid default value given for property `{}` type: `{}`",
+    //                 name,
+    //                 default
+    //             )
+    //         })?;
+    //         let flags_expr: Expr = syn::parse_str(
+    //             flags
+    //                 .as_ref()
+    //                 .map(|flags| flags.as_str())
+    //                 .unwrap_or("PropertyFlags::Public"),
+    //         )
+    //         .map_err(|_| {
+    //             anyhow!(
+    //                 "Invalid default value given for property `{}` type: `{}`",
+    //                 name,
+    //                 default
+    //             )
+    //         })?;
+
+    //         Ok(quote! { .property(#name, #default_expr, #flags_expr) })
+    //     })
+    //     .collect::<Result<Vec<_>>>()?;
+    let class_modifier = class.modifier.as_ref().map(|modifier| {
+        let modifier = Ident::new(modifier, Span::call_site());
+        quote! {
+            let builder = #modifier(builder).expect(concat!("Failed to build class ", #class_name));
+        }
+    });
+
+    let flags = {
+        if let Some(flags) = &class.flags {
+            let mut name = "::ext_php_rs::flags::ClassFlags::".to_owned();
+            name.push_str(flags);
+            let expr: Expr = syn::parse_str(&name)
+                .map_err(|_| anyhow!("Invalid expression given for `{}` flags", class_name))?;
+            Some(quote! { .flags(#expr) })
+        } else {
+            None
+        }
+    };
+
+    let object_override = {
+        if let Some(flags) = &class.flags {
+            if flags == "Interface" {
+                None
+            } else {
+                Some(quote! { .object_override::<#ident>() })
+            }
+        } else {
+            Some(quote! { .object_override::<#ident>() })
+        }
+    };
+
+    Ok(quote! {
+        let builder = ::ext_php_rs::builders::ClassBuilder::new(#class_name)
+            #(#methods)*
+            #(#constants)*
+            #(#interfaces)*
+            // #(#properties)*
+            #parent
+            #flags
+            #object_override
+            ;
+        #class_modifier
+    })
+}
+
 /// Returns a vector of `ClassBuilder`s for each class.
 fn build_classes(classes: &HashMap<String, Class>) -> Result<Vec<TokenStream>> {
     classes
         .iter()
         .map(|(name, class)| {
-            let Class { class_name, .. } = &class;
-            let ident = Ident::new(name, Span::call_site());
             let meta = Ident::new(&format!("_{name}_META"), Span::call_site());
-            let methods = class.methods.iter().map(|method| {
-                let builder = method.get_builder(&ident);
-                let flags = method.get_flags();
-                quote! { .method(#builder.unwrap(), #flags) }
-            });
-            let constants = class.constants.iter().map(|constant| {
-                let name = &constant.name;
-                let val = constant.val_tokens();
-                quote! { .constant(#name, #val).unwrap() }
-            });
-            let parent = {
-                if let Some(parent) = &class.parent {
-                    let expr: Expr = syn::parse_str(parent).map_err(|_| {
-                        anyhow!("Invalid expression given for `{}` parent", class_name)
-                    })?;
-                    Some(quote! { .extends(#expr) })
-                } else {
-                    None
-                }
-            };
-            let interfaces = class
-                .interfaces
-                .iter()
-                .map(|interface| {
-                    let expr: Expr = syn::parse_str(interface).map_err(|_| {
-                        anyhow!(
-                            "Invalid expression given for `{}` interface: `{}`",
-                            class_name,
-                            interface
-                        )
-                    })?;
-                    Ok(quote! { .implements(#expr) })
-                })
-                .collect::<Result<Vec<_>>>()?;
-            // TODO(david): register properties for reflection (somehow)
-            // let properties = class
-            //     .properties
-            //     .iter()
-            //     .map(|(name, (default, flags))| {
-            //         let default_expr: Expr = syn::parse_str(default).map_err(|_| {
-            //             anyhow!(
-            //                 "Invalid default value given for property `{}` type: `{}`",
-            //                 name,
-            //                 default
-            //             )
-            //         })?;
-            //         let flags_expr: Expr = syn::parse_str(
-            //             flags
-            //                 .as_ref()
-            //                 .map(|flags| flags.as_str())
-            //                 .unwrap_or("PropertyFlags::Public"),
-            //         )
-            //         .map_err(|_| {
-            //             anyhow!(
-            //                 "Invalid default value given for property `{}` type: `{}`",
-            //                 name,
-            //                 default
-            //             )
-            //         })?;
 
-            //         Ok(quote! { .property(#name, #default_expr, #flags_expr) })
-            //     })
-            //     .collect::<Result<Vec<_>>>()?;
-            let class_modifier = class.modifier.as_ref().map(|modifier| {
-                let modifier = Ident::new(modifier, Span::call_site());
-                quote! {
-                    let builder = #modifier(builder).expect(concat!("Failed to build class ", #class_name));
-                }
-            });
-
-            let flags = {
-                if let Some(flags) = &class.flags {
-                    let mut name = "::ext_php_rs::flags::ClassFlags::".to_owned();
-                    name.push_str(flags);
-                    let expr: Expr = syn::parse_str(&name).map_err(|_| {
-                        anyhow!("Invalid expression given for `{}` flags", class_name)
-                    })?;
-                    Some(quote! { .flags(#expr) })
-                } else {
-                    None
-                }
-            };
-
-            let object_override = {
-                if let Some(flags) = &class.flags {
-                    if  flags == "Interface" {
-                        None
-                    } else {
-                        Some(quote! { .object_override::<#ident>() })
-                    }
-                } else {
-                    Some(quote! { .object_override::<#ident>() })
-                }
-            };
+            let class_name = &class.class_name;
+            let generated = generate_class(name, class)?;
 
             Ok(quote! {{
-                let builder = ::ext_php_rs::builders::ClassBuilder::new(#class_name)
-                    #(#methods)*
-                    #(#constants)*
-                    #(#interfaces)*
-                    // #(#properties)*
-                    #parent
-                    #flags
-                    #object_override
-                    ;
-                #class_modifier
+                #generated
                 let class = builder.build()
                     .expect(concat!("Unable to build class `", #class_name, "`"));
 


### PR DESCRIPTION
State (through the static `STATE`) is modified and used throughout ext-php-rs, but it's giving rise to various problems during development - the order in which the run compiler runs things is not guaranteed, and it appears that at least in some cases (in rust analyzer?) the system gets confused. See #327. 

To make this go away, I want to introduce an explicit registration mode. This is a preparatory refactor (which should introduce no behavioral changes) to help go into this direction, unweaving STATE access and modification from generation of token streams. It doesn't do anything by itself, but hopefully clears the ground.

The next step would be to see whether we can defer building and registration to a later phase. In particular, the `ClassBuilder` `build` method registers as a side-effect, though the other builders don't appear to do so.

This is a step in the direction of #329