### PR TITLE
Windows - add a DEBUG build with debugging symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ best resource at the moment. This can be viewed at [docs.rs].
   bundled with Microsoft Visual Studio.
 - `cargo-php`'s stub generation feature does not work on Windows. Rewriting this
   functionality to be cross-platform is on the roadmap.
+- To build the application in `DEBUG` mode on Windows,
+  you must have a `PHP SDK` built with the `DEBUG` option enabled
+  and specify the `PHP_LIB` to the folder containing the lib files. 
+  For example: set `PHP_LIB=C:\php-sdk\php-dev\vc16\x64\php-8.3.13-src\x64\Debug_TS`.
 
 [vectorcall]: https://docs.microsoft.com/en-us/cpp/cpp/vectorcall?view=msvc-170
 

--- a/windows_build.rs
+++ b/windows_build.rs
@@ -234,13 +234,15 @@ impl DevelPack {
 
     /// Returns the path of the PHP library containing symbols for linking.
     pub fn php_lib(&self, is_debug: bool) -> PathBuf {
-
         let php_lib_path = std::env::var("PHP_LIB")
             .map(PathBuf::from)
             .unwrap_or_else(|_| self.0.join("lib"));
 
         if !php_lib_path.exists() {
-            panic!("Error: Specified PHP library path '{}' does not exist.", php_lib_path.display());
+            panic!(
+                "Error: Specified PHP library path '{}' does not exist.",
+                php_lib_path.display()
+            );
         }
 
         let candidates = if is_debug {
@@ -265,7 +267,10 @@ For example: set PHP_LIB=C:\php-sdk\php-dev\vc16\x64\php-8.3.13-src\x64\Debug_TS
                         php_lib_path.display()
                     )
                 } else {
-                    format!("Error: No suitable PHP library found in '{}'.", php_lib_path.display())
+                    format!(
+                        "Error: No suitable PHP library found in '{}'.",
+                        php_lib_path.display()
+                    )
                 }
             ))
     }

--- a/windows_build.rs
+++ b/windows_build.rs
@@ -253,22 +253,21 @@ impl DevelPack {
             .iter()
             .map(|lib| php_lib_path.join(lib))
             .find(|path| path.exists())
-            .unwrap_or_else(||
-                panic!(
-                    "{}",
-                    if is_debug {
-                        format!(
-                            r#"Error: No suitable PHP library found in '{}'.
+            .expect(&format!(
+                "{}",
+                if is_debug {
+                    format!(
+                        r#"Error: No suitable PHP library found in '{}'.
 To build the application in DEBUG mode on Windows,
 you must have a PHP SDK built with the DEBUG option enabled
 and specify the PHP_LIB to the folder containing the lib files.
 For example: set PHP_LIB=C:\php-sdk\php-dev\vc16\x64\php-8.3.13-src\x64\Debug_TS."#,
-                            php_lib_path.display()
-                        )
-                    } else {
-                        format!("Error: No suitable PHP library found in '{}'.", php_lib_path.display())
-                    }
-                ))
+                        php_lib_path.display()
+                    )
+                } else {
+                    format!("Error: No suitable PHP library found in '{}'.", php_lib_path.display())
+                }
+            ))
     }
 
     /// Returns a list of include paths to pass to the compiler.


### PR DESCRIPTION
This change enables the extension to be compiled correctly in debug mode.
The issue was that, in the default case, the builder attempted to use files from the PHP DEV PACK, which lacks debug symbols. This resulted in a linker error, as it couldn't find the emalloc functions (these have different signatures in DEBUG builds).

Solution:
* Add an environment variable `PHP_LIB`.
* Check if we are compiling in debug mode. If so, require this variable to be set. Otherwise, proceed as before.
* `PHP_LIB` must point to a built `PHP` instance. The library name is chosen as `php8ts_debug.lib`.

P.S. I tried to find a place in the documentation to add this, but I can't figure out where it should go. If you can provide details, I would certainly include it.