### PR TITLE
fix(deps): bump parking_lot required version to 0.12.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ autotests = false
 
 [dependencies]
 bitflags = "2"
-parking_lot = { version = "0.12", features = ["arc_lock"] }
+parking_lot = { version = "0.12.3", features = ["arc_lock"] }
 cfg-if = "1.0"
 once_cell = "1.21"
 anyhow = { version = "1", optional = true }


### PR DESCRIPTION
to include support for parking_lot::ArcRwLockReadGuard and parking_lot::ArcRwLockWriteGuard that we use in src/zend/globals.rs, that was only publicly exposed in 0.12.3 (commit [[c357017d](https://github.com/Amanieu/parking_lot/commit/c357017decfa0f21ca597a4958745ad0999cf9eb)]).