### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.14.2](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-v0.14.1...ext-php-rs-v0.14.2) - 2025-07-13
+
+### Added
+- Make Sapi work with ZTS builds (by @Qard) [[#488](https://github.com/davidcole1340/ext-php-rs/issues/488)] 
+
+### Fixed
+- *(clippy)* Fix new clippy rule (by @Xenira)
+- *(macro)* Allow multiple refs with `self_` (by @Xenira) [[#506](https://github.com/davidcole1340/ext-php-rs/issues/506)] 
+- *(macro)* Fix `self_` reference when multiple method arguments supplied (by @Xenira) [[#504](https://github.com/davidcole1340/ext-php-rs/issues/504)] 
+- *(stubs)* Include doc comments in `__construct()` stubs (by @Xenira) [[#497](https://github.com/davidcole1340/ext-php-rs/issues/497)] 
+
+### Other
+- *(args)* Add missing `embed` feature guard (by @Xenira) [[#501](https://github.com/davidcole1340/ext-php-rs/issues/501)] 
+- *(deps)* Upgrade bindgen to `v0.70` (by @Xenira)
+- *(release-plz)* Only run release workflow on build and lint success (by @Xenira)
+
 ## [0.14.1](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-v0.14.0...ext-php-rs-v0.14.1) - 2025-07-06
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/davidcole1340/ext-php-rs"
 homepage = "https://github.com/davidcole1340/ext-php-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.14.1"
+version = "0.14.2"
 authors = ["David Cole <david.cole1340@gmail.com>"]
 edition = "2021"
 categories = ["api-bindings"]
@@ -18,7 +18,7 @@ parking_lot = { version = "0.12", features = ["arc_lock"] }
 cfg-if = "1.0"
 once_cell = "1.17"
 anyhow = { version = "1", optional = true }
-ext-php-rs-derive = { version = "=0.11.1", path = "./crates/macros" }
+ext-php-rs-derive = { version = "=0.11.2", path = "./crates/macros" }
 
 [dev-dependencies]
 skeptic = "0.13"

--- a/crates/macros/CHANGELOG.md
+++ b/crates/macros/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.11.2](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-derive-v0.11.1...ext-php-rs-derive-v0.11.2) - 2025-07-13
+
+### Fixed
+- *(macro)* Allow multiple refs with `self_` (by @Xenira) [[#506](https://github.com/davidcole1340/ext-php-rs/issues/506)] 
+- *(macro)* Fix `self_` reference when multiple method arguments supplied (by @Xenira) [[#504](https://github.com/davidcole1340/ext-php-rs/issues/504)] 
+- *(stubs)* Include doc comments in `__construct()` stubs (by @Xenira) [[#497](https://github.com/davidcole1340/ext-php-rs/issues/497)] 
+
 ## [0.11.1](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-derive-v0.11.0...ext-php-rs-derive-v0.11.1) - 2025-07-06
 
 ### Other

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -4,7 +4,7 @@ description = "Derive macros for ext-php-rs."
 repository = "https://github.com/davidcole1340/ext-php-rs"
 homepage = "https://github.com/davidcole1340/ext-php-rs"
 license = "MIT OR Apache-2.0"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["David Cole <david.cole1340@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION



## 🤖 New release

* `ext-php-rs-derive`: 0.11.1 -> 0.11.2
* `ext-php-rs`: 0.14.1 -> 0.14.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `ext-php-rs-derive`

<blockquote>

## [0.11.2](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-derive-v0.11.1...ext-php-rs-derive-v0.11.2) - 2025-07-13

### Fixed
- *(macro)* Allow multiple refs with `self_` (by @Xenira) [[#506](https://github.com/davidcole1340/ext-php-rs/issues/506)] 
- *(macro)* Fix `self_` reference when multiple method arguments supplied (by @Xenira) [[#504](https://github.com/davidcole1340/ext-php-rs/issues/504)] 
- *(stubs)* Include doc comments in `__construct()` stubs (by @Xenira) [[#497](https://github.com/davidcole1340/ext-php-rs/issues/497)]
</blockquote>

## `ext-php-rs`

<blockquote>

## [0.14.2](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-v0.14.1...ext-php-rs-v0.14.2) - 2025-07-13

### Added
- Make Sapi work with ZTS builds (by @Qard) [[#488](https://github.com/davidcole1340/ext-php-rs/issues/488)] 

### Fixed
- *(clippy)* Fix new clippy rule (by @Xenira)
- *(macro)* Allow multiple refs with `self_` (by @Xenira) [[#506](https://github.com/davidcole1340/ext-php-rs/issues/506)] 
- *(macro)* Fix `self_` reference when multiple method arguments supplied (by @Xenira) [[#504](https://github.com/davidcole1340/ext-php-rs/issues/504)] 
- *(stubs)* Include doc comments in `__construct()` stubs (by @Xenira) [[#497](https://github.com/davidcole1340/ext-php-rs/issues/497)] 

### Other
- *(args)* Add missing `embed` feature guard (by @Xenira) [[#501](https://github.com/davidcole1340/ext-php-rs/issues/501)] 
- *(deps)* Upgrade bindgen to `v0.70` (by @Xenira)
- *(release-plz)* Only run release workflow on build and lint success (by @Xenira)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).