### PR TITLE
fix(macro): fix `self_` reference when multiple method arguments supplied

### DIFF
--- a/crates/macros/src/impl_.rs
+++ b/crates/macros/src/impl_.rs
@@ -229,7 +229,7 @@ impl<'a> ParsedImpl<'a> {
                             {
                                 // `self_: &[mut] ZendClassObject<Self>`
                                 // Need to remove arg from argument list
-                                func.args.typed.pop();
+                                func.args.typed.remove(0);
                                 MethodReceiver::ZendClassObject
                             } else {
                                 modifiers.insert(MethodModifier::Static);

--- a/tests/src/integration/class/class.php
+++ b/tests/src/integration/class/class.php
@@ -10,6 +10,8 @@ assert($class instanceof TestClass);
 assert($class->getString() === 'lorem ipsum');
 $class->setString('dolor et');
 assert($class->getString() === 'dolor et');
+$class->selfRef("foo");
+assert($class->getString() === 'Changed to foo');
 
 assert($class->getNumber() === 2022);
 $class->setNumber(2023);

--- a/tests/src/integration/class/mod.rs
+++ b/tests/src/integration/class/mod.rs
@@ -1,5 +1,10 @@
 #![allow(clippy::unused_self)]
-use ext_php_rs::{convert::IntoZval, prelude::*, types::Zval, zend::ce};
+use ext_php_rs::{
+    convert::IntoZval,
+    prelude::*,
+    types::{ZendClassObject, Zval},
+    zend::ce,
+};
 
 /// Doc comment
 /// Goes here
@@ -35,6 +40,14 @@ impl TestClass {
 
     pub fn static_call(name: String) -> String {
         format!("Hello {name}")
+    }
+
+    pub fn self_ref(
+        self_: &mut ZendClassObject<TestClass>,
+        val: String,
+    ) -> &mut ZendClassObject<TestClass> {
+        self_.string = format!("Changed to {val}");
+        self_
     }
 }
 


### PR DESCRIPTION
Refs: #504

## Description

When having multiple arguments in a method that takes a `self_` reference the wrong argument was removed from the argument list.

## Checklist

_Check the boxes that apply (put an `x` in the brackets, like `[x]`). You can also check boxes after the PR is created._

- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests that prove my code works as expected.
- [ ] I have added documentation if applicable.
- [ ] I have added a [migration guide](../CONTRIBUTING.md#breaking-changes) if applicable.

:heart: Thank you for your contribution!
