### PR TITLE
Windows build should try archives

### DIFF
--- a/windows_build.rs
+++ b/windows_build.rs
@@ -222,10 +222,8 @@ impl DevelPack {
             Ok(devpack_path)
         }
 
-        let is_archive = if version == "8.4.1" { false } else { true };
-
         download(&zip_name, false)
-            .or_else(|_| download(&zip_name, is_archive))
+            .or_else(|_| download(&zip_name, true))
             .map(DevelPack)
     }
 


### PR DESCRIPTION
Follow up to https://github.com/davidcole1340/ext-php-rs/pull/338

Windows bulds should check the releases page, and the archive, as it's not clear when they'll be moved by Microsoft.
