### PR TITLE
fix(cargo-php): get_ext_dir()/get_php_ini(): stdout noise tolerance

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -272,7 +272,7 @@ fn get_ext_dir() -> AResult<PathBuf> {
         bail!("Failed to call PHP: {:?}", cmd);
     }
     let stdout = String::from_utf8_lossy(&cmd.stdout);
-    let ext_dir = PathBuf::from(&*stdout);
+    let ext_dir = PathBuf::from(stdout.rsplit('\n').next().unwrap());
     if !ext_dir.is_dir() {
         if ext_dir.exists() {
             bail!(
@@ -302,7 +302,7 @@ fn get_php_ini() -> AResult<PathBuf> {
         bail!("Failed to call PHP: {:?}", cmd);
     }
     let stdout = String::from_utf8_lossy(&cmd.stdout);
-    let ini = PathBuf::from(&*stdout);
+    let ini = PathBuf::from(stdout.rsplit('\n').next().unwrap());
     if !ini.is_file() {
         bail!(
             "php.ini does not exist or is not a file at the given path: {:?}",


### PR DESCRIPTION
cargo-php fails to detect extension directory if there's a startup error in PHP.

```
Error: Failed to create extension directory at "\nWarning: PHP Startup: Invalid library (maybe not a PHP library) \'libuntitled5.dylib\' in Unknown on line 0\n/opt/homebrew/lib/php/pecl/20240924-zts"

Caused by:
    No such file or directory (os error 2)
```

It's pretty annoying as it makes you go to php.ini and remove `extension=...` manually.

