### PR TITLE
feat(hook): Add cargo machete

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -10,6 +10,9 @@ pre-commit:
     - name: clippy
       run: cargo clippy --workspace --all-targets --all-features -- -W clippy::pedantic -D warnings
       glob: "*.rs"
+    - name: machete
+      run: cargo machete
+      glob: "*Cargo.toml"
     - name: bindings
       run: tools/update_bindings.sh && git diff --exit-code docsrs_bindings.rs
       glob: "allowed_bindings.rs"


### PR DESCRIPTION
## Description

Add `cargo machete` to `lefthook`. This is an optimistic PR as I'm not fully aware of the pipeline environment and whether [cargo-machete](https://crates.io/crates/cargo-machete) is present as it is not a rustup component.

Motivated by https://github.com/davidcole1340/ext-php-rs/pull/554#issuecomment-3300020774

## Checklist

_Check the boxes that apply (put an `x` in the brackets, like `[x]`). You can also check boxes after the PR is created._

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests that prove my code works as expected.
- [ ] I have added documentation if applicable.
- [ ] I have added a [migration guide](../CONTRIBUTING.md#breaking-changes) if applicable.

:heart: Thank you for your contribution!
