### PR TITLE
test: improve test reliability and ease of use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["David Cole <david.cole1340@gmail.com>"]
 edition = "2021"
 categories = ["api-bindings"]
 exclude = ["/.github", "/.crates"]
+autotests = false
 
 [dependencies]
 bitflags = "2"
@@ -39,6 +40,7 @@ zip = "4.0"
 [features]
 closure = []
 embed = []
+anyhow = ["dep:anyhow"]
 
 [workspace]
 members = [
@@ -56,3 +58,16 @@ missing_docs = "warn"
 [[example]]
 name = "hello_world"
 crate-type = ["cdylib"]
+
+[[test]]
+name = "guide_tests"
+path = "tests/guide.rs"
+required-features = ["embed", "closure", "anyhow"]
+
+[[test]]
+name = "module_tests"
+path = "tests/module.rs"
+
+[[test]]
+name = "sapi_tests"
+path = "tests/sapi.rs"

--- a/guide/src/advanced/async_impl.md
+++ b/guide/src/advanced/async_impl.md
@@ -18,7 +18,11 @@ This allows full compatibility with [amphp](https://amphp.org), [PSL](https://gi
 
 Make sure to require [php-tokio](https://github.com/danog/php-tokio) as a dependency before proceeding.
 
-```rust,ignore
+<!-- Must ignore because of circular dependency with php_tokio. Otherwise, this _should_ work. -->
+```rust,no_run,ignore
+# extern crate ext_php_rs;
+# extern crate php_tokio;
+# extern crate reqwest;
 use ext_php_rs::prelude::*;
 use php_tokio::{php_async_impl, EventLoop};
 

--- a/guide/src/macros/classes.md
+++ b/guide/src/macros/classes.md
@@ -121,7 +121,7 @@ pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
 To implement an interface, use `#[php(implements(ce = ce_fn, stub = "InterfaceName")]` where `ce_fn` is an function returning a `ClassEntry`.
 The following example implements [`ArrayAccess`](https://www.php.net/manual/en/class.arrayaccess.php):
 
-````rust,no_run
+```rust,no_run
 # #![cfg_attr(windows, feature(abi_vectorcall))]
 # extern crate ext_php_rs;
 use ext_php_rs::{

--- a/guide/src/types/functions.md
+++ b/guide/src/types/functions.md
@@ -1,9 +1,9 @@
 # Functions & methods
 
-PHP functions and methods are represented by the `Function` struct.  
+PHP functions and methods are represented by the `Function` struct.
 
-You can use the `try_from_function` and `try_from_method` methods to obtain a Function struct corresponding to the passed function or static method name.  
-It's heavily recommended you reuse returned `Function` objects, to avoid the overhead of looking up the function/method name.  
+You can use the `try_from_function` and `try_from_method` methods to obtain a Function struct corresponding to the passed function or static method name.
+It's heavily recommended you reuse returned `Function` objects, to avoid the overhead of looking up the function/method name.
 
 ```rust,no_run
 # #![cfg_attr(windows, feature(abi_vectorcall))]

--- a/guide/src/types/iterable.md
+++ b/guide/src/types/iterable.md
@@ -6,7 +6,7 @@
 |---------------|----------------|-----------------| ---------------- |----------------------------------|
 | Yes           | No             | No              | No               | `ZendHashTable` or `ZendIterator` |
 
-Converting from a zval to a `Iterable` is valid when the value is either an array or an object 
+Converting from a zval to a `Iterable` is valid when the value is either an array or an object
 that implements the `Traversable` interface. This means that any value that can be used in a
 `foreach` loop can be converted into a `Iterable`.
 

--- a/guide/src/types/iterator.md
+++ b/guide/src/types/iterator.md
@@ -6,12 +6,12 @@
 |---------------| -------------- |-----------------| ---------------- | ------------------ |
 | No            | Yes            | No              | No               | `ZendIterator`    |
 
-Converting from a zval to a `ZendIterator` is valid when there is an associated iterator to 
-the variable. This means that any value, at the exception of an `array`, that can be used in 
+Converting from a zval to a `ZendIterator` is valid when there is an associated iterator to
+the variable. This means that any value, at the exception of an `array`, that can be used in
 a `foreach` loop can be converted into a `ZendIterator`. As an example, a `Generator` can be
 used but also a the result of a `query` call with `PDO`.
 
-If you want a more universal `iterable` type that also supports arrays, see [Iterable](./iterable.md).  
+If you want a more universal `iterable` type that also supports arrays, see [Iterable](./iterable.md).
 
 ## Rust example
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -306,6 +306,8 @@ impl<'a, 'b> ArgParser<'a, 'b> {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
+    #[cfg(feature = "embed")]
+    use crate::embed::Embed;
 
     use super::*;
 
@@ -427,12 +429,14 @@ mod tests {
     #[test]
     #[cfg(feature = "embed")]
     fn test_try_call_not_callable() {
-        let mut arg = Arg::new("test", DataType::Long);
-        let mut zval = Zval::from(42);
-        arg.zval = Some(&mut zval);
+        Embed::run(|| {
+            let mut arg = Arg::new("test", DataType::Long);
+            let mut zval = Zval::from(42);
+            arg.zval = Some(&mut zval);
 
-        let result = arg.try_call(vec![]);
-        assert!(result.is_err());
+            let result = arg.try_call(vec![]);
+            assert!(result.is_err());
+        });
     }
 
     // TODO: Test the callable case

--- a/src/zend/try_catch.rs
+++ b/src/zend/try_catch.rs
@@ -190,20 +190,22 @@ mod tests {
 
     #[test]
     fn test_memory_leak() {
-        let mut ptr = null_mut();
+        Embed::run(|| {
+            let mut ptr = null_mut();
 
-        let _ = try_catch(|| {
-            let mut result = "foo".to_string();
-            ptr = &mut result;
+            let _ = try_catch(|| {
+                let mut result = "foo".to_string();
+                ptr = &mut result;
 
-            unsafe {
-                bailout();
-            }
+                unsafe {
+                    bailout();
+                }
+            });
+
+            // Check that the string is never released
+            let result = unsafe { &*ptr as &str };
+
+            assert_eq!(result, "foo");
         });
-
-        // Check that the string is never released
-        let result = unsafe { &*ptr as &str };
-
-        assert_eq!(result, "foo");
     }
 }


### PR DESCRIPTION
This disables automatic filesystem-based test inclusion, opting for manual inclusion so the guides, which rely on additional features, can skip running unless all their required features are enabled.

This also wraps a few tests with `Embed::run(...)` as they may crash if the PHP environment is not fully set up. I think that is specific to ZTS builds as some things are not set up until the PHP bootstrap functions get called.