### PR TITLE
feat(stubs)!: add stubs for `RustClosure`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -203,6 +203,7 @@ impl From<Arg<'_>> for Parameter {
             name: val.name.into(),
             ty: Some(val.r#type).into(),
             nullable: val.allow_null,
+            variadic: val.variadic,
             default: val.default_value.map(abi::RString::from).into(),
         }
     }

--- a/src/describe/stub.rs
+++ b/src/describe/stub.rs
@@ -154,6 +154,10 @@ impl ToStub for Parameter {
             write!(buf, " ")?;
         }
 
+        if self.variadic {
+            write!(buf, "...")?;
+        }
+
         write!(buf, "${}", self.name)
     }
 }


### PR DESCRIPTION
Fixes: #373
BREAKING CHANGE: New field `variadic` added to `Parameter` struct.

## Description

Added basic stubs for rust closure. This will always be included if the `closure` feature is enabled.

No argument information, as that is not rly available, but better than having no stubs.

## Checklist

_Check the boxes that apply (put an `x` in the brackets, like `[x]`). You can also check boxes after the PR is created._

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests that prove my code works as expected.
- [x] I have added documentation if applicable.
- [x] I have added a [migration guide](../CONTRIBUTING.md#breaking-changes) if applicable.

:heart: Thank you for your contribution!
