### PR TITLE
fix(release-plz): update workflow to run release-plz

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,3 +226,21 @@ jobs:
 
       - name: Test with embed feature
         run: cargo test --workspace --release --features closure,embed,anyhow --no-fail-fast
+
+  trigger-release-plz:
+    name: Trigger Release Workflow
+    runs-on: ubuntu-latest
+    needs: [lint, build, test-embed]
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    steps:
+      - name: Trigger release-plz workflow
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release-plz.yml',
+              ref: 'master'
+            });

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -5,11 +5,7 @@ permissions:
   contents: write
 
 on:
-  workflow_run:
-    workflows: ["Build and Lint"]
-    branches: ["master"]
-    types:
-      - completed
+  workflow_dispatch:
 
 jobs:
   release-plz-release:
@@ -17,10 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
       clang: '17'
-      php_version: '8.2'
+      php_version: '8.4'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -68,7 +63,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false


### PR DESCRIPTION
## Description

Previous release-plz jobs are failing: https://github.com/extphprs/ext-php-rs/actions/runs/18954177887/job/54175907346

```
Run rust-lang/crates-io-auth-action@v1
  with:
    url: https://crates.io/
  env:
    CARGO_HOME: /home/runner/.cargo
    CARGO_INCREMENTAL: 0
    CARGO_TERM_COLOR: always
Retrieving GitHub Actions JWT token with audience: crates.io
Retrieved JWT token successfully
Requesting token from: https://crates.io/api/v1/trusted_publishing/tokens. User agent: crates-io-auth-action/1.0.1
Error: Failed to retrieve token from Cargo registry. Status: 400. Error: Trusted Publishing does not support the `workflow_run` event trigger due to security concerns. Please use a different trigger such as `push`, `release`, or `workflow_dispatch`.
```