### PR TITLE
Treat string with leading zeros like php does.

### DIFF
--- a/tests/src/integration/array/array.php
+++ b/tests/src/integration/array/array.php
@@ -64,3 +64,18 @@ assert(test_btree_map(['foo', 'bar', 'baz']) === [
     1 => 'bar',
     2 => 'baz',
 ]);
+
+$leading_zeros = test_array_assoc_array_keys([
+  '0' => 'zero',
+  '00' => 'zerozero',
+  '007' => 'bond',
+]);
+
+assert(array_key_exists(0, $leading_zeros), '"0" should become integer key 0');
+assert($leading_zeros[0] === 'zero', 'Value at key 0 should be "zero"');
+
+assert(array_key_exists('007', $leading_zeros), '"007" should stay as string key');
+assert($leading_zeros['007'] === 'bond', 'Value at key "007" should be "bond"');
+
+assert(array_key_exists('00', $leading_zeros), '"00" should stay as string key');
+assert($leading_zeros['00'] === 'zerozero', 'Value at key "00" should be "zerozero"');


### PR DESCRIPTION
php does not convert string-keys with leading zeros to integer keys. This PR special cases string-keys of this form in the easiest way possible to me (in array_keys.rs) to let ext-php-rs key handling conform to phps behaviour in these cases.

An example psysh session (php8.2) showing the respective behaviours:

```
> $a = [];
= []

> $a['0815'] = "0815";
= "0815"

> $a
= [
    "0815" => "0815",
  ]
```

ext-php-rs without this pr:
```
> Yaml::
Yaml::emit       Yaml::parse      Yaml::parseFile
> Yaml::emit($a);
= """
  ---\n
  "0815": "0815"
  """

> Yaml::parse(Yaml::emit($a));
= [
    815 => "0815",                       # <---- leading 0 stripped and converted, this is wrong
  ]
```

With this PR applied/compiled:
```
> $a
= [
    "0815" => "0815",
  ]

> Yaml::parse(Yaml::emit($a));
= [
    "0815" => "0815",      # <-- correct behaviour
  ]
```


## Description
In `types/array/array_keys.rs`, I have added simple code that, after a conversion to `Long` was possible, checks that the key is either the string `"0"` or does not start with a `\`0\``, otherwise (that is of the form "0[0-9]+") the key is returned as string key  --- see the above psysh session transscripts for details.

I have tried to add tests in `mod.rs` but failed miserably,  my attempts were either skipped or did not compile.

I tried to add them to the `get` doc-block. 

<!--
Describes the changes made in the pull request. This should include:
- A summary of the changes made.
- Relevant or closing issues (e.g. `Fixes #123`).
- Any additional context or information that might be helpful for reviewers.
- If this is a breaking change, please ensure to include a migration guide.

If your PR is related to an issue you can keep this section short and just link the issue.
If you are unsure about something, please ask in the issue or PR. We are always happy to help.
-->

## Checklist

_Check the boxes that apply (put an `x` in the brackets, like `[x]`). You can also check boxes after the PR is created._

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have added tests that prove my code works as expected.
- [ ] I have added documentation if applicable.
- [ ] I have added a [migration guide](../CONTRIBUTING.md#breaking-changes) if applicable.

:heart: Thank you for your contribution!
