### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## [0.15.0](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-v0.14.2...ext-php-rs-v0.15.0) - 2025-10-28
+
+### BREAKING CHANGES
+
+- *(stubs)* [**breaking**] Add stubs for `RustClosure` (by @Xenira) [[#373](https://github.com/davidcole1340/ext-php-rs/issues/373)] 
+> New field `variadic` added to `Parameter` struct.
+- *(enum)* [**breaking**] Add basic enum support (by @Xenira, @joehoyle) [[#178](https://github.com/davidcole1340/ext-php-rs/issues/178)] [[#302](https://github.com/davidcole1340/ext-php-rs/issues/302)] 
+> New field `enums` added to `Module` struct.
+
+### Added
+- *(array)* Introducing BTreeMap conversion and refactoring HashMap conversion (by @kakserpom) [[#535](https://github.com/davidcole1340/ext-php-rs/issues/535)] 
+- *(array)* Support `Vec<(K,V)>` for hashtables (by @Xenira) [[#425](https://github.com/davidcole1340/ext-php-rs/issues/425)] 
+- *(module)* Add `ModuleBuilder` name and version setters (by @kakserpom) [[#534](https://github.com/davidcole1340/ext-php-rs/issues/534)] 
+- *(zval)* Add `Zval::null()` (by @kakserpom) [[#521](https://github.com/davidcole1340/ext-php-rs/issues/521)] 
+- Add constructor visibility (by @Norbytus) [[#542](https://github.com/davidcole1340/ext-php-rs/issues/542)] 
+
+### Fixed
+- *(array)* Don't convert array keys with leading zeros (by @tomterl)
+- *(embed)* Add missing zend_destroy_file_handle (by @el7cosmos) [[#556](https://github.com/davidcole1340/ext-php-rs/issues/556)] 
+
+### Other
+- *(array)* Split `array.rs` types into smaller files (by @ptondereau) [[#524](https://github.com/davidcole1340/ext-php-rs/issues/524)] 
+- *(clippy)* Fix new clippy errors (by @Xenira) [[#558](https://github.com/davidcole1340/ext-php-rs/issues/558)] 
+- *(clippy)* Fix new clippy findings (by @Xenira) [[#543](https://github.com/davidcole1340/ext-php-rs/issues/543)] 
+- *(deps)* Upgrade bindgen to 0.72 (by @ptondereau)
+- *(deps)* Update zip requirement from 5.1 to 6.0 (by @dependabot[bot])
+- *(deps)* Bump actions/stale from 9 to 10 (by @dependabot[bot])
+- *(deps)* Update cargo_metadata requirement from 0.22 to 0.23 (by @dependabot[bot])
+- *(deps)* Update zip requirement from 4.0 to 5.1 (by @dependabot[bot])
+- *(deps)* Remove unused deps (by @robem)
+- *(deps)* Update dialoguer requirement from 0.11 to 0.12 (by @dependabot[bot])
+- *(deps)* Update cargo_metadata requirement from 0.21 to 0.22 (by @dependabot[bot])
+- *(deps)* Bump actions/checkout from 4 to 5 (by @dependabot[bot])
+- *(macro)* Add test infrastructure for macro crate (by @Xenira) [[#530](https://github.com/davidcole1340/ext-php-rs/issues/530)] 
+- *(php)* Use PHP 8.4 for linting (by @ptondereau)
+- *(readme)* Update example in readme (by @joehoyle) [[#539](https://github.com/davidcole1340/ext-php-rs/issues/539)] 
+- Add ptondereau to maintainer list (by @ptondereau)
+- Remove old ZTS docker and remove docker for embed tests (by @ptondereau)
+- Update guide url and authors (by @Xenira) [[#500](https://github.com/davidcole1340/ext-php-rs/issues/500)] 
 ## [0.14.2](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-v0.14.1...ext-php-rs-v0.14.2) - 2025-07-13
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/davidcole1340/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.14.2"
+version = "0.15.0"
 authors = [
     "Pierre Tondereau <pierre.tondereau@protonmail.com>",
     "Xenira <xenira@php.rs>",
@@ -22,7 +22,7 @@ parking_lot = { version = "0.12", features = ["arc_lock"] }
 cfg-if = "1.0"
 once_cell = "1.21"
 anyhow = { version = "1", optional = true }
-ext-php-rs-derive = { version = "=0.11.2", path = "./crates/macros" }
+ext-php-rs-derive = { version = "=0.11.3", path = "./crates/macros" }
 
 [dev-dependencies]
 skeptic = "0.13"

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.1.12](https://github.com/davidcole1340/ext-php-rs/compare/cargo-php-v0.1.11...cargo-php-v0.1.12) - 2025-10-28
+
+### Added
+- *(enum)* Add basic enum support (by @Xenira, @joehoyle) [[#178](https://github.com/davidcole1340/ext-php-rs/issues/178)] [[#302](https://github.com/davidcole1340/ext-php-rs/issues/302)] 
+
+### Other
+- *(clippy)* Fix new clippy errors (by @Xenira) [[#558](https://github.com/davidcole1340/ext-php-rs/issues/558)] 
+- *(deps)* Update cargo_metadata requirement from 0.22 to 0.23 (by @dependabot[bot])
+- *(deps)* Update dialoguer requirement from 0.11 to 0.12 (by @dependabot[bot])
+- *(deps)* Update cargo_metadata requirement from 0.21 to 0.22 (by @dependabot[bot])
+- *(deps)* Update cargo_metadata requirement from 0.20 to 0.21 (by @dependabot[bot])
+- Update guide url and authors (by @Xenira) [[#500](https://github.com/davidcole1340/ext-php-rs/issues/500)] 
 ## [0.1.11](https://github.com/davidcole1340/ext-php-rs/compare/cargo-php-v0.1.10...cargo-php-v0.1.11) - 2025-07-04
 
 ### Added

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/davidcole1340/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.1.11"
+version = "0.1.12"
 authors = [
     "Xenira <xenira@php.rs>",
     "David Cole <david.cole1340@gmail.com>"
@@ -14,7 +14,7 @@ edition = "2018"
 categories = ["api-bindings", "command-line-interface"]
 
 [dependencies]
-ext-php-rs = { version = "0.14", default-features = false, path = "../../" }
+ext-php-rs = { version = "0.15", default-features = false, path = "../../" }
 
 clap = { version = "4.0", features = ["derive"] }
 anyhow = "1"

--- a/crates/macros/CHANGELOG.md
+++ b/crates/macros/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.11.3](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-derive-v0.11.2...ext-php-rs-derive-v0.11.3) - 2025-10-28
+
+### Added
+- *(enum)* Add basic enum support (by @Xenira, @joehoyle) [[#178](https://github.com/davidcole1340/ext-php-rs/issues/178)] [[#302](https://github.com/davidcole1340/ext-php-rs/issues/302)] 
+- Add constructor visibility (by @Norbytus) [[#542](https://github.com/davidcole1340/ext-php-rs/issues/542)] 
+
+### Other
+- *(clippy)* Fix new clippy findings (by @Xenira) [[#543](https://github.com/davidcole1340/ext-php-rs/issues/543)] 
+- *(deps)* Upgrade bindgen to 0.72 (by @ptondereau)
+- *(deps)* Remove unused deps (by @robem)
+- *(deps)* Update darling requirement from 0.20 to 0.21 (by @dependabot[bot])
+- *(macro)* Add test infrastructure for macro crate (by @Xenira) [[#530](https://github.com/davidcole1340/ext-php-rs/issues/530)] 
+- *(readme)* Update example in readme (by @joehoyle) [[#539](https://github.com/davidcole1340/ext-php-rs/issues/539)] 
+- Update guide url and authors (by @Xenira) [[#500](https://github.com/davidcole1340/ext-php-rs/issues/500)] 
 ## [0.11.2](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-derive-v0.11.1...ext-php-rs-derive-v0.11.2) - 2025-07-13
 
 ### Fixed

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -4,7 +4,7 @@ description = "Derive macros for ext-php-rs."
 repository = "https://github.com/davidcole1340/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
-version = "0.11.2"
+version = "0.11.3"
 authors = [
     "Xenira <xenira@php.rs>",
     "David Cole <david.cole1340@gmail.com>"


### PR DESCRIPTION



## 🤖 New release

* `ext-php-rs-derive`: 0.11.2 -> 0.11.3
* `ext-php-rs`: 0.14.2 -> 0.15.0 (✓ API compatible changes)
* `cargo-php`: 0.1.11 -> 0.1.12 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `ext-php-rs-derive`

<blockquote>

## [0.11.3](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-derive-v0.11.2...ext-php-rs-derive-v0.11.3) - 2025-10-28

### Added
- *(enum)* Add basic enum support (by @Xenira) [[#178](https://github.com/davidcole1340/ext-php-rs/issues/178)] [[#302](https://github.com/davidcole1340/ext-php-rs/issues/302)] 
- Add constructor visibility (by @Norbytus) [[#542](https://github.com/davidcole1340/ext-php-rs/issues/542)] 

### Other
- *(clippy)* Fix new clippy findings (by @Xenira) [[#543](https://github.com/davidcole1340/ext-php-rs/issues/543)] 
- *(deps)* Upgrade bindgen to 0.72 (by @ptondereau)
- *(deps)* Remove unused deps (by @robem)
- *(deps)* Update darling requirement from 0.20 to 0.21 (by @dependabot[bot])
- *(macro)* Add test infrastructure for macro crate (by @Xenira) [[#530](https://github.com/davidcole1340/ext-php-rs/issues/530)] 
- *(readme)* Update example in readme (by @joehoyle) [[#539](https://github.com/davidcole1340/ext-php-rs/issues/539)] 
- Update guide url and authors (by @Xenira) [[#500](https://github.com/davidcole1340/ext-php-rs/issues/500)]
</blockquote>

## `ext-php-rs`

<blockquote>

## [0.15.0](https://github.com/davidcole1340/ext-php-rs/compare/ext-php-rs-v0.14.2...ext-php-rs-v0.15.0) - 2025-10-28

### BREAKING CHANGES

- *(stubs)* [**breaking**] Add stubs for `RustClosure` (by @Xenira) [[#373](https://github.com/davidcole1340/ext-php-rs/issues/373)] 
> New field `variadic` added to `Parameter` struct.

### Added
- *(array)* Introducing BTreeMap conversion and refactoring HashMap conversion (by @kakserpom) [[#535](https://github.com/davidcole1340/ext-php-rs/issues/535)] 
- *(array)* Support `Vec<(K,V)>` for hashtables (by @Xenira) [[#425](https://github.com/davidcole1340/ext-php-rs/issues/425)] 
- *(enum)* Add basic enum support (by @Xenira) [[#178](https://github.com/davidcole1340/ext-php-rs/issues/178)] [[#302](https://github.com/davidcole1340/ext-php-rs/issues/302)] 
- *(module)* Add `ModuleBuilder` name and version setters (by @kakserpom) [[#534](https://github.com/davidcole1340/ext-php-rs/issues/534)] 
- *(zval)* Add `Zval::null()` (by @kakserpom) [[#521](https://github.com/davidcole1340/ext-php-rs/issues/521)] 
- Add constructor visibility (by @Norbytus) [[#542](https://github.com/davidcole1340/ext-php-rs/issues/542)] 

### Fixed
- *(array)* Don't convert array keys with leading zeros (by @tomterl)
- *(embed)* Add missing zend_destroy_file_handle (by @el7cosmos) [[#556](https://github.com/davidcole1340/ext-php-rs/issues/556)] 

### Other
- *(array)* Split `array.rs` types into smaller files (by @ptondereau) [[#524](https://github.com/davidcole1340/ext-php-rs/issues/524)] 
- *(clippy)* Fix new clippy errors (by @Xenira) [[#558](https://github.com/davidcole1340/ext-php-rs/issues/558)] 
- *(clippy)* Fix new clippy findings (by @Xenira) [[#543](https://github.com/davidcole1340/ext-php-rs/issues/543)] 
- *(deps)* Upgrade bindgen to 0.72 (by @ptondereau)
- *(deps)* Update zip requirement from 5.1 to 6.0 (by @dependabot[bot])
- *(deps)* Bump actions/stale from 9 to 10 (by @dependabot[bot])
- *(deps)* Update cargo_metadata requirement from 0.22 to 0.23 (by @dependabot[bot])
- *(deps)* Update zip requirement from 4.0 to 5.1 (by @dependabot[bot])
- *(deps)* Remove unused deps (by @robem)
- *(deps)* Update dialoguer requirement from 0.11 to 0.12 (by @dependabot[bot])
- *(deps)* Update cargo_metadata requirement from 0.21 to 0.22 (by @dependabot[bot])
- *(deps)* Bump actions/checkout from 4 to 5 (by @dependabot[bot])
- *(macro)* Add test infrastructure for macro crate (by @Xenira) [[#530](https://github.com/davidcole1340/ext-php-rs/issues/530)] 
- *(php)* Use PHP 8.4 for linting (by @ptondereau)
- *(readme)* Update example in readme (by @joehoyle) [[#539](https://github.com/davidcole1340/ext-php-rs/issues/539)] 
- Add ptondereau to maintainer list (by @ptondereau)
- Remove old ZTS docker and remove docker for embed tests (by @ptondereau)
- Update guide url and authors (by @Xenira) [[#500](https://github.com/davidcole1340/ext-php-rs/issues/500)]
</blockquote>

## `cargo-php`

<blockquote>

## [0.1.12](https://github.com/davidcole1340/ext-php-rs/compare/cargo-php-v0.1.11...cargo-php-v0.1.12) - 2025-10-28

### Added
- *(enum)* Add basic enum support (by @Xenira) [[#178](https://github.com/davidcole1340/ext-php-rs/issues/178)] [[#302](https://github.com/davidcole1340/ext-php-rs/issues/302)] 

### Other
- *(clippy)* Fix new clippy errors (by @Xenira) [[#558](https://github.com/davidcole1340/ext-php-rs/issues/558)] 
- *(deps)* Update cargo_metadata requirement from 0.22 to 0.23 (by @dependabot[bot])
- *(deps)* Update dialoguer requirement from 0.11 to 0.12 (by @dependabot[bot])
- *(deps)* Update cargo_metadata requirement from 0.21 to 0.22 (by @dependabot[bot])
- *(deps)* Update cargo_metadata requirement from 0.20 to 0.21 (by @dependabot[bot])
- Update guide url and authors (by @Xenira) [[#500](https://github.com/davidcole1340/ext-php-rs/issues/500)]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).