### PR TITLE
fix(stubs): include doc comments in `__construct()` stubs

### DIFF
--- a/crates/macros/src/function.rs
+++ b/crates/macros/src/function.rs
@@ -337,6 +337,7 @@ impl<'a> Function<'a> {
                 .variadic()
             }
         });
+        let docs = &self.docs;
 
         quote! {
             ::ext_php_rs::class::ConstructorMeta {
@@ -359,6 +360,7 @@ impl<'a> Function<'a> {
                 build_fn: {
                     fn inner(func: ::ext_php_rs::builders::FunctionBuilder) -> ::ext_php_rs::builders::FunctionBuilder {
                         func
+                            .docs(&[#(#docs),*])
                             #(.arg(#required_args))*
                             .not_required()
                             #(.arg(#not_required_args))*

--- a/tests/src/integration/class/mod.rs
+++ b/tests/src/integration/class/mod.rs
@@ -53,6 +53,9 @@ pub struct TestClassArrayAccess {}
 
 #[php_impl]
 impl TestClassArrayAccess {
+    /// Constructor
+    /// doc
+    /// comment
     pub fn __construct() -> Self {
         Self {}
     }


### PR DESCRIPTION
Refs: #497

## Description

Doc comments were not exported for constructors

## Checklist

_Check the boxes that apply (put an `x` in the brackets, like `[x]`). You can also check boxes after the PR is created._

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests that prove my code works as expected.
- [x] I have added documentation if applicable.
- [x] I have added a [migration guide](../CONTRIBUTING.md#breaking-changes) if applicable.

:heart: Thank you for your contribution!
