### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.14.1](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-v0.14.0...ext-php-rs-v0.14.1) - 2025-07-06
+
+### Added
+- *(error)* Deprecate `E_USER_ERROR` in PHP 8.4 (by @Xenira) [[#476](https://github.com/davidcole1340/ext-php-rs/issues/476)] 
+
+### Fixed
+- Support defaults for calls with named arguments (by @Stranger6667) [[#490](https://github.com/davidcole1340/ext-php-rs/issues/490)] 
+
+### Other
+- Add missing parenthesis (by @Stranger6667) [[#486](https://github.com/davidcole1340/ext-php-rs/issues/486)] 
+
 ## [0.14.0](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-v0.13.1...ext-php-rs-v0.14.0) - 2025-07-04
 
 ### BREAKING CHANGES

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/davidcole1340/ext-php-rs"
 homepage = "https://github.com/davidcole1340/ext-php-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.14.0"
+version = "0.14.1"
 authors = ["David Cole <david.cole1340@gmail.com>"]
 edition = "2021"
 categories = ["api-bindings"]
@@ -18,7 +18,7 @@ parking_lot = { version = "0.12", features = ["arc_lock"] }
 cfg-if = "1.0"
 once_cell = "1.17"
 anyhow = { version = "1", optional = true }
-ext-php-rs-derive = { version = "=0.11.0", path = "./crates/macros" }
+ext-php-rs-derive = { version = "=0.11.1", path = "./crates/macros" }
 
 [dev-dependencies]
 skeptic = "0.13"

--- a/crates/macros/CHANGELOG.md
+++ b/crates/macros/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.11.1](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-derive-v0.11.0...ext-php-rs-derive-v0.11.1) - 2025-07-06
+
+### Other
+- Add missing parenthesis (by @Stranger6667) [[#486](https://github.com/davidcole1340/ext-php-rs/issues/486)] 
+
 ## [0.11.0](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-derive-v0.10.2...ext-php-rs-derive-v0.11.0) - 2025-07-04
 
 ### BREAKING CHANGES

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -4,7 +4,7 @@ description = "Derive macros for ext-php-rs."
 repository = "https://github.com/davidcole1340/ext-php-rs"
 homepage = "https://github.com/davidcole1340/ext-php-rs"
 license = "MIT OR Apache-2.0"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["David Cole <david.cole1340@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION



## 🤖 New release

* `ext-php-rs-derive`: 0.11.0 -> 0.11.1
* `ext-php-rs`: 0.14.0 -> 0.14.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `ext-php-rs-derive`

<blockquote>

## [0.11.1](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-derive-v0.11.0...ext-php-rs-derive-v0.11.1) - 2025-07-06

### Other
- Add missing parenthesis (by @Stranger6667) [[#486](https://github.com/davidcole1340/ext-php-rs/issues/486)]
</blockquote>

## `ext-php-rs`

<blockquote>

## [0.14.1](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-v0.14.0...ext-php-rs-v0.14.1) - 2025-07-06

### Added
- *(error)* Deprecate `E_USER_ERROR` in PHP 8.4 (by @Xenira) [[#476](https://github.com/davidcole1340/ext-php-rs/issues/476)] 

### Fixed
- Support defaults for calls with named arguments (by @Stranger6667) [[#490](https://github.com/davidcole1340/ext-php-rs/issues/490)] 

### Other
- Add missing parenthesis (by @Stranger6667) [[#486](https://github.com/davidcole1340/ext-php-rs/issues/486)]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).