### PR TITLE
test: add missing cfg gate to anyhow exception test

### DIFF
--- a/src/exception.rs
+++ b/src/exception.rs
@@ -342,6 +342,7 @@ mod tests {
         });
     }
 
+    #[cfg(feature = "anyhow")]
     #[test]
     fn test_from_anyhow() {
         Embed::run(|| {


### PR DESCRIPTION
Running tests with `embed` feature but not `anyhow` features fails because this needs a cfg gate.