### PR TITLE
feat: Add constructor visability

### DIFF
--- a/crates/macros/src/function.rs
+++ b/crates/macros/src/function.rs
@@ -308,7 +308,11 @@ impl<'a> Function<'a> {
 
     /// Returns a constructor metadata object for this function. This doesn't
     /// check if the function is a constructor, however.
-    pub fn constructor_meta(&self, class: &syn::Path) -> TokenStream {
+    pub fn constructor_meta(
+        &self,
+        class: &syn::Path,
+        visibility: Option<&Visibility>,
+    ) -> TokenStream {
         let ident = self.ident;
         let (required, not_required) = self.args.split_args(self.optional.as_ref());
         let required_args = required
@@ -339,6 +343,7 @@ impl<'a> Function<'a> {
             }
         });
         let docs = &self.docs;
+        let flags = visibility.option_tokens();
 
         quote! {
             ::ext_php_rs::class::ConstructorMeta {
@@ -368,7 +373,8 @@ impl<'a> Function<'a> {
                             #variadic
                     }
                     inner
-                }
+                },
+                flags: #flags
             }
         }
     }

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -712,8 +712,8 @@ fn php_module_internal(args: TokenStream2, input: TokenStream2) -> TokenStream2 
 /// - `#[php(optional = i)]` - Sets the first optional parameter. Note that this
 ///   also sets the remaining parameters as optional, so all optional parameters
 ///   must be a variant of `Option<T>`.
-/// - `#[php(public)]`, `#[php(protected)]` and `#[php(private)]` - Sets the
-///   visibility of the method.
+/// - `#[php(vis = "public")]`, `#[php(vis = "protected")]` and `#[php(vis =
+///   "private")]` - Sets the visibility of the method.
 /// - `#[php(name = "method_name")]` - Renames the PHP method to a different
 ///   identifier, without renaming the Rust method name.
 ///

--- a/crates/macros/src/parsing.rs
+++ b/crates/macros/src/parsing.rs
@@ -1,5 +1,6 @@
 use convert_case::{Case, Casing};
 use darling::FromMeta;
+use quote::{quote, ToTokens};
 
 const MAGIC_METHOD: [&str; 17] = [
     "__construct",
@@ -29,6 +30,17 @@ pub enum Visibility {
     Private,
     #[darling(rename = "protected")]
     Protected,
+}
+
+impl ToTokens for Visibility {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        match self {
+            Visibility::Public => quote! { ::ext_php_rs::flags::MethodFlags::Public },
+            Visibility::Protected => quote! { ::ext_php_rs::flags::MethodFlags::Protected },
+            Visibility::Private => quote! { ::ext_php_rs::flags::MethodFlags::Private },
+        }
+        .to_tokens(tokens);
+    }
 }
 
 pub trait Rename {

--- a/guide/src/macros/impl.md
+++ b/guide/src/macros/impl.md
@@ -42,7 +42,7 @@ The rest of the options are passed as separate attributes:
 - `#[php(optional = i)]` - Sets the first optional parameter. Note that this also sets
   the remaining parameters as optional, so all optional parameters must be a
   variant of `Option<T>`.
-- `#[php(public)]`, `#[php(protected)]` and `#[php(private)]` - Sets the visibility of the
+- `#[php(vis = "public")]`, `#[php(vis = "protected")]` and `#[php(vis = "private")]` - Sets the visibility of the
   method.
 - `#[php(name = "method_name")]` - Renames the PHP method to a different identifier,
   without renaming the Rust method name.

--- a/src/class.rs
+++ b/src/class.rs
@@ -82,6 +82,8 @@ pub struct ConstructorMeta<T> {
     /// Function called to build the constructor function. Usually adds
     /// arguments.
     pub build_fn: fn(FunctionBuilder) -> FunctionBuilder,
+    /// Add constructor modification
+    pub flags: Option<MethodFlags>,
 }
 
 /// Result returned from a constructor of a class.

--- a/tests/src/integration/class/class.php
+++ b/tests/src/integration/class/class.php
@@ -43,3 +43,11 @@ assert_exception_thrown(fn() => $arrayAccess[0] = 'foo');
 assert_exception_thrown(fn() => $arrayAccess['foo']);
 assert($arrayAccess[0] === true);
 assert($arrayAccess[1] === false);
+
+$classReflection = new ReflectionClass(TestClassMethodVisibility::class);
+assert($classReflection->getMethod('__construct')->isPrivate());
+assert($classReflection->getMethod('private')->isPrivate());
+assert($classReflection->getMethod('protected')->isProtected());
+
+$classReflection = new ReflectionClass(TestClassProtectedConstruct::class);
+assert($classReflection->getMethod('__construct')->isProtected());

--- a/tests/src/integration/class/mod.rs
+++ b/tests/src/integration/class/mod.rs
@@ -144,12 +144,45 @@ impl TestClassExtendsImpl {
     }
 }
 
+#[php_class]
+struct TestClassMethodVisibility;
+
+#[php_impl]
+impl TestClassMethodVisibility {
+    #[php(vis = "private")]
+    fn __construct() -> Self {
+        Self
+    }
+
+    #[php(vis = "private")]
+    fn private() -> u32 {
+        3
+    }
+
+    #[php(vis = "protected")]
+    fn protected() -> u32 {
+        3
+    }
+}
+#[php_class]
+struct TestClassProtectedConstruct;
+
+#[php_impl]
+impl TestClassProtectedConstruct {
+    #[php(vis = "protected")]
+    fn __construct() -> Self {
+        Self
+    }
+}
+
 pub fn build_module(builder: ModuleBuilder) -> ModuleBuilder {
     builder
         .class::<TestClass>()
         .class::<TestClassArrayAccess>()
         .class::<TestClassExtends>()
         .class::<TestClassExtendsImpl>()
+        .class::<TestClassMethodVisibility>()
+        .class::<TestClassProtectedConstruct>()
         .function(wrap_function!(test_class))
         .function(wrap_function!(throw_exception))
 }


### PR DESCRIPTION
Add visability in constructor meta, and feature mark constructor as private and protected

## Description

- Add MethodFlags to ConstructorMeta 
- Relevant or closing issues[ (https://github.com/davidcole1340/ext-php-rs/issues/541)
- I made fast solution, and it could be not neat


## Checklist

_Check the boxes that apply (put an `x` in the brackets, like `[x]`). You can also check boxes after the PR is created._

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have added tests that prove my code works as expected.
- [x] I have added documentation if applicable.
- [x] I have added a [migration guide](../CONTRIBUTING.md#breaking-changes) if applicable.

:heart: Thank you for your contribution!
