### PR TITLE
feat(cargo-php)!: escalate privilege and to copy extension and edit ini file

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,7 +19,9 @@ dialoguer = "0.11"
 libloading = "0.8"
 cargo_metadata = "0.20"
 semver = "1.0"
-elevate = "0.6.1"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [lints.rust]
 missing_docs = "warn"


### PR DESCRIPTION
Fixes: #481
BREAKING CHANGE: installing extensions as root user will now fail unless `--bypass-root-check` is provided