### PR TITLE
fix(binary): avoid leaking in Pack::pack_into

### DIFF
--- a/src/binary.rs
+++ b/src/binary.rs
@@ -149,7 +149,7 @@ macro_rules! pack_impl {
         unsafe impl Pack for $t {
             fn pack_into(vec: Vec<Self>) -> *mut zend_string {
                 let len = vec.len() * ($d as usize / 8);
-                let ptr = Box::into_raw(vec.into_boxed_slice());
+                let ptr = vec.as_ptr();
                 unsafe { ext_php_rs_zend_string_init(ptr.cast(), len as _, false) }
             }
 


### PR DESCRIPTION
## Summary

Fix a memory leak in `binary.rs` `Pack::pack_into` when converting `Vec<T>` into a Zend binary string.

## Problem

`Pack::pack_into` previously used `Box::into_raw` on a boxed slice to obtain a pointer for `zend_string_init`, but the allocation was never reclaimed after the Zend string copied the bytes. This leaked on every call to `pack_into`.

## Change

`Pack::pack_into` now passes `vec.as_ptr()` directly to `ext_php_rs_zend_string_init` and relies on Zend copying the bytes into the newly-created `zend_string`. The Rust `Vec` is then dropped at the end of the function, so the Rust allocation is freed normally.

## Safety notes

This relies on the documented behavior of `zend_string_init` copying the provided buffer.

## How to test

- Build an extension that exercises `Pack::pack_into` (e.g., returning `Binary<u8>` / using `set_binary`).
- Run a PHP script that calls the affected function in a loop.
- Verify with a leak checker (Valgrind / ASan) that the leak present before this change no longer occurs.

## Notes

No API changes intended; this is a memory management fix.
