### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.15.2](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.1...ext-php-rs-v0.15.2) - 2025-12-06
+
+### Added
+- *(builders)* Add send_headers setter to SapiBuilder (by @Qard)
+- *(interface)* Add support for interfaces (by @Norbytus) [[#533](https://github.com/davidcole1340/ext-php-rs/issues/533)] 
+- *(php)* Add PHP 8.5 support ([#592](https://github.com/extphprs/ext-php-rs/pull/592)) (by @ptondereau) [[#592](https://github.com/davidcole1340/ext-php-rs/issues/592)] 
+
+### Fixed
+- *(musl)* Use Alpine 3.22 for musl tests ([#595](https://github.com/extphprs/ext-php-rs/pull/595)) (by @ptondereau) [[#595](https://github.com/davidcole1340/ext-php-rs/issues/595)] 
+- *(release-plz)* Update workflow to run release-plz ([#578](https://github.com/extphprs/ext-php-rs/pull/578)) (by @ptondereau) [[#578](https://github.com/davidcole1340/ext-php-rs/issues/578)] 
+- *(releaze-plz)* Trusted publishing token ([#579](https://github.com/extphprs/ext-php-rs/pull/579)) (by @ptondereau) [[#579](https://github.com/davidcole1340/ext-php-rs/issues/579)] 
+
+### Other
+- *(deps)* Update convert_case requirement from 0.9.0 to 0.10.0 ([#593](https://github.com/extphprs/ext-php-rs/pull/593)) (by @dependabot[bot]) [[#593](https://github.com/davidcole1340/ext-php-rs/issues/593)] 
+- *(deps)* Bump JamesIves/github-pages-deploy-action (by @dependabot[bot])
+- *(deps)* Update convert_case requirement from 0.8.0 to 0.9.0 (by @dependabot[bot])
+- *(deps)* Update libloading requirement from 0.8 to 0.9 (by @dependabot[bot])
+- *(docs)* Fix docs workflow permissions (by @Xenira)
+- *(release)* Pass github pat to release workflow (by @Xenira)
+- *(release)* Fix permissions again (by @Xenira)
+- *(release)* Add missing permissions to release trigger (by @Xenira) [[#580](https://github.com/davidcole1340/ext-php-rs/issues/580)] 
+- *(release)* Trigger release via reusable workflow (by @Xenira) [[#579](https://github.com/davidcole1340/ext-php-rs/issues/579)] [[#578](https://github.com/davidcole1340/ext-php-rs/issues/578)] 
+- Add musl build step ([#561](https://github.com/extphprs/ext-php-rs/pull/561)) (by @ptondereau) [[#561](https://github.com/davidcole1340/ext-php-rs/issues/561)] 
+- Restructure master and pr workflows (by @Xenira)
 ## [0.15.1](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.0...ext-php-rs-v0.15.1) - 2025-10-29
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.15.1"
+version = "0.15.2"
 authors = [
     "Pierre Tondereau <pierre.tondereau@protonmail.com>",
     "Xenira <xenira@php.rs>",
@@ -22,7 +22,7 @@ parking_lot = { version = "0.12", features = ["arc_lock"] }
 cfg-if = "1.0"
 once_cell = "1.21"
 anyhow = { version = "1", optional = true }
-ext-php-rs-derive = { version = "=0.11.4", path = "./crates/macros" }
+ext-php-rs-derive = { version = "=0.11.5", path = "./crates/macros" }
 
 [dev-dependencies]
 skeptic = "0.13"

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.14](https://github.com/extphprs/ext-php-rs/compare/cargo-php-v0.1.13...cargo-php-v0.1.14) - 2025-12-06
+
+### Other
+- *(deps)* Update libloading requirement from 0.8 to 0.9 (by @dependabot[bot])
+- *(rust)* Bump Rust edition to 2024 (by @ptondereau)
 ## [0.1.13](https://github.com/extphprs/ext-php-rs/compare/cargo-php-v0.1.12...cargo-php-v0.1.13) - 2025-10-29
 
 ### Other

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.1.13"
+version = "0.1.14"
 authors = [
     "Xenira <xenira@php.rs>",
     "David Cole <david.cole1340@gmail.com>",

--- a/crates/macros/CHANGELOG.md
+++ b/crates/macros/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.11.5](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.4...ext-php-rs-derive-v0.11.5) - 2025-12-06
+
+### Added
+- *(interface)* Add support for interfaces (by @Norbytus) [[#533](https://github.com/davidcole1340/ext-php-rs/issues/533)] 
+
+### Other
+- *(deps)* Update convert_case requirement from 0.9.0 to 0.10.0 ([#593](https://github.com/extphprs/ext-php-rs/pull/593)) (by @dependabot[bot]) [[#593](https://github.com/davidcole1340/ext-php-rs/issues/593)] 
+- *(deps)* Update convert_case requirement from 0.8.0 to 0.9.0 (by @dependabot[bot])
+- *(rust)* Bump Rust edition to 2024 (by @ptondereau)
+- Add musl build step ([#561](https://github.com/extphprs/ext-php-rs/pull/561)) (by @ptondereau) [[#561](https://github.com/davidcole1340/ext-php-rs/issues/561)] 
 ## [0.11.4](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.3...ext-php-rs-derive-v0.11.4) - 2025-10-29
 
 ### Other

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -4,7 +4,7 @@ description = "Derive macros for ext-php-rs."
 repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
-version = "0.11.4"
+version = "0.11.5"
 authors = [
     "Xenira <xenira@php.rs>",
     "David Cole <david.cole1340@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `ext-php-rs-derive`: 0.11.4 -> 0.11.5
* `ext-php-rs`: 0.15.1 -> 0.15.2 (✓ API compatible changes)
* `cargo-php`: 0.1.13 -> 0.1.14 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `ext-php-rs-derive`

<blockquote>

## [0.11.5](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.4...ext-php-rs-derive-v0.11.5) - 2025-12-06

### Added
- *(interface)* Add support for interfaces (by @Norbytus) [[#533](https://github.com/davidcole1340/ext-php-rs/issues/533)] 

### Other
- *(deps)* Update convert_case requirement from 0.9.0 to 0.10.0 ([#593](https://github.com/extphprs/ext-php-rs/pull/593)) (by @dependabot[bot]) [[#593](https://github.com/davidcole1340/ext-php-rs/issues/593)] 
- *(deps)* Update convert_case requirement from 0.8.0 to 0.9.0 (by @dependabot[bot])
- *(rust)* Bump Rust edtion to 2024 (by @ptondereau)
- Add musl build step ([#561](https://github.com/extphprs/ext-php-rs/pull/561)) (by @ptondereau) [[#561](https://github.com/davidcole1340/ext-php-rs/issues/561)]
</blockquote>

## `ext-php-rs`

<blockquote>

## [0.15.2](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.1...ext-php-rs-v0.15.2) - 2025-12-06

### Added
- *(builders)* Add send_headers setter to SapiBuilder (by @Qard)
- *(interface)* Add support for interfaces (by @Norbytus) [[#533](https://github.com/davidcole1340/ext-php-rs/issues/533)] 
- *(php)* Add PHP 8.5 support ([#592](https://github.com/extphprs/ext-php-rs/pull/592)) (by @ptondereau) [[#592](https://github.com/davidcole1340/ext-php-rs/issues/592)] 

### Fixed
- *(musl)* Use Alpine 3.22 for musl tests ([#595](https://github.com/extphprs/ext-php-rs/pull/595)) (by @ptondereau) [[#595](https://github.com/davidcole1340/ext-php-rs/issues/595)] 
- *(release-plz)* Update workflow to run release-plz ([#578](https://github.com/extphprs/ext-php-rs/pull/578)) (by @ptondereau) [[#578](https://github.com/davidcole1340/ext-php-rs/issues/578)] 
- *(releaze-plz)* Trusted publishing token ([#579](https://github.com/extphprs/ext-php-rs/pull/579)) (by @ptondereau) [[#579](https://github.com/davidcole1340/ext-php-rs/issues/579)] 

### Other
- *(deps)* Update convert_case requirement from 0.9.0 to 0.10.0 ([#593](https://github.com/extphprs/ext-php-rs/pull/593)) (by @dependabot[bot]) [[#593](https://github.com/davidcole1340/ext-php-rs/issues/593)] 
- *(deps)* Bump JamesIves/github-pages-deploy-action (by @dependabot[bot])
- *(deps)* Update convert_case requirement from 0.8.0 to 0.9.0 (by @dependabot[bot])
- *(deps)* Update libloading requirement from 0.8 to 0.9 (by @dependabot[bot])
- *(docs)* Fix docs workflow permissions (by @Xenira)
- *(release)* Pass github pat to release workflow (by @Xenira)
- *(release)* Fix permissions again (by @Xenira)
- *(release)* Add missing permissions to release trigger (by @Xenira) [[#580](https://github.com/davidcole1340/ext-php-rs/issues/580)] 
- *(release)* Trigger release via reusable workflow (by @Xenira) [[#579](https://github.com/davidcole1340/ext-php-rs/issues/579)] [[#578](https://github.com/davidcole1340/ext-php-rs/issues/578)] 
- Add musl build step ([#561](https://github.com/extphprs/ext-php-rs/pull/561)) (by @ptondereau) [[#561](https://github.com/davidcole1340/ext-php-rs/issues/561)] 
- Restructure master and pr workflows (by @Xenira)
</blockquote>

## `cargo-php`

<blockquote>

## [0.1.14](https://github.com/extphprs/ext-php-rs/compare/cargo-php-v0.1.13...cargo-php-v0.1.14) - 2025-12-06

### Other
- *(deps)* Update libloading requirement from 0.8 to 0.9 (by @dependabot[bot])
- *(rust)* Bump Rust edtion to 2024 (by @ptondereau)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).