### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.15.3](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.2...ext-php-rs-v0.15.3) - 2025-12-15
+
+### Added
+- *(types)* Argument coercion into HashSet/BTreeSet #493 ([#598](https://github.com/extphprs/ext-php-rs/pull/598)) (by @kakserpom) [[#493](https://github.com/davidcole1340/ext-php-rs/issues/493)] [[#598](https://github.com/davidcole1340/ext-php-rs/issues/598)] 
+
+### Fixed
+- *(ci)* Disable TS build for embed tests ([#600](https://github.com/extphprs/ext-php-rs/pull/600)) (by @ptondereau) [[#600](https://github.com/davidcole1340/ext-php-rs/issues/600)] 
+- *(clippy)* Default hasher for ArrayKey ([#608](https://github.com/extphprs/ext-php-rs/pull/608)) (by @ptondereau) [[#608](https://github.com/davidcole1340/ext-php-rs/issues/608)] 
+- *(clippy)* Clippy v1.92.0 ([#605](https://github.com/extphprs/ext-php-rs/pull/605)) (by @ptondereau) [[#605](https://github.com/davidcole1340/ext-php-rs/issues/605)] 
 ## [0.15.2](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.1...ext-php-rs-v0.15.2) - 2025-12-06
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.15.2"
+version = "0.15.3"
 authors = [
     "Pierre Tondereau <pierre.tondereau@protonmail.com>",
     "Xenira <xenira@php.rs>",
@@ -22,7 +22,7 @@ parking_lot = { version = "0.12", features = ["arc_lock"] }
 cfg-if = "1.0"
 once_cell = "1.21"
 anyhow = { version = "1", optional = true }
-ext-php-rs-derive = { version = "=0.11.5", path = "./crates/macros" }
+ext-php-rs-derive = { version = "=0.11.6", path = "./crates/macros" }
 
 [dev-dependencies]
 skeptic = "0.13"

--- a/crates/macros/CHANGELOG.md
+++ b/crates/macros/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.11.6](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.5...ext-php-rs-derive-v0.11.6) - 2025-12-15
+
+### Fixed
+- *(clippy)* Clippy v1.92.0 ([#605](https://github.com/extphprs/ext-php-rs/pull/605)) (by @ptondereau) [[#605](https://github.com/davidcole1340/ext-php-rs/issues/605)] 
+
+### Other
+- *(deps)* Update darling requirement from 0.21 to 0.23 ([#596](https://github.com/extphprs/ext-php-rs/pull/596)) (by @dependabot[bot]) [[#596](https://github.com/davidcole1340/ext-php-rs/issues/596)] 
 ## [0.11.5](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.4...ext-php-rs-derive-v0.11.5) - 2025-12-06
 
 ### Added

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -4,7 +4,7 @@ description = "Derive macros for ext-php-rs."
 repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
-version = "0.11.5"
+version = "0.11.6"
 authors = [
     "Xenira <xenira@php.rs>",
     "David Cole <david.cole1340@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `ext-php-rs-derive`: 0.11.5 -> 0.11.6
* `ext-php-rs`: 0.15.2 -> 0.15.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `ext-php-rs-derive`

<blockquote>

## [0.11.6](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.5...ext-php-rs-derive-v0.11.6) - 2025-12-15

### Fixed
- *(clippy)* Clippy v1.92.0 ([#605](https://github.com/extphprs/ext-php-rs/pull/605)) (by @ptondereau) [[#605](https://github.com/davidcole1340/ext-php-rs/issues/605)] 

### Other
- *(deps)* Update darling requirement from 0.21 to 0.23 ([#596](https://github.com/extphprs/ext-php-rs/pull/596)) (by @dependabot[bot]) [[#596](https://github.com/davidcole1340/ext-php-rs/issues/596)]
</blockquote>

## `ext-php-rs`

<blockquote>

## [0.15.3](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.2...ext-php-rs-v0.15.3) - 2025-12-15

### Added
- *(types)* Argument coercion into HashSet/BTreeSet #493 ([#598](https://github.com/extphprs/ext-php-rs/pull/598)) (by @kakserpom) [[#493](https://github.com/davidcole1340/ext-php-rs/issues/493)] [[#598](https://github.com/davidcole1340/ext-php-rs/issues/598)] 

### Fixed
- *(ci)* Disable TS build for embed tests ([#600](https://github.com/extphprs/ext-php-rs/pull/600)) (by @ptondereau) [[#600](https://github.com/davidcole1340/ext-php-rs/issues/600)] 
- *(clippy)* Default hasher for ArrayKey ([#608](https://github.com/extphprs/ext-php-rs/pull/608)) (by @ptondereau) [[#608](https://github.com/davidcole1340/ext-php-rs/issues/608)] 
- *(clippy)* Clippy v1.92.0 ([#605](https://github.com/extphprs/ext-php-rs/pull/605)) (by @ptondereau) [[#605](https://github.com/davidcole1340/ext-php-rs/issues/605)]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).