### PR TITLE
fix: ensure update_bindings runs as amd64

### DIFF
--- a/tools/update_bindings.sh
+++ b/tools/update_bindings.sh
@@ -6,6 +6,7 @@
 set -e
 
 docker buildx build \
+  --platform linux/amd64 \
   --target docsrs_bindings \
   -o type=local,dest=. \
   --build-arg PHP_VERSION=8.3 \


### PR DESCRIPTION
#446 had a minor problem when running locally that it may not match the architecture of CI and so may generate different bindings. This fixes that by always running as amd64 regardless of the host platform.

cc @Xenira 