### PR TITLE
chore: enable zts Linux and macOS builds in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,11 +94,6 @@ jobs:
           # ext-php-rs requires nightly Rust when on Windows.
           - os: windows-latest
             rust: stable
-          # setup-php doesn't support thread safe PHP on Linux and macOS.
-          - os: macos-latest
-            phpts: ts
-          - os: ubuntu-latest
-            phpts: ts
           - os: macos-latest
             clang: "17"
           - os: ubuntu-latest


### PR DESCRIPTION
The comment seems to not be true anymore, setup-php has supported it for a couple years now.