### PR TITLE
fix(macro): fix syntax error for `#[php_class]` with multiline doc comments

### DIFF
--- a/crates/macros/src/class.rs
+++ b/crates/macros/src/class.rs
@@ -153,7 +153,7 @@ fn generate_registered_class_impl(
     };
 
     let docs = quote! {
-        #(#docs)*
+        #(#docs,)*
     };
 
     let extends = if let Some(extends) = extends {

--- a/tests/src/integration/class/mod.rs
+++ b/tests/src/integration/class/mod.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::unused_self)]
 use ext_php_rs::{convert::IntoZval, prelude::*, types::Zval, zend::ce};
 
+/// Doc comment
+/// Goes here
 #[php_class]
 pub struct TestClass {
     string: String,


### PR DESCRIPTION

Refs: #467