### PR TITLE
fix(ci): disable TS build for embed tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,11 +169,8 @@ jobs:
         if: "!(contains(matrix.os, 'macos') && matrix.rust == 'nightly')"
         run: cargo test --release --workspace --features closure,anyhow,runtime --no-fail-fast
   test-embed:
-    name: Test with embed (${{ matrix.phpts }})
+    name: Test with embed (NTS)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        phpts: [ts, nts]
     env:
       clang: "17"
       php_version: "8.5"
@@ -186,7 +183,6 @@ jobs:
         with:
           php-version: ${{ env.php_version }}
         env:
-          phpts: ${{ matrix.phpts }}
           debug: true
 
       - name: Setup Rust


### PR DESCRIPTION
## Description

ZTS `libphp-embed` is not available (see: https://codeberg.org/oerdnj/deb.sury.org/issues/49) and building a whole PHP "just" for this case is too long for now.
Let's disable it 