### PR TITLE
Take only the first line of which/where when searching for php executable

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -60,7 +60,7 @@ pub fn find_executable(name: &str) -> Option<PathBuf> {
     let cmd = Command::new(WHICH).arg(name).output().ok()?;
     if cmd.status.success() {
         let stdout = String::from_utf8_lossy(&cmd.stdout);
-        Some(stdout.trim().into())
+        stdout.trim().lines().next().map(|l| l.trim().into())
     } else {
         None
     }


### PR DESCRIPTION
In windows, `where` command can return more than one line; this will cause the following error to be emitted when trying to invoke `php -i`:

```
The filename, directory name, or volume label syntax is incorrect. (os error 123)
```

This PR provides a fix for this error, taking only the first line of the output.