### PR TITLE
fix: support defaults for calls with named arguments

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -168,6 +168,7 @@ impl<'a> Arg<'a> {
             )
             .ok_or(Error::InvalidCString)?,
             default_value: match &self.default_value {
+                Some(val) if val.as_str() == "None" => CString::new("null")?.into_raw(),
                 Some(val) => CString::new(val.as_str())?.into_raw(),
                 None => ptr::null(),
             },

--- a/tests/src/integration/defaults/defaults.php
+++ b/tests/src/integration/defaults/defaults.php
@@ -4,3 +4,6 @@ assert(test_defaults_integer() === 42);
 assert(test_defaults_integer(12) === 12);
 assert(test_defaults_nullable_string() === null);
 assert(test_defaults_nullable_string('test') === 'test');
+assert(test_defaults_multiple_option_arguments() === 'Default');
+assert(test_defaults_multiple_option_arguments(a: 'a') === 'a');
+assert(test_defaults_multiple_option_arguments(b: 'b') === 'b');

--- a/tests/src/integration/defaults/mod.rs
+++ b/tests/src/integration/defaults/mod.rs
@@ -12,10 +12,20 @@ pub fn test_defaults_nullable_string(a: Option<String>) -> Option<String> {
     a
 }
 
+#[php_function]
+#[php(defaults(a = None, b = None))]
+pub fn test_defaults_multiple_option_arguments(
+    a: Option<String>,
+    b: Option<String>,
+) -> PhpResult<String> {
+    Ok(a.or(b).unwrap_or_else(|| "Default".to_string()))
+}
+
 pub fn build_module(builder: ModuleBuilder) -> ModuleBuilder {
     builder
         .function(wrap_function!(test_defaults_integer))
         .function(wrap_function!(test_defaults_nullable_string))
+        .function(wrap_function!(test_defaults_multiple_option_arguments))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #490

I see it is an ad-hoc fix to illustrate the issue. I hope that in the end we can arrive at a more fundamental fix + add some more test cases, as it looks quite fragile right now (all the string passing part)

## Checklist

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have added tests that prove my code works as expected.
- [x] I have added documentation if applicable.
- [x] I have added a [migration guide](../CONTRIBUTING.md#breaking-changes) if applicable.

:heart: Thank you
