### PR TITLE
fix(macro): Add missing separator pipe in flags

### DIFF
--- a/crates/macros/src/impl_.rs
+++ b/crates/macros/src/impl_.rs
@@ -388,7 +388,7 @@ impl quote::ToTokens for FnBuilder {
             flags.push(quote! { ::ext_php_rs::flags::MethodFlags::Abstract });
         }
         quote! {
-            (#builder, #(#flags)*)
+            (#builder, #(#flags)|*)
         }
         .to_tokens(tokens);
     }


### PR DESCRIPTION
While impl interface registration, find error in proc macros php_impl
Is missing separator for quote