### PR TITLE
feat(zts): set lock per thread on zts build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["/.github", "/.crates"]
 
 [dependencies]
 bitflags = "2"
-parking_lot = "0.12"
+parking_lot = { version = "0.12", features = ["arc_lock"] }
 cfg-if = "1.0"
 once_cell = "1.17"
 anyhow = { version = "1", optional = true }


### PR DESCRIPTION
Since on zts each thread gets its own globals (at the exception of sapi_module), i updated the lock to be on local thread (instead of static) so we can update / get globals without getting lock by another thread when in ZTS

