### PR TITLE
fix: Messing static flags in php_impl proc macro

### DIFF
--- a/tests/src/integration/class.php
+++ b/tests/src/integration/class.php
@@ -19,3 +19,12 @@ assert($class->getNumber() === 2023);
 assert($class->boolean);
 $class->boolean = false;
 assert($class->boolean === false);
+
+// Call regular from object
+assert($class->staticCall('Php') === 'Hello Php');
+
+// Call static from object
+assert($class::staticCall('Php') === 'Hello Php');
+
+// Call static from class
+assert(TestClass::staticCall('Php') === 'Hello Php');

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -210,6 +210,10 @@ impl TestClass {
     pub fn set_number(&mut self, number: i32) {
         self.number = number;
     }
+
+    pub fn static_call(name: String) -> String {
+        format!("Hello {name}")
+    }
 }
 
 #[php_function]


### PR DESCRIPTION
If try class static method from php it throws exception
```
Uncaught Error: Non-static method Test::staticTest()
```

Cause in proc_macros missing usage of MethodFlags::Static

```rust
#[php_class]
#[derive(Default)]
struct Test {}

#[php_impl]
impl Test {
    #[php(constructor)]
    fn new() -> Self {
        Self {}
    }
    /// Declare as static method
    fn static_test() -> String {
        String::from("Hello")
    }
}
```

```php
<?php

$t = new Test;
Test::staticTest(); // Get exception
```

In PR i change FnBuilder from single additional modifier with flag abstract to Vec<Modifier>, Myabe we should make uniq Vec, idk)