### PR TITLE
fix(musl): Use Alpine 3.22 for musl tests

### DIFF
--- a/.github/action/musl/Dockerfile
+++ b/.github/action/musl/Dockerfile
@@ -1,7 +1,7 @@
 ARG PHP_VERSION=8.5
 ARG TS=-zts
 
-FROM php:${PHP_VERSION}${TS}-alpine
+FROM php:${PHP_VERSION}${TS}-alpine3.22
 
 RUN apk add --no-cache \
     llvm17 \


### PR DESCRIPTION
## Description

Alpine 3.23 doesn't include LLVM 17 anymore; let's freeze it to 3.22 for now.