### PR TITLE
fix(bindings): exclude `preserve_none` instruction from bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,10 @@ path = "tests/module.rs"
 name = "sapi_tests"
 path = "tests/sapi.rs"
 
-# Patch clang-sys to support preserve_none calling convention (libclang 19/20)
+# Patch clang-sys and bindgen for preserve_none calling convention support (libclang 19/20)
 # Required for PHP 8.5+ on macOS ARM64 which uses TAILCALL VM mode
-# See: https://github.com/KyleMayes/clang-sys/pull/195
+# - clang-sys: Adds libclang 19/20 bindings (https://github.com/KyleMayes/clang-sys/pull/195)
+# - bindgen: Maps CXCallingConv_PreserveNone to C ABI
 [patch.crates-io]
 clang-sys = { git = "https://github.com/extphprs/clang-sys.git", branch = "preserve-none-support" }
+bindgen = { git = "https://github.com/extphprs/rust-bindgen.git", branch = "preserve-none-support" }


### PR DESCRIPTION
## Description

`bindgen` doesn't support calling the `preserve_none` convention that has been introduced in the last PHP 8.5.1.
We can't exclude it with Clang Builder nor passing CFLAGS because this convention is used everywhere in the PHP src code.

I've forked bindgen + clang-sys to be able to build an extension on arm64 with macOS, but we clearly need an update from these repositories.

PHP issue: https://github.com/php/php-src/issues/20546