### PR TITLE
fix(FunctionBuilder): return type '?void' is now just 'void'

### DIFF
--- a/src/builders/function.rs
+++ b/src/builders/function.rs
@@ -138,7 +138,7 @@ impl<'a> FunctionBuilder<'a> {
     pub fn returns(mut self, type_: DataType, as_ref: bool, allow_null: bool) -> Self {
         self.retval = Some(type_);
         self.ret_as_ref = as_ref;
-        self.ret_as_null = allow_null;
+        self.ret_as_null = allow_null && type_ != DataType::Void;
         self
     }
 

--- a/src/builders/function.rs
+++ b/src/builders/function.rs
@@ -138,7 +138,7 @@ impl<'a> FunctionBuilder<'a> {
     pub fn returns(mut self, type_: DataType, as_ref: bool, allow_null: bool) -> Self {
         self.retval = Some(type_);
         self.ret_as_ref = as_ref;
-        self.ret_as_null = allow_null && type_ != DataType::Void;
+        self.ret_as_null = allow_null && type_ != DataType::Void && type_ != DataType::Mixed;
         self
     }
 


### PR DESCRIPTION
A quick fix for these errors:

```
PHP Deprecated:  Return type of EvenNumbersArray::offsetSet(mixed $offset, mixed $value): ?void should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of EvenNumbersArray::offsetSet(mixed $offset, mixed $value): ?void should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0
PHP Deprecated:  Return type of EvenNumbersArray::offsetUnset(mixed $offset): ?void should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of EvenNumbersArray::offsetUnset(mixed $offset): ?void should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0
```