### PR TITLE
refactor(macro): use `#[php]` attribute for startup function

### DIFF
--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -499,10 +499,10 @@ pub fn php_const(_args: TokenStream, input: TokenStream) -> TokenStream {
 /// # fn main() {}
 /// ```
 #[proc_macro_attribute]
-pub fn php_module(args: TokenStream, input: TokenStream) -> TokenStream {
+pub fn php_module(_args: TokenStream, input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemFn);
 
-    module::parser(args.into(), input)
+    module::parser(input)
         .unwrap_or_else(|e| e.to_compile_error())
         .into()
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -76,7 +76,8 @@ fn startup(_ty: i32, mod_num: i32) -> i32 {
     0
 }
 
-#[php_module(startup = "startup")]
+#[php_module]
+#[php(startup = startup)]
 pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
     module
         .class::<TestClass>()

--- a/guide/src/ini-settings.md
+++ b/guide/src/ini-settings.md
@@ -27,7 +27,8 @@ pub fn startup(ty: i32, mod_num: i32) -> i32 {
     0
 }
 
-#[php_module(startup = "startup")]
+#[php_module]
+#[php(startup = "startup")]
 pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
     module
 }
@@ -54,7 +55,8 @@ pub fn startup(ty: i32, mod_num: i32) -> i32 {
     0
 }
 
-#[php_module(startup = "startup")]
+#[php_module]
+#[php(startup = "startup")]
 pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
     module
 }

--- a/guide/src/migration-guides/v0.14.md
+++ b/guide/src/migration-guides/v0.14.md
@@ -15,7 +15,8 @@ register functions, classes, constants and startup function when declaring
 the module.
 
 ```rs
-#[php_module(startup = "startup_function")]
+#[php_module]
+#[php(startup = "startup_function")]
 pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
     module
         .class::<TestClass>()
@@ -174,7 +175,8 @@ fn startup_function(ty: i32, mod_num: i32) -> i32 {
     0
 }
 
-#[php_module(startup = "startup_function")]
+#[php_module]
+#[php(startup = "startup_function")]
 pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
     module
 }


### PR DESCRIPTION
This unifies the behaviour of the `#[php_module]` macro and the other `#[php_*]` macros.

Refs: #423