### PR TITLE
chore(macro)!: change rename defaults to match psr

### DIFF
--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -14,11 +14,11 @@ proc-macro = true
 [dependencies]
 syn = { version = "2.0.100", features = ["full", "extra-traits", "printing"] }
 darling = "0.20"
-ident_case = "1.0.1"
 quote = "1.0.9"
 proc-macro2 = "1.0.26"
 lazy_static = "1.4.0"
 anyhow = "1.0"
+convert_case = "0.8.0"
 
 [lints.rust]
 missing_docs = "warn"

--- a/crates/macros/src/class.rs
+++ b/crates/macros/src/class.rs
@@ -5,7 +5,7 @@ use quote::quote;
 use syn::{Attribute, Expr, Fields, ItemStruct};
 
 use crate::helpers::get_docs;
-use crate::parsing::PhpRename;
+use crate::parsing::{PhpRename, RenameRule};
 use crate::prelude::*;
 
 #[derive(FromAttributes, Debug, Default)]
@@ -35,7 +35,7 @@ pub struct ClassEntryAttribute {
 pub fn parser(mut input: ItemStruct) -> Result<TokenStream> {
     let attr = StructAttributes::from_attributes(&input.attrs)?;
     let ident = &input.ident;
-    let name = attr.rename.rename(ident.to_string());
+    let name = attr.rename.rename(ident.to_string(), RenameRule::Pascal);
     let docs = get_docs(&attr.attrs)?;
     input.attrs.retain(|attr| !attr.path().is_ident("php"));
 
@@ -107,7 +107,9 @@ struct Property<'a> {
 
 impl Property<'_> {
     pub fn name(&self) -> String {
-        self.attr.rename.rename(self.ident.to_string())
+        self.attr
+            .rename
+            .rename(self.ident.to_string(), RenameRule::Camel)
     }
 }
 

--- a/crates/macros/src/constant.rs
+++ b/crates/macros/src/constant.rs
@@ -4,7 +4,7 @@ use quote::{format_ident, quote};
 use syn::ItemConst;
 
 use crate::helpers::get_docs;
-use crate::parsing::PhpRename;
+use crate::parsing::{PhpRename, RenameRule};
 use crate::prelude::*;
 
 const INTERNAL_CONST_DOC_PREFIX: &str = "_internal_const_docs_";
@@ -23,7 +23,9 @@ pub(crate) struct PhpConstAttribute {
 pub fn parser(mut item: ItemConst) -> Result<TokenStream> {
     let attr = PhpConstAttribute::from_attributes(&item.attrs)?;
 
-    let name = attr.rename.rename(item.ident.to_string());
+    let name = attr
+        .rename
+        .rename(item.ident.to_string(), RenameRule::ScreamingSnake);
     let name_ident = format_ident!("{INTERNAL_CONST_NAME_PREFIX}{}", item.ident);
 
     let docs = get_docs(&attr.attrs)?;

--- a/crates/macros/src/function.rs
+++ b/crates/macros/src/function.rs
@@ -7,7 +7,7 @@ use syn::spanned::Spanned as _;
 use syn::{Expr, FnArg, GenericArgument, ItemFn, PatType, PathArguments, Type, TypePath};
 
 use crate::helpers::get_docs;
-use crate::parsing::{PhpRename, Visibility};
+use crate::parsing::{PhpRename, RenameRule, Visibility};
 use crate::prelude::*;
 use crate::syn_ext::DropLifetimes;
 
@@ -46,7 +46,9 @@ pub fn parser(mut input: ItemFn) -> Result<TokenStream> {
 
     let func = Function::new(
         &input.sig,
-        php_attr.rename.rename(input.sig.ident.to_string()),
+        php_attr
+            .rename
+            .rename(input.sig.ident.to_string(), RenameRule::Snake),
         args,
         php_attr.optional,
         docs,

--- a/guide/src/migration-guides/v0.14.md
+++ b/guide/src/migration-guides/v0.14.md
@@ -204,6 +204,19 @@ the following variants are equivalent:
 #[php(rename = case, vis = "public")]
 ```
 
+### Renaming and Case Changes
+
+Default case was adjusted to match PSR standards:
+- Class names are now `PascalCase`
+- Property names are now `camelCase`
+- Method names are now `camelCase`
+- Constant names are now `UPPER_CASE`
+- Function names are now `snake_case`
+
+This can be changed using the `rename` attribute on the item.
+Additionally, the `rename_methods` and `rename_consts` attributes can be used
+to change the case of all methods and constants in a class.
+
 #### `name` vs `rename`
 
 Previously the (re)name parameter was used to rename items. This has been

--- a/tests/src/integration/class/class.php
+++ b/tests/src/integration/class/class.php
@@ -15,10 +15,11 @@ assert($class->getNumber() === 2022);
 $class->setNumber(2023);
 assert($class->getNumber() === 2023);
 
+var_dump($class);
 // Tests #prop decorator
-assert($class->boolean);
-$class->boolean = false;
-assert($class->boolean === false);
+assert($class->booleanProp);
+$class->booleanProp = false;
+assert($class->booleanProp === false);
 
 // Call regular from object
 assert($class->staticCall('Php') === 'Hello Php');
@@ -31,7 +32,7 @@ assert(TestClass::staticCall('Php') === 'Hello Php');
 
 $ex = new TestClassExtends();
 assert_exception_thrown(fn() => throw $ex);
-assert_exception_thrown(fn() => throw_exception());
+assert_exception_thrown(fn() => throwException());
 
 $arrayAccess = new TestClassArrayAccess();
 assert_exception_thrown(fn() => $arrayAccess[0] = 'foo');

--- a/tests/src/integration/class/mod.rs
+++ b/tests/src/integration/class/mod.rs
@@ -6,7 +6,7 @@ pub struct TestClass {
     string: String,
     number: i32,
     #[php(prop)]
-    boolean: bool,
+    boolean_prop: bool,
 }
 
 #[php_impl]
@@ -41,7 +41,7 @@ pub fn test_class(string: String, number: i32) -> TestClass {
     TestClass {
         string,
         number,
-        boolean: true,
+        boolean_prop: true,
     }
 }
 


### PR DESCRIPTION
BREAKING CHANGE: Methods and Properties are renamed to camelCase by default. Classes to PascalCase and constants to UPPER_CASE.

Refs: #189