### PR TITLE
fix: fixed object access in object write/read/has_property handlers

### DIFF
--- a/src/zend/handlers.rs
+++ b/src/zend/handlers.rs
@@ -92,7 +92,7 @@ impl ZendObjectHandlers {
             let prop_name = member
                 .as_ref()
                 .ok_or("Invalid property name pointer given")?;
-            let self_ = &mut **obj;
+            let self_ = &mut *obj;
             let props = T::get_metadata().get_properties();
             let prop = props.get(prop_name.as_str()?);
 
@@ -141,7 +141,7 @@ impl ZendObjectHandlers {
             let prop_name = member
                 .as_ref()
                 .ok_or("Invalid property name pointer given")?;
-            let self_ = &mut **obj;
+            let self_ = &mut *obj;
             let props = T::get_metadata().get_properties();
             let prop = props.get(prop_name.as_str()?);
             let value_mut = value.as_mut().ok_or("Invalid return zval given")?;
@@ -178,7 +178,7 @@ impl ZendObjectHandlers {
                 .as_mut()
                 .and_then(|obj| ZendClassObject::<T>::from_zend_obj_mut(obj))
                 .ok_or("Invalid object pointer given")?;
-            let self_ = &mut **obj;
+            let self_ = &mut *obj;
             let struct_props = T::get_metadata().get_properties();
 
             for (name, val) in struct_props {
@@ -230,7 +230,7 @@ impl ZendObjectHandlers {
                 .ok_or("Invalid property name pointer given")?;
             let props = T::get_metadata().get_properties();
             let prop = props.get(prop_name.as_str()?);
-            let self_ = &mut **obj;
+            let self_ = &mut *obj;
 
             match has_set_exists {
                 //

--- a/tests/src/integration/exception/exception.php
+++ b/tests/src/integration/exception/exception.php
@@ -1,0 +1,13 @@
+<?php
+
+require(__DIR__ . '/../_utils.php');
+
+assert_exception_thrown(fn() => throw_default_exception(), \Exception::class);
+
+try {
+    throw_custom_exception();
+} catch (\Throwable $e) {
+    // Check if object is initiated
+    assert($e instanceof \Test\TestException);
+    assert("Not good custom!" === $e->getMessage());
+}

--- a/tests/src/integration/exception/mod.rs
+++ b/tests/src/integration/exception/mod.rs
@@ -1,0 +1,34 @@
+use ext_php_rs::{prelude::*, zend::ce};
+
+#[php_class]
+#[php(name = "Test\\TestException")]
+#[php(extends(ce = ce::exception, stub = "\\Exception"))]
+#[derive(Debug)]
+pub struct TestException;
+
+#[php_function]
+pub fn throw_custom_exception() -> PhpResult<i32> {
+    Err(PhpException::from_class::<TestException>(
+        "Not good custom!".into(),
+    ))
+}
+
+#[php_function]
+pub fn throw_default_exception() -> PhpResult<i32> {
+    Err(PhpException::default("Not good!".into()))
+}
+
+pub fn build_module(builder: ModuleBuilder) -> ModuleBuilder {
+    builder
+        .class::<TestException>()
+        .function(wrap_function!(throw_default_exception))
+        .function(wrap_function!(throw_custom_exception))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn exception_works() {
+        assert!(crate::integration::test::run_php("exception/exception.php"));
+    }
+}

--- a/tests/src/integration/mod.rs
+++ b/tests/src/integration/mod.rs
@@ -5,6 +5,7 @@ pub mod callable;
 pub mod class;
 pub mod closure;
 pub mod defaults;
+pub mod exception;
 pub mod globals;
 pub mod iterator;
 pub mod magic_method;

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -18,6 +18,7 @@ pub fn build_module(module: ModuleBuilder) -> ModuleBuilder {
     module = integration::class::build_module(module);
     module = integration::closure::build_module(module);
     module = integration::defaults::build_module(module);
+    module = integration::exception::build_module(module);
     module = integration::globals::build_module(module);
     module = integration::iterator::build_module(module);
     module = integration::magic_method::build_module(module);


### PR DESCRIPTION
Fixes: #262

Partially derived from #313, this commit fixes access to object properties from Rust code. This is needed to correctly initialize exception objects.