### PR TITLE
feat(sapi): add global module handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM php:zts-bullseye
+
+# Install rust
+RUN apt-get update && apt-get install -y curl clang
+
+# Add app user with uid 1000
+RUN useradd -m -u 1000 app
+USER app
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+ENV PATH="/home/app/.cargo/bin:${PATH}"

--- a/allowed_bindings.rs
+++ b/allowed_bindings.rs
@@ -307,6 +307,7 @@ bind! {
     _zend_bailout,
     sapi_startup,
     sapi_shutdown,
+    sapi_module,
     php_module_startup,
     php_module_shutdown,
     php_request_startup,

--- a/src/embed/sapi.rs
+++ b/src/embed/sapi.rs
@@ -1,15 +1,56 @@
 //! Builder and objects for creating modules in PHP. A module is the base of a
 //! PHP extension.
 
-use crate::ffi::sapi_module_struct;
+use crate::ffi::{sapi_module, sapi_module_struct};
 
 /// A Zend module entry, also known as an extension.
 pub type SapiModule = sapi_module_struct;
+
+pub fn set_global_module(module: SapiModule) {
+    // leak the module to the global scope
+    let module = Box::leak(Box::new(module));
+
+    unsafe {
+        sapi_module = *module;
+    }
+}
+
+pub fn get_global_module() -> Option<&'static SapiModule> {
+    let module = unsafe { &*&raw const sapi_module };
+
+    if module.name.is_null() {
+        return None;
+    }
+
+    Some(module)
+}
 
 impl SapiModule {
     /// Allocates the module entry on the heap, returning a pointer to the
     /// memory location. The caller is responsible for the memory pointed to.
     pub fn into_raw(self) -> *mut Self {
         Box::into_raw(Box::new(self))
+    }
+
+    pub fn name(&self) -> &str {
+        unsafe { std::ffi::CStr::from_ptr(self.name).to_str().unwrap() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::embed::Embed;
+    use super::*;
+
+    #[test]
+    fn test_get_global_module() {
+        Embed::run(|| {
+            let module = get_global_module();
+
+            assert!(module.is_some());
+            let module = module.unwrap();
+
+            assert_eq!(module.name(), "embed");
+        })
     }
 }

--- a/src/zend/try_catch.rs
+++ b/src/zend/try_catch.rs
@@ -105,7 +105,7 @@ pub unsafe fn bailout() -> ! {
 #[cfg(feature = "embed")]
 #[cfg(test)]
 mod tests {
-    use crate::embed::Embed;
+    use crate::embed::{ext_php_rs_sapi_startup, Embed};
     use crate::zend::{bailout, try_catch};
     use std::ptr::null_mut;
 
@@ -179,20 +179,22 @@ mod tests {
 
     #[test]
     fn test_memory_leak() {
-        let mut ptr = null_mut();
+        Embed::run(|| {
+            let mut ptr = null_mut();
 
-        let _ = try_catch(|| {
-            let mut result = "foo".to_string();
-            ptr = &mut result;
+            let _ = try_catch(|| {
+                let mut result = "foo".to_string();
+                ptr = &mut result;
 
-            unsafe {
-                bailout();
-            }
+                unsafe {
+                    bailout();
+                }
+            });
+
+            // Check that the string is never released
+            let result = unsafe { &*ptr as &str };
+
+            assert_eq!(result, "foo");
         });
-
-        // Check that the string is never released
-        let result = unsafe { &*ptr as &str };
-
-        assert_eq!(result, "foo");
     }
 }


### PR DESCRIPTION
Still a draft but i want to open this to discussion before going further.

I want to try what it would give to have a proper API for creating a SAPI module for PHP.

Current api is limited and was mainly for test.

The goal here would be to accept that there should only one SAPI at a time (even if we can shut it down properly and create it afterwards it does not really make sense as a feature, it's like having multiple main method)

In order to that i want to propose the following api : 

```rust
sapi::set_global_module(module: SapiModule) -> Result<(), SetSapiModuleError>;
sapi::get_global_module() -> Option<&'static SapiModule>;
```

`set_global_module` would set the global sapi_module variable and make the necessary step to initialize the module

I'm wondering if it should return a "guard" that would shutdown the module when dropped, or even lock installing a module ? (For me it's not necessary as long as we don't allow calling twice this function, otherwise it can be useful)

This method would throw an error if there is already an existing sapi module (at the moment i only check that the name is not null, not sure if there is a better way ?)

The `get_global_module` allow to retrieve the current installed sapi

Then someone could create a rust binary that act as a SAPI for PHP by doing something like : 

```rust
fn main() {
    let sapi_module = SapiBuilder::new("my-sapi", "My awesome sapi")
        ->build().expect("cannot build sapi module");
        
    ext_php_rs::embed::sapi::set_global_module(sapi_module).expect("cannot register sapi module");
    
    // we can now execute a php script safely
}
```
