### PR TITLE
refac: Make rename as Trait && separate to common rename, method_rename

### DIFF
--- a/crates/macros/src/parsing.rs
+++ b/crates/macros/src/parsing.rs
@@ -118,14 +118,11 @@ impl MethodRename for &str {
             RenameRule::None => self.to_string(),
             _ => {
                 if MAGIC_METHOD.contains(self) {
-                    if self == &MAGIC_METHOD[12] {
-                        "__toString".to_string()
-                    } else if self == &MAGIC_METHOD[16] {
-                        "__debugInfo".to_string()
-                    } else if self == &MAGIC_METHOD[3] {
-                        "__callStatic".to_string()
-                    } else {
-                        self.to_string()
+                    match *self {
+                        "__to_string" => "__toString".to_string(),
+                        "__debug_info" => "__debugInfo".to_string(),
+                        "__call_static" => "__callStatic".to_string(),
+                        _ => self.to_string(),
                     }
                 } else {
                     self.rename(rule)

--- a/crates/macros/src/parsing.rs
+++ b/crates/macros/src/parsing.rs
@@ -114,12 +114,23 @@ impl MethodRename for syn::Ident {
 
 impl MethodRename for &str {
     fn rename_method(&self, rule: &RenameRule) -> String {
-        let s = self.to_string();
-
-        if MAGIC_METHOD.contains(&s.as_str()) {
-            s
-        } else {
-            self.rename(rule)
+        match rule {
+            RenameRule::None => self.to_string(),
+            _ => {
+                if MAGIC_METHOD.contains(self) {
+                    if self == &MAGIC_METHOD[12] {
+                        "__toString".to_string()
+                    } else if self == &MAGIC_METHOD[16] {
+                        "__debugInfo".to_string()
+                    } else if self == &MAGIC_METHOD[3] {
+                        "__callStatic".to_string()
+                    } else {
+                        self.to_string()
+                    }
+                } else {
+                    self.rename(rule)
+                }
+            }
         }
     }
 }

--- a/crates/macros/src/parsing.rs
+++ b/crates/macros/src/parsing.rs
@@ -167,12 +167,33 @@ mod tests {
 
     #[test]
     fn rename_magic_method() {
-        for magic in MAGIC_METHOD {
+        for &(magic, expected) in &[
+            ("__construct", "__construct"),
+            ("__destruct", "__destruct"),
+            ("__call", "__call"),
+            ("__call_static", "__callStatic"),
+            ("__get", "__get"),
+            ("__set", "__set"),
+            ("__isset", "__isset"),
+            ("__unset", "__unset"),
+            ("__sleep", "__sleep"),
+            ("__wakeup", "__wakeup"),
+            ("__serialize", "__serialize"),
+            ("__unserialize", "__unserialize"),
+            ("__to_string", "__toString"),
+            ("__invoke", "__invoke"),
+            ("__set_state", "__set_state"),
+            ("__clone", "__clone"),
+            ("__debug_info", "__debugInfo"),
+        ] {
             assert_eq!(magic, magic.rename_method(&RenameRule::None));
-            assert_eq!(magic, magic.rename_method(&RenameRule::Camel));
-            assert_eq!(magic, magic.rename_method(&RenameRule::Pascal));
-            assert_eq!(magic, magic.rename_method(&RenameRule::Snake));
-            assert_eq!(magic, magic.rename_method(&RenameRule::ScreamingSnakeCase));
+            assert_eq!(expected, magic.rename_method(&RenameRule::Camel));
+            assert_eq!(expected, magic.rename_method(&RenameRule::Pascal));
+            assert_eq!(expected, magic.rename_method(&RenameRule::Snake));
+            assert_eq!(
+                expected,
+                magic.rename_method(&RenameRule::ScreamingSnakeCase)
+            );
         }
     }
 

--- a/tests/src/integration/magic_method.php
+++ b/tests/src/integration/magic_method.php
@@ -1,0 +1,37 @@
+<?php
+
+$magicMethod = new MagicMethod();
+
+// __set
+$magicMethod->count = 10;
+// __get
+assert(10 === $magicMethod->count);
+assert(null === $magicMethod->test);
+
+//__isset
+assert(true === isset($magicMethod->count));
+assert(false === isset($magicMethod->noCount));
+
+// __unset
+unset($magicMethod->count);
+assert(0 === $magicMethod->count);
+
+// __toString
+assert("0" === $magicMethod->__toString());
+assert("0" === (string) $magicMethod);
+
+// __invoke
+assert(34 === $magicMethod(34));
+
+// __debugInfo
+$debug = print_r($magicMethod, true);
+$expectedDebug = "MagicMethod Object\n(\n    [count] => 0\n)\n";
+assert($expectedDebug === $debug);
+
+// __call
+assert("Hello" === $magicMethod->callMagicMethod(1, 2, 3));
+assert(null === $magicMethod->callUndefinedMagicMethod());
+
+// __call_static
+assert("Hello from static call 1 2 3" === MagicMethod::callStaticSomeMagic(1, 2, 3));
+assert(null === MagicMethod::callUndefinedStaticSomeMagic());

--- a/tests/src/integration/magic_method.php
+++ b/tests/src/integration/magic_method.php
@@ -33,5 +33,5 @@ assert("Hello" === $magicMethod->callMagicMethod(1, 2, 3));
 assert(null === $magicMethod->callUndefinedMagicMethod());
 
 // __call_static
-assert("Hello from static call 1 2 3" === MagicMethod::callStaticSomeMagic(1, 2, 3));
+assert("Hello from static call 6" === MagicMethod::callStaticSomeMagic(1, 2, 3));
 assert(null === MagicMethod::callUndefinedStaticSomeMagic());

--- a/tests/src/integration/magic_method.rs
+++ b/tests/src/integration/magic_method.rs
@@ -1,0 +1,4 @@
+#[test]
+fn magic_method() {
+    assert!(crate::integration::run_php("magic_method.php"));
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -257,9 +257,10 @@ impl MagicMethod {
                 arguments
                     .iter()
                     .filter(|(_, v)| v.is_long())
-                    .map(|(_, s)| s.long().unwrap().to_string())
+                    .map(|(_, s)| s.long().unwrap())
                     .collect::<Vec<_>>()
-                    .join(" ")
+                    .iter()
+                    .sum::<i64>()
             );
 
             let _ = zval.set_string(&concat_args, false);

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -225,10 +225,100 @@ pub fn test_class(string: String, number: i32) -> TestClass {
     }
 }
 
+#[php_class]
+pub struct MagicMethod(i64);
+
+#[php_impl]
+impl MagicMethod {
+    pub fn __construct() -> Self {
+        Self(0)
+    }
+
+    pub fn __destruct(&self) {}
+
+    pub fn __call(&self, name: String, _arguments: HashMap<String, &Zval>) -> Zval {
+        let mut z = Zval::new();
+        if name == "callMagicMethod" {
+            let s = "Hello".to_string();
+
+            let _ = z.set_string(s.as_str(), false);
+            z
+        } else {
+            z.set_null();
+            z
+        }
+    }
+
+    pub fn __call_static(name: String, arguments: HashMap<String, &Zval>) -> Zval {
+        let mut zval = Zval::new();
+        if name == "callStaticSomeMagic" {
+            let concat_args = format!(
+                "Hello from static call {}",
+                arguments
+                    .iter()
+                    .filter(|(_, v)| v.is_long())
+                    .map(|(_, s)| s.long().unwrap().to_string())
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            );
+
+            let _ = zval.set_string(&concat_args, false);
+            zval
+        } else {
+            zval.set_null();
+            zval
+        }
+    }
+
+    pub fn __get(&self, name: String) -> Zval {
+        let mut v = Zval::new();
+        v.set_null();
+        if name == "count" {
+            v.set_long(self.0);
+        }
+
+        v
+    }
+
+    pub fn __set(&mut self, prop_name: String, val: &Zval) {
+        if val.is_long() && prop_name == "count" {
+            self.0 = val.long().unwrap()
+        }
+    }
+
+    pub fn __isset(&self, prop_name: String) -> bool {
+        "count" == prop_name
+    }
+
+    pub fn __unset(&mut self, prop_name: String) {
+        if prop_name == "count" {
+            self.0 = 0;
+        }
+    }
+
+    pub fn __to_string(&self) -> String {
+        self.0.to_string()
+    }
+
+    pub fn __invoke(&self, n: i64) -> i64 {
+        self.0 + n
+    }
+
+    pub fn __debug_info(&self) -> HashMap<String, Zval> {
+        let mut h: HashMap<String, Zval> = HashMap::new();
+        let mut z = Zval::new();
+        z.set_long(self.0);
+        h.insert("count".to_string(), z);
+
+        h
+    }
+}
+
 #[php_module]
 pub fn build_module(module: ModuleBuilder) -> ModuleBuilder {
     module
         .class::<TestClass>()
+        .class::<MagicMethod>()
         .function(wrap_function!(test_str))
         .function(wrap_function!(test_string))
         .function(wrap_function!(test_bool))
@@ -321,6 +411,7 @@ mod integration {
     mod closure;
     mod globals;
     mod iterator;
+    mod magic_method;
     mod nullable;
     mod number;
     mod object;


### PR DESCRIPTION
I see how you @Xenira changed renaming, maybe change it to trait for common rename things and method?