### PR TITLE
chore(clippy): flowing lifetimes warning and clippy::mut_from_ref

### DIFF
--- a/src/builders/class.rs
+++ b/src/builders/class.rs
@@ -303,7 +303,7 @@ impl ClassBuilder {
 
         let class = unsafe {
             zend_register_internal_class_ex(
-                &mut self.ce,
+                &raw mut self.ce,
                 match self.extends {
                     Some((ptr, _)) => ptr::from_ref(ptr()).cast_mut(),
                     None => std::ptr::null_mut(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![warn(clippy::pedantic)]
 #![cfg_attr(docs, feature(doc_cfg))]
 #![cfg_attr(windows, feature(abi_vectorcall))]
 

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -378,7 +378,7 @@ impl ZendHashTable {
         V: IntoZval,
     {
         let mut val = val.into_zval(false)?;
-        unsafe { zend_hash_str_update(self, CString::new(key)?.as_ptr(), key.len(), &mut val) };
+        unsafe { zend_hash_str_update(self, CString::new(key)?.as_ptr(), key.len(), &raw mut val) };
         val.release();
         Ok(())
     }
@@ -416,7 +416,7 @@ impl ZendHashTable {
         V: IntoZval,
     {
         let mut val = val.into_zval(false)?;
-        unsafe { zend_hash_index_update(self, key, &mut val) };
+        unsafe { zend_hash_index_update(self, key, &raw mut val) };
         val.release();
         Ok(())
     }
@@ -453,7 +453,7 @@ impl ZendHashTable {
         V: IntoZval,
     {
         let mut val = val.into_zval(false)?;
-        unsafe { zend_hash_next_index_insert(self, &mut val) };
+        unsafe { zend_hash_next_index_insert(self, &raw mut val) };
         val.release();
 
         Ok(())

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -534,7 +534,7 @@ impl ZendHashTable {
     /// }
     #[inline]
     #[must_use]
-    pub fn values(&self) -> Values {
+    pub fn values(&self) -> Values<'_> {
         Values::new(self)
     }
 
@@ -559,7 +559,7 @@ impl ZendHashTable {
     /// }
     #[inline]
     #[must_use]
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         self.into_iter()
     }
 }

--- a/src/types/callable.rs
+++ b/src/types/callable.rs
@@ -131,12 +131,12 @@ impl<'a> ZendCallable<'a> {
         let result = unsafe {
             #[allow(clippy::used_underscore_items)]
             _call_user_function_impl(
-                std::ptr::null_mut(),
+                ptr::null_mut(),
                 ptr::from_ref(self.0.as_ref()).cast_mut(),
-                &mut retval,
+                &raw mut retval,
                 len.try_into()?,
                 packed.as_ptr().cast_mut(),
-                std::ptr::null_mut(),
+                ptr::null_mut(),
             )
         };
 

--- a/src/types/class_object.rs
+++ b/src/types/class_object.rs
@@ -115,13 +115,13 @@ impl<T: RegisteredClass> ZendClassObject<T> {
             .as_mut()
             .expect("Failed to allocate for new Zend object");
 
-        zend_object_std_init(&mut obj.std, ce);
-        object_properties_init(&mut obj.std, ce);
+        zend_object_std_init(&raw mut obj.std, ce);
+        object_properties_init(&raw mut obj.std, ce);
 
         // SAFETY: `obj` is non-null and well aligned as it is a reference.
         // As the data in `obj.obj` is uninitialized, we don't want to drop
         // the data, but directly override it.
-        ptr::write(&mut obj.obj, val);
+        ptr::write(&raw mut obj.obj, val);
 
         obj.std.handlers = meta.handlers();
         ZBox::from_raw(obj)
@@ -239,7 +239,7 @@ unsafe impl<T: RegisteredClass> ZBoxable for ZendClassObject<T> {
         // SAFETY: All constructors guarantee that `self` contains a valid pointer.
         // Further, all constructors guarantee that the `std` field of
         // `ZendClassObject` will be initialized.
-        unsafe { ext_php_rs_zend_object_release(&mut self.std) }
+        unsafe { ext_php_rs_zend_object_release(&raw mut self.std) }
     }
 }
 
@@ -276,7 +276,7 @@ impl<T: RegisteredClass + Clone> Clone for ZBox<ZendClassObject<T>> {
         // therefore we can dereference both safely.
         unsafe {
             let mut new = ZendClassObject::new((***self).clone());
-            zend_objects_clone_members(&mut new.std, (&raw const self.std).cast_mut());
+            zend_objects_clone_members(&raw mut new.std, (&raw const self.std).cast_mut());
             new
         }
     }

--- a/src/types/iterable.rs
+++ b/src/types/iterable.rs
@@ -19,7 +19,7 @@ impl Iterable<'_> {
     /// May return None if a Traversable cannot be rewound.
     // TODO: Check iter not returning iterator
     #[allow(clippy::iter_not_returning_iterator)]
-    pub fn iter(&mut self) -> Option<Iter> {
+    pub fn iter(&mut self) -> Option<Iter<'_>> {
         match self {
             Iterable::Array(array) => Some(Iter::Array(array.iter())),
             Iterable::Traversable(traversable) => Some(Iter::Traversable(traversable.iter()?)),

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -23,7 +23,7 @@ impl ZendIterator {
     /// iterator cannot be rewound.
     // TODO: Check iter not returning iterator
     #[allow(clippy::iter_not_returning_iterator)]
-    pub fn iter(&mut self) -> Option<Iter> {
+    pub fn iter(&mut self) -> Option<Iter<'_>> {
         self.index = 0;
 
         if self.rewind() {

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -39,7 +39,7 @@ impl ZendIterator {
     /// `\Iterator` interface. see <https://www.php.net/manual/en/iterator.valid.php>
     pub fn valid(&mut self) -> bool {
         if let Some(valid) = unsafe { (*self.funcs).valid } {
-            let valid = unsafe { valid(&mut *self) == ZEND_RESULT_CODE_SUCCESS };
+            let valid = unsafe { valid(&raw mut *self) == ZEND_RESULT_CODE_SUCCESS };
 
             if ExecutorGlobals::has_exception() {
                 return false;
@@ -63,7 +63,7 @@ impl ZendIterator {
     pub fn rewind(&mut self) -> bool {
         if let Some(rewind) = unsafe { (*self.funcs).rewind } {
             unsafe {
-                rewind(&mut *self);
+                rewind(&raw mut *self);
             }
         }
 
@@ -82,7 +82,7 @@ impl ZendIterator {
     pub fn move_forward(&mut self) -> bool {
         if let Some(move_forward) = unsafe { (*self.funcs).move_forward } {
             unsafe {
-                move_forward(&mut *self);
+                move_forward(&raw mut *self);
             }
         }
 
@@ -97,7 +97,7 @@ impl ZendIterator {
     /// , [`None`] otherwise.
     pub fn get_current_data<'a>(&mut self) -> Option<&'a Zval> {
         let get_current_data = unsafe { (*self.funcs).get_current_data }?;
-        let value = unsafe { &*get_current_data(&mut *self) };
+        let value = unsafe { &*get_current_data(&raw mut *self) };
 
         if ExecutorGlobals::has_exception() {
             return None;
@@ -117,7 +117,7 @@ impl ZendIterator {
         let mut key = Zval::new();
 
         unsafe {
-            get_current_key(&mut *self, &mut key);
+            get_current_key(&raw mut *self, &raw mut key);
         }
 
         if ExecutorGlobals::has_exception() {

--- a/src/types/object.rs
+++ b/src/types/object.rs
@@ -179,7 +179,7 @@ impl ZendObject {
 
         unsafe {
             let res = zend_hash_str_find_ptr_lc(
-                &(*self.ce).function_table,
+                &raw const (*self.ce).function_table,
                 name.as_ptr().cast::<c_char>(),
                 name.len(),
             )
@@ -193,7 +193,7 @@ impl ZendObject {
                 res,
                 ptr::from_ref(self).cast_mut(),
                 self.ce,
-                &mut retval,
+                &raw mut retval,
                 len.try_into()?,
                 packed.as_ptr().cast_mut(),
                 std::ptr::null_mut(),
@@ -230,10 +230,10 @@ impl ZendObject {
         let zv = unsafe {
             self.handlers()?.read_property.ok_or(Error::InvalidScope)?(
                 self.mut_ptr(),
-                &mut *name,
+                &raw mut *name,
                 1,
-                std::ptr::null_mut(),
-                &mut rv,
+                ptr::null_mut(),
+                &raw mut rv,
             )
             .as_ref()
         }
@@ -260,9 +260,9 @@ impl ZendObject {
         unsafe {
             self.handlers()?.write_property.ok_or(Error::InvalidScope)?(
                 self,
-                &mut *name,
-                &mut value,
-                std::ptr::null_mut(),
+                &raw mut *name,
+                &raw mut value,
+                ptr::null_mut(),
             )
             .as_ref()
         }
@@ -289,7 +289,7 @@ impl ZendObject {
         Ok(unsafe {
             self.handlers()?.has_property.ok_or(Error::InvalidScope)?(
                 self.mut_ptr(),
-                &mut *name,
+                &raw mut *name,
                 query as _,
                 std::ptr::null_mut(),
             )
@@ -440,10 +440,10 @@ impl FromZendObject<'_> for String {
                 (*obj.ce).__tostring,
                 ptr::from_ref(obj).cast_mut(),
                 obj.ce,
-                &mut ret,
+                &raw mut ret,
                 0,
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
+                ptr::null_mut(),
+                ptr::null_mut(),
             );
         }
 

--- a/src/types/zval.rs
+++ b/src/types/zval.rs
@@ -291,7 +291,7 @@ impl Zval {
 
     /// Returns the value of the zval if it is callable.
     #[must_use]
-    pub fn callable(&self) -> Option<ZendCallable> {
+    pub fn callable(&self) -> Option<ZendCallable<'_>> {
         // The Zval is checked if it is callable in the `new` function.
         ZendCallable::new(self).ok()
     }
@@ -309,7 +309,7 @@ impl Zval {
     /// Returns an iterable over the zval if it is an array or traversable. (is
     /// iterable)
     #[must_use]
-    pub fn iterable(&self) -> Option<Iterable> {
+    pub fn iterable(&self) -> Option<Iterable<'_>> {
         if self.is_iterable() {
             Iterable::from_zval(self)
         } else {

--- a/src/zend/class.rs
+++ b/src/zend/class.rs
@@ -27,7 +27,9 @@ impl ClassEntry {
         ExecutorGlobals::get().class_table()?;
         let mut name = ZendStr::new(name, false);
 
-        unsafe { crate::ffi::zend_lookup_class_ex(&raw mut *name, std::ptr::null_mut(), 0).as_ref() }
+        unsafe {
+            crate::ffi::zend_lookup_class_ex(&raw mut *name, std::ptr::null_mut(), 0).as_ref()
+        }
     }
 
     /// Creates a new [`ZendObject`], returned inside an [`ZBox<ZendObject>`]

--- a/src/zend/class.rs
+++ b/src/zend/class.rs
@@ -27,7 +27,7 @@ impl ClassEntry {
         ExecutorGlobals::get().class_table()?;
         let mut name = ZendStr::new(name, false);
 
-        unsafe { crate::ffi::zend_lookup_class_ex(&mut *name, std::ptr::null_mut(), 0).as_ref() }
+        unsafe { crate::ffi::zend_lookup_class_ex(&raw mut *name, std::ptr::null_mut(), 0).as_ref() }
     }
 
     /// Creates a new [`ZendObject`], returned inside an [`ZBox<ZendObject>`]

--- a/src/zend/function.rs
+++ b/src/zend/function.rs
@@ -83,7 +83,7 @@ impl Function {
             None => None,
             Some(ce) => unsafe {
                 let res = zend_hash_str_find_ptr_lc(
-                    &ce.function_table,
+                    &raw const ce.function_table,
                     name.as_ptr().cast::<c_char>(),
                     name.len(),
                 )
@@ -139,12 +139,12 @@ impl Function {
         unsafe {
             zend_call_known_function(
                 ptr::from_ref(self).cast_mut(),
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
-                &mut retval,
+                ptr::null_mut(),
+                ptr::null_mut(),
+                &raw mut retval,
                 len.try_into()?,
                 packed.as_ptr().cast_mut(),
-                std::ptr::null_mut(),
+                ptr::null_mut(),
             );
         };
 

--- a/src/zend/globals.rs
+++ b/src/zend/globals.rs
@@ -55,7 +55,7 @@ impl ExecutorGlobals {
 
         cfg_if::cfg_if! {
             if #[cfg(php_zts)] {
-                let guard = lock::GLOBALS_LOCK.with(|l| l.read_arc());
+                let guard = lock::GLOBALS_LOCK.with(RwLock::read_arc);
             } else {
                 let guard = lock::GLOBALS_LOCK.read_arc();
             }
@@ -83,7 +83,7 @@ impl ExecutorGlobals {
 
         cfg_if::cfg_if! {
             if #[cfg(php_zts)] {
-                let guard = lock::GLOBALS_LOCK.with(|l| l.write_arc());
+                let guard = lock::GLOBALS_LOCK.with(RwLock::write_arc);
             } else {
                 let guard = lock::GLOBALS_LOCK.write_arc();
             }
@@ -201,7 +201,7 @@ impl ExecutorGlobals {
         cfg_if::cfg_if! {
             if #[cfg(php82)] {
                 unsafe {
-                    zend_atomic_bool_store(&mut self.vm_interrupt, true);
+                    zend_atomic_bool_store(&raw mut self.vm_interrupt, true);
                 }
             } else {
                 self.vm_interrupt = true;
@@ -214,7 +214,7 @@ impl ExecutorGlobals {
         cfg_if::cfg_if! {
             if #[cfg(php82)] {
                 unsafe {
-                    zend_atomic_bool_store(&mut self.vm_interrupt, false);
+                    zend_atomic_bool_store(&raw mut self.vm_interrupt, false);
                 }
             } else {
                 self.vm_interrupt = true;
@@ -245,7 +245,7 @@ impl CompilerGlobals {
 
         cfg_if::cfg_if! {
             if #[cfg(php_zts)] {
-                let guard = lock::GLOBALS_LOCK.with(|l| l.read_arc());
+                let guard = lock::GLOBALS_LOCK.with(RwLock::read_arc);
             } else {
                 let guard = lock::GLOBALS_LOCK.read_arc();
             }
@@ -273,7 +273,7 @@ impl CompilerGlobals {
 
         cfg_if::cfg_if! {
             if #[cfg(php_zts)] {
-                let guard = lock::GLOBALS_LOCK.with(|l| l.write_arc());
+                let guard = lock::GLOBALS_LOCK.with(RwLock::write_arc);
             } else {
                 let guard = lock::GLOBALS_LOCK.write_arc();
             }
@@ -346,7 +346,7 @@ impl ProcessGlobals {
 
         cfg_if::cfg_if! {
             if #[cfg(php_zts)] {
-                let guard = lock::PROCESS_GLOBALS_LOCK.with(|l| l.read_arc());
+                let guard = lock::PROCESS_GLOBALS_LOCK.with(RwLock::read_arc);
             } else {
                 let guard = lock::PROCESS_GLOBALS_LOCK.read_arc();
             }
@@ -369,7 +369,7 @@ impl ProcessGlobals {
 
         cfg_if::cfg_if! {
             if #[cfg(php_zts)] {
-                let guard = lock::PROCESS_GLOBALS_LOCK.with(|l| l.write_arc());
+                let guard = lock::PROCESS_GLOBALS_LOCK.with(RwLock::write_arc);
             } else {
                 let guard = lock::PROCESS_GLOBALS_LOCK.write_arc();
             }
@@ -506,6 +506,7 @@ impl SapiGlobals {
     /// Attempting to retrieve the globals while already holding the global
     /// guard will lead to a deadlock. Dropping the globals guard will release
     /// the lock.
+    #[must_use]
     pub fn get() -> GlobalReadGuard<Self> {
         // SAFETY: PHP executor globals are statically declared therefore should never
         // return an invalid pointer.
@@ -513,7 +514,7 @@ impl SapiGlobals {
 
         cfg_if::cfg_if! {
             if #[cfg(php_zts)] {
-                let guard = lock::SAPI_GLOBALS_LOCK.with(|l| l.read_arc());
+                let guard = lock::SAPI_GLOBALS_LOCK.with(RwLock::read_arc);
             } else {
                 let guard = lock::SAPI_GLOBALS_LOCK.read_arc();
             }
@@ -536,7 +537,7 @@ impl SapiGlobals {
 
         cfg_if::cfg_if! {
             if #[cfg(php_zts)] {
-                let guard = lock::SAPI_GLOBALS_LOCK.with(|l| l.write_arc());
+                let guard = lock::SAPI_GLOBALS_LOCK.with(RwLock::write_arc);
             } else {
                 let guard = lock::SAPI_GLOBALS_LOCK.write_arc();
             }
@@ -777,7 +778,7 @@ impl FileGlobals {
 
         cfg_if::cfg_if! {
             if #[cfg(php_zts)] {
-                let guard = lock::FILE_GLOBALS_LOCK.with(|l| l.read_arc());
+                let guard = lock::FILE_GLOBALS_LOCK.with(RwLock::read_arc);
             } else {
                 let guard = lock::FILE_GLOBALS_LOCK.read_arc();
             }
@@ -793,6 +794,7 @@ impl FileGlobals {
     /// Attempting to retrieve the globals while already holding the global
     /// guard will lead to a deadlock. Dropping the globals guard will release
     /// the lock.
+    #[must_use]
     pub fn get_mut() -> GlobalWriteGuard<Self> {
         // SAFETY: PHP executor globals are statically declared therefore should never
         // return an invalid pointer.
@@ -800,7 +802,7 @@ impl FileGlobals {
 
         cfg_if::cfg_if! {
             if #[cfg(php_zts)] {
-                let guard = lock::FILE_GLOBALS_LOCK.with(|l| l.write_arc());
+                let guard = lock::FILE_GLOBALS_LOCK.with(RwLock::write_arc);
             } else {
                 let guard = lock::FILE_GLOBALS_LOCK.write_arc();
             }

--- a/src/zend/handlers.rs
+++ b/src/zend/handlers.rs
@@ -23,7 +23,7 @@ impl ZendObjectHandlers {
         let mut this = MaybeUninit::uninit();
 
         // SAFETY: `this` is allocated on the stack and is a valid memory location.
-        unsafe { Self::init::<T>(&mut *this.as_mut_ptr()) };
+        unsafe { Self::init::<T>(&raw mut *this.as_mut_ptr()) };
 
         // SAFETY: We just initialized the handlers in the previous statement, therefore
         // we are returning a valid object.
@@ -46,7 +46,7 @@ impl ZendObjectHandlers {
     ///
     /// * If the offset of the `T` type is not a valid `i32` value.
     pub unsafe fn init<T: RegisteredClass>(ptr: *mut ZendObjectHandlers) {
-        std::ptr::copy_nonoverlapping(&std_object_handlers, ptr, 1);
+        ptr::copy_nonoverlapping(&raw const std_object_handlers, ptr, 1);
         let offset = ZendClassObject::<T>::std_offset();
         (*ptr).offset = offset.try_into().expect("Invalid offset");
         (*ptr).free_obj = Some(Self::free_obj::<T>);
@@ -63,7 +63,7 @@ impl ZendObjectHandlers {
             .expect("Invalid object pointer given for `free_obj`");
 
         // Manually drop the object as we don't want to free the underlying memory.
-        ptr::drop_in_place(&mut obj.obj);
+        ptr::drop_in_place(&raw mut obj.obj);
 
         zend_object_std_dtor(object);
     }
@@ -254,12 +254,12 @@ impl ZendObjectHandlers {
                         cfg_if::cfg_if! {
                             if #[cfg(php84)] {
                                 #[allow(clippy::unnecessary_mut_passed)]
-                                if zend_is_true(&mut zv) {
+                                if zend_is_true(&raw mut zv) {
                                     return Ok(1);
                                 }
                             } else {
                                 #[allow(clippy::unnecessary_mut_passed)]
-                                if zend_is_true(&mut zv) == 1 {
+                                if zend_is_true(&raw mut zv) == 1 {
                                     return Ok(1);
                                 }
                             }

--- a/src/zend/linked_list.rs
+++ b/src/zend/linked_list.rs
@@ -8,7 +8,7 @@ pub type ZendLinkedList = zend_llist;
 impl ZendLinkedList {
     /// Create an iterator over the linked list
     #[must_use]
-    pub fn iter<T>(&self) -> ZendLinkedListIterator<T> {
+    pub fn iter<T>(&self) -> ZendLinkedListIterator<'_, T> {
         ZendLinkedListIterator::new(self)
     }
 }

--- a/src/zend/linked_list.rs
+++ b/src/zend/linked_list.rs
@@ -41,7 +41,7 @@ impl<'a, T: 'a> Iterator for ZendLinkedListIterator<'a, T> {
         unsafe {
             zend_llist_get_next_ex(
                 ptr::from_ref::<ZendLinkedList>(self.list).cast_mut(),
-                &mut self.position,
+                &raw mut self.position,
             )
         };
         Some(value)

--- a/src/zend/streams.rs
+++ b/src/zend/streams.rs
@@ -41,6 +41,7 @@ impl StreamWrapper {
 
     /// Get mutable wrapped stream by name
     #[must_use]
+    #[allow(clippy::mut_from_ref)]
     pub fn get_mut(name: &str) -> Option<&mut Self> {
         unsafe {
             let result = php_stream_locate_url_wrapper(name.as_ptr().cast(), ptr::null_mut(), 0);


### PR DESCRIPTION
 - lifetime flowing from input to output with different syntax can be confusing
 - mutable borrow from immutable input(s)
 - chore(clippy): warning: implicit borrow as raw pointer