### PR TITLE
Allow optional variadic arguments for methods/functions

### DIFF
--- a/crates/macros/src/function.rs
+++ b/crates/macros/src/function.rs
@@ -188,7 +188,7 @@ pub fn build_arg_parser<'a>(
                 None
             });
 
-            if rest_optional && !arg.nullable && arg.default.is_none() {
+            if rest_optional && !arg.nullable && arg.default.is_none() && !arg.variadic {
                 bail!(
                     "Parameter `{}` must be a variant of `Option` or have a default value as it is optional.",
                     arg.name

--- a/src/types/zval.rs
+++ b/src/types/zval.rs
@@ -718,3 +718,18 @@ impl<'a> FromZvalMut<'a> for &'a mut Zval {
         Some(zval)
     }
 }
+
+impl<'a> FromZvalMut<'a> for &'a [&'a Zval] {
+    const TYPE: DataType = DataType::Array;
+
+    fn from_zval_mut(zval: &'a mut Zval) -> Option<Self> {
+        // Check if the input Zval is an array and convert it into a slice of references
+        if let Some(a) = zval.array(){
+            // Collect references to each element in the array
+            let slice: Vec<&'a Zval> = a.values().collect();
+            Some(Box::leak(slice.into_boxed_slice()))
+        } else {
+            None
+        }
+    }
+}


### PR DESCRIPTION
I was implementing the variadic arguments into our extension allow for the following signatures:
```php
// no arguments - impl 1
$client->query('SELECT * FROM Employees');

// one or more arguments
$client->query('SELECT * FROM Employees WHERE Employee_ID = ?', 1);
$client->query('SELECT * FROM Employees WHERE Employee_ID = ? OR Employee_ID = ?', 1, 2);
$client->query('SELECT * FROM Employees WHERE Employee_ID = ? OR Employee_ID = ?', [1, 2]);

// reference arguments - impl 2
$a = 1;
$client->query('SELECT * FROM Employees WHERE Employee_ID = ?', $a);
$b = [1, 2];
$client->query('SELECT * FROM Employees WHERE Employee_ID = ? OR Employee_ID = ?', $b);
$client->query('SELECT * FROM Employees WHERE Employee_ID = ? OR Employee_ID = ?', ...$b);
$client->query('SELECT * FROM Employees WHERE Employee_ID = ? OR Employee_ID = ?', ...[1, 2]);

```
This raised multiple issues for me:
1. "impl 1": macro `#[optional(params)]` parameter forces you to set defaults. But only literals are allowed, so `vec![], Vec::new(), None` etc. do not work.
2. "impl 1": `params: Option<&[&Zval]>` it worked.. kinda.. but raised 2 problems: 
   - only allowed referenced parameters/arguments via variables, dunno why.
   - removed `Option<...>`, and then this missed the implementation for `FromZvalMut` for `&[&Zval]`. So I added implementation, in the PR because its nice allow handle for `Option<&[&Zval]>`.
   
## Fixes
1. Resolved by checking when requiring defaults for optional arguments if its not variadic.
2. Resolved by adding the `FromZvalMut` implementation for `&[&Zval]`.