### PR TITLE
feat: make Sapi work with ZTS builds

### DIFF
--- a/src/embed/embed.c
+++ b/src/embed/embed.c
@@ -29,6 +29,21 @@ void ext_php_rs_sapi_startup() {
   zend_signal_startup();
 }
 
+SAPI_API void ext_php_rs_sapi_shutdown() {
+  #ifdef ZTS
+    tsrm_shutdown();
+  #endif
+}
+
+SAPI_API void ext_php_rs_sapi_per_thread_init() {
+  #ifdef ZTS
+    (void)ts_resource(0);
+    #ifdef PHP_WIN32
+      ZEND_TSRMLS_CACHE_UPDATE();
+    #endif
+  #endif
+}
+
 void ext_php_rs_php_error(int type, const char *format, ...) {
   va_list args;
   va_start(args, format);

--- a/src/embed/embed.h
+++ b/src/embed/embed.h
@@ -7,5 +7,7 @@
 void* ext_php_rs_embed_callback(int argc, char** argv, void* (*callback)(void *), void *ctx);
 
 void ext_php_rs_sapi_startup();
+void ext_php_rs_sapi_shutdown();
+void ext_php_rs_sapi_per_thread_init();
 
 void ext_php_rs_php_error(int type, const char *format, ...);

--- a/src/embed/ffi.rs
+++ b/src/embed/ffi.rs
@@ -18,6 +18,9 @@ extern "C" {
     ) -> *mut c_void;
 
     pub fn ext_php_rs_sapi_startup();
+    pub fn ext_php_rs_sapi_shutdown();
+    pub fn ext_php_rs_sapi_per_thread_init();
+
     pub fn ext_php_rs_php_error(
         type_: ::std::os::raw::c_int,
         error_msg: *const ::std::os::raw::c_char,

--- a/src/embed/sapi.rs
+++ b/src/embed/sapi.rs
@@ -6,6 +6,9 @@ use crate::ffi::sapi_module_struct;
 /// A Zend module entry, also known as an extension.
 pub type SapiModule = sapi_module_struct;
 
+unsafe impl Send for SapiModule {}
+unsafe impl Sync for SapiModule {}
+
 impl SapiModule {
     /// Allocates the module entry on the heap, returning a pointer to the
     /// memory location. The caller is responsible for the memory pointed to.

--- a/src/zend/globals.rs
+++ b/src/zend/globals.rs
@@ -562,7 +562,7 @@ impl SapiGlobals {
     }
 }
 
-/// Stores SAPI headers. Exposed through SapiGlobals.
+/// Stores SAPI headers. Exposed through `SapiGlobals`.
 pub type SapiHeaders = sapi_headers_struct;
 
 impl<'a> SapiHeaders {

--- a/src/zend/globals.rs
+++ b/src/zend/globals.rs
@@ -562,6 +562,7 @@ impl SapiGlobals {
     }
 }
 
+/// Stores SAPI headers. Exposed through SapiGlobals.
 pub type SapiHeaders = sapi_headers_struct;
 
 impl<'a> SapiHeaders {
@@ -571,6 +572,7 @@ impl<'a> SapiHeaders {
     }
 }
 
+/// Manage a key/value pair of SAPI headers.
 pub type SapiHeader = sapi_header_struct;
 
 impl<'a> SapiHeader {

--- a/src/zend/mod.rs
+++ b/src/zend/mod.rs
@@ -28,6 +28,8 @@ pub use globals::ExecutorGlobals;
 pub use globals::FileGlobals;
 pub use globals::ProcessGlobals;
 pub use globals::SapiGlobals;
+pub use globals::SapiHeader;
+pub use globals::SapiHeaders;
 pub use globals::SapiModule;
 pub use handlers::ZendObjectHandlers;
 pub use ini_entry_def::IniEntryDef;

--- a/tests/sapi.rs
+++ b/tests/sapi.rs
@@ -9,7 +9,9 @@
 extern crate ext_php_rs;
 
 use ext_php_rs::builders::SapiBuilder;
-use ext_php_rs::embed::{ext_php_rs_sapi_startup, Embed};
+use ext_php_rs::embed::{
+    ext_php_rs_sapi_per_thread_init, ext_php_rs_sapi_shutdown, ext_php_rs_sapi_startup, Embed,
+};
 use ext_php_rs::ffi::{
     php_module_shutdown, php_module_startup, php_request_shutdown, php_request_startup,
     sapi_shutdown, sapi_startup, ZEND_RESULT_CODE_SUCCESS,
@@ -17,8 +19,14 @@ use ext_php_rs::ffi::{
 use ext_php_rs::prelude::*;
 use ext_php_rs::zend::try_catch_first;
 use std::ffi::c_char;
+use std::sync::Mutex;
 
 static mut LAST_OUTPUT: String = String::new();
+
+// Global mutex to ensure SAPI tests don't run concurrently. PHP does not allow
+// multiple SAPIs to exist at the same time. This prevents the tests from
+// overwriting each other's state.
+static SAPI_TEST_MUTEX: Mutex<()> = Mutex::new(());
 
 extern "C" fn output_tester(str: *const c_char, str_length: usize) -> usize {
     let char = unsafe { std::slice::from_raw_parts(str.cast::<u8>(), str_length) };
@@ -35,6 +43,8 @@ extern "C" fn output_tester(str: *const c_char, str_length: usize) -> usize {
 
 #[test]
 fn test_sapi() {
+    let _guard = SAPI_TEST_MUTEX.lock().unwrap();
+
     let mut builder = SapiBuilder::new("test", "Test");
     builder = builder.ub_write_function(output_tester);
 
@@ -86,6 +96,10 @@ fn test_sapi() {
     unsafe {
         sapi_shutdown();
     }
+
+    unsafe {
+        ext_php_rs_sapi_shutdown();
+    }
 }
 
 /// Gives you a nice greeting!
@@ -101,4 +115,93 @@ pub fn hello_world(name: String) -> String {
 #[php_module]
 pub fn module(module: ModuleBuilder) -> ModuleBuilder {
     module.function(wrap_function!(hello_world))
+}
+
+#[test]
+fn test_sapi_multithread() {
+    let _guard = SAPI_TEST_MUTEX.lock().unwrap();
+
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+
+    let mut builder = SapiBuilder::new("test-mt", "Test Multi-threaded");
+    builder = builder.ub_write_function(output_tester);
+
+    let sapi = builder.build().unwrap().into_raw();
+    let module = get_module();
+
+    unsafe {
+        ext_php_rs_sapi_startup();
+    }
+
+    unsafe {
+        sapi_startup(sapi);
+    }
+
+    unsafe {
+        php_module_startup(sapi, module);
+    }
+
+    let results = Arc::new(Mutex::new(Vec::new()));
+    let mut handles = vec![];
+
+    for i in 0..4 {
+        let results = Arc::clone(&results);
+
+        let handle = thread::spawn(move || {
+            unsafe {
+                ext_php_rs_sapi_per_thread_init();
+            }
+
+            let result = unsafe { php_request_startup() };
+            assert_eq!(result, ZEND_RESULT_CODE_SUCCESS);
+
+            let _ = try_catch_first(|| {
+                let eval_result = Embed::eval(&format!("hello_world('thread-{}');", i));
+
+                match eval_result {
+                    Ok(zval) => {
+                        assert!(zval.is_string());
+                        let string = zval.string().unwrap();
+                        let output = string.to_string();
+                        assert_eq!(output, format!("Hello, thread-{}!", i));
+
+                        results.lock().unwrap().push((i, output));
+                    }
+                    Err(_) => panic!("Evaluation failed in thread {}", i),
+                }
+            });
+
+            unsafe {
+                php_request_shutdown(std::ptr::null_mut());
+            }
+        });
+
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().expect("Thread panicked");
+    }
+
+    let results = results.lock().unwrap();
+    assert_eq!(results.len(), 4);
+
+    for i in 0..4 {
+        assert!(results
+            .iter()
+            .any(|(idx, output)| { *idx == i && output == &format!("Hello, thread-{}!", i) }));
+    }
+
+    unsafe {
+        php_module_shutdown();
+    }
+
+    unsafe {
+        sapi_shutdown();
+    }
+
+    unsafe {
+        ext_php_rs_sapi_shutdown();
+    }
 }

--- a/tests/sapi.rs
+++ b/tests/sapi.rs
@@ -9,9 +9,7 @@
 extern crate ext_php_rs;
 
 use ext_php_rs::builders::SapiBuilder;
-use ext_php_rs::embed::{
-    ext_php_rs_sapi_per_thread_init, ext_php_rs_sapi_shutdown, ext_php_rs_sapi_startup, Embed,
-};
+use ext_php_rs::embed::{ext_php_rs_sapi_startup, Embed};
 use ext_php_rs::ffi::{
     php_module_shutdown, php_module_startup, php_request_shutdown, php_request_startup,
     sapi_shutdown, sapi_startup, ZEND_RESULT_CODE_SUCCESS,
@@ -19,14 +17,8 @@ use ext_php_rs::ffi::{
 use ext_php_rs::prelude::*;
 use ext_php_rs::zend::try_catch_first;
 use std::ffi::c_char;
-use std::sync::Mutex;
 
 static mut LAST_OUTPUT: String = String::new();
-
-// Global mutex to ensure SAPI tests don't run concurrently. PHP does not allow
-// multiple SAPIs to exist at the same time. This prevents the tests from
-// overwriting each other's state.
-static SAPI_TEST_MUTEX: Mutex<()> = Mutex::new(());
 
 extern "C" fn output_tester(str: *const c_char, str_length: usize) -> usize {
     let char = unsafe { std::slice::from_raw_parts(str.cast::<u8>(), str_length) };
@@ -43,8 +35,6 @@ extern "C" fn output_tester(str: *const c_char, str_length: usize) -> usize {
 
 #[test]
 fn test_sapi() {
-    let _guard = SAPI_TEST_MUTEX.lock().unwrap();
-
     let mut builder = SapiBuilder::new("test", "Test");
     builder = builder.ub_write_function(output_tester);
 
@@ -96,10 +86,6 @@ fn test_sapi() {
     unsafe {
         sapi_shutdown();
     }
-
-    unsafe {
-        ext_php_rs_sapi_shutdown();
-    }
 }
 
 /// Gives you a nice greeting!
@@ -115,93 +101,4 @@ pub fn hello_world(name: String) -> String {
 #[php_module]
 pub fn module(module: ModuleBuilder) -> ModuleBuilder {
     module.function(wrap_function!(hello_world))
-}
-
-#[test]
-fn test_sapi_multithread() {
-    let _guard = SAPI_TEST_MUTEX.lock().unwrap();
-
-    use std::sync::{Arc, Mutex};
-    use std::thread;
-
-    let mut builder = SapiBuilder::new("test-mt", "Test Multi-threaded");
-    builder = builder.ub_write_function(output_tester);
-
-    let sapi = builder.build().unwrap().into_raw();
-    let module = get_module();
-
-    unsafe {
-        ext_php_rs_sapi_startup();
-    }
-
-    unsafe {
-        sapi_startup(sapi);
-    }
-
-    unsafe {
-        php_module_startup(sapi, module);
-    }
-
-    let results = Arc::new(Mutex::new(Vec::new()));
-    let mut handles = vec![];
-
-    for i in 0..4 {
-        let results = Arc::clone(&results);
-
-        let handle = thread::spawn(move || {
-            unsafe {
-                ext_php_rs_sapi_per_thread_init();
-            }
-
-            let result = unsafe { php_request_startup() };
-            assert_eq!(result, ZEND_RESULT_CODE_SUCCESS);
-
-            let _ = try_catch_first(|| {
-                let eval_result = Embed::eval(&format!("hello_world('thread-{}');", i));
-
-                match eval_result {
-                    Ok(zval) => {
-                        assert!(zval.is_string());
-                        let string = zval.string().unwrap();
-                        let output = string.to_string();
-                        assert_eq!(output, format!("Hello, thread-{}!", i));
-
-                        results.lock().unwrap().push((i, output));
-                    }
-                    Err(_) => panic!("Evaluation failed in thread {}", i),
-                }
-            });
-
-            unsafe {
-                php_request_shutdown(std::ptr::null_mut());
-            }
-        });
-
-        handles.push(handle);
-    }
-
-    for handle in handles {
-        handle.join().expect("Thread panicked");
-    }
-
-    let results = results.lock().unwrap();
-    assert_eq!(results.len(), 4);
-
-    for i in 0..4 {
-        assert!(results
-            .iter()
-            .any(|(idx, output)| { *idx == i && output == &format!("Hello, thread-{}!", i) }));
-    }
-
-    unsafe {
-        php_module_shutdown();
-    }
-
-    unsafe {
-        sapi_shutdown();
-    }
-
-    unsafe {
-        ext_php_rs_sapi_shutdown();
-    }
 }


### PR DESCRIPTION
## Description

This enables a `SapiModule` to work in ZTS mode. I'm using `SapiModule` directly in my case rather than going through the `Embed` type. I missed this when submitting my other PR to expand `SapiBuilder`.

Not sure what making `Embed` ZTS-capable would look like as it would require constructing a single `SapiModule` and reusing it so the API might need to be different or it might need to do some internal `OnceCell` magic.

Not entirely sure how to test this in a way that's not rather complicated. The only observable difference I'm aware of is that without the change it _might_ randomly segfault eventually with enough parallel requests. Any ideas? 😅 

I'm already using this code in my fork, so I know it _works_, just writing a test that's not _gigantic_ would be a challenge. 🤔 

## Checklist

_Check the boxes that apply (put an `x` in the brackets, like `[x]`). You can also check boxes after the PR is created._

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have added tests that prove my code works as expected.
- [ ] I have added documentation if applicable.
- [ ] I have added a [migration guide](../CONTRIBUTING.md#breaking-changes) if applicable.

:heart: Thank you for your contribution!
