### PR TITLE
test(args): add missing `embed` feature guard

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -420,6 +420,7 @@ mod tests {
         assert_eq!(result.unwrap().dereference_mut().long(), Some(42));
     }
 
+    #[cfg(feature = "embed")]
     #[test]
     fn test_try_call_no_value() {
         let arg = Arg::new("test", DataType::Long);


### PR DESCRIPTION
Fixes: #501

## Description

Missing feature guard caused `cargo test` to fail linking.

## Checklist

_Check the boxes that apply (put an `x` in the brackets, like `[x]`). You can also check boxes after the PR is created._

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have added tests that prove my code works as expected.
- [x] I have added documentation if applicable.
- [x] I have added a [migration guide](../CONTRIBUTING.md#breaking-changes) if applicable.

:heart: Thank you for your contribution!
