### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.15.4](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.3...ext-php-rs-v0.15.4) - 2026-01-26
+
+### Added
+- *(array)* Entry API (Issue #525) ([#611](https://github.com/extphprs/ext-php-rs/pull/611)) (by @kakserpom) [[#525](https://github.com/davidcole1340/ext-php-rs/issues/525)] [[#611](https://github.com/davidcole1340/ext-php-rs/issues/611)] 
+- *(class)* Readonly and final classes ([#639](https://github.com/extphprs/ext-php-rs/pull/639)) (by @kakserpom) [[#639](https://github.com/davidcole1340/ext-php-rs/issues/639)] 
+- *(core)* Add observer API ([#650](https://github.com/extphprs/ext-php-rs/pull/650)) (by @ptondereau) [[#650](https://github.com/davidcole1340/ext-php-rs/issues/650)] 
+- *(object)* Lazy ghost and Lazy Proxy ([#636](https://github.com/extphprs/ext-php-rs/pull/636)) (by @kakserpom) [[#636](https://github.com/davidcole1340/ext-php-rs/issues/636)] 
+- *(string)* Smartstring support ([#643](https://github.com/extphprs/ext-php-rs/pull/643)) (by @kakserpom) [[#643](https://github.com/davidcole1340/ext-php-rs/issues/643)] 
+
+### Fixed
+- *(cargo-php)* Use runtime feature for cargo-php to avoid dynamic linking on musl ([#645](https://github.com/extphprs/ext-php-rs/pull/645)) (by @ptondereau) [[#645](https://github.com/davidcole1340/ext-php-rs/issues/645)] 
+- *(clippy)* V1.93.0 errors ([#648](https://github.com/extphprs/ext-php-rs/pull/648)) (by @ptondereau) [[#648](https://github.com/davidcole1340/ext-php-rs/issues/648)] 
+- *(deps)* Bump parking_lot required version to 0.12.3 (by @TobiasBengtsson) [[#640](https://github.com/davidcole1340/ext-php-rs/issues/640)] 
+- *(doc)* Update mdbook config ([#651](https://github.com/extphprs/ext-php-rs/pull/651)) (by @ptondereau) [[#651](https://github.com/davidcole1340/ext-php-rs/issues/651)] 
+- *(macro)* Refactor allowed and forbidden keywords to match PHP parser ([#647](https://github.com/extphprs/ext-php-rs/pull/647)) (by @ptondereau) [[#647](https://github.com/davidcole1340/ext-php-rs/issues/647)] 
+- *(windows)* Add fallback for 404 errors in windows build ([#649](https://github.com/extphprs/ext-php-rs/pull/649)) (by @ptondereau) [[#649](https://github.com/davidcole1340/ext-php-rs/issues/649)] 
+- Handle PHP mocks and subclasses of Rust-backed classes ([#653](https://github.com/extphprs/ext-php-rs/pull/653)) (by @ptondereau) [[#653](https://github.com/davidcole1340/ext-php-rs/issues/653)] 
 ## [0.15.3](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.2...ext-php-rs-v0.15.3) - 2025-12-28
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.15.3"
+version = "0.15.4"
 authors = [
     "Pierre Tondereau <pierre.tondereau@protonmail.com>",
     "Xenira <xenira@php.rs>",
@@ -23,7 +23,7 @@ cfg-if = "1.0"
 once_cell = "1.21"
 anyhow = { version = "1", optional = true }
 smartstring = { version = "1", optional = true }
-ext-php-rs-derive = { version = "=0.11.6", path = "./crates/macros" }
+ext-php-rs-derive = { version = "=0.11.7", path = "./crates/macros" }
 
 [dev-dependencies]
 skeptic = "0.13"

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.16](https://github.com/extphprs/ext-php-rs/compare/cargo-php-v0.1.15...cargo-php-v0.1.16) - 2026-01-26
+
+### Fixed
+- *(cargo-php)* Use runtime feature for cargo-php to avoid dynamic linking on musl ([#645](https://github.com/extphprs/ext-php-rs/pull/645)) (by @ptondereau) [[#645](https://github.com/davidcole1340/ext-php-rs/issues/645)] 
 ## [0.1.15](https://github.com/extphprs/ext-php-rs/compare/cargo-php-v0.1.14...cargo-php-v0.1.15) - 2025-12-28
 
 ### Added

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.1.15"
+version = "0.1.16"
 authors = [
     "Xenira <xenira@php.rs>",
     "David Cole <david.cole1340@gmail.com>",

--- a/crates/macros/CHANGELOG.md
+++ b/crates/macros/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.11.7](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.6...ext-php-rs-derive-v0.11.7) - 2026-01-26
+
+### Added
+- *(class)* Readonly and final classes ([#639](https://github.com/extphprs/ext-php-rs/pull/639)) (by @kakserpom) [[#639](https://github.com/davidcole1340/ext-php-rs/issues/639)] 
+
+### Fixed
+- *(cargo-php)* Use runtime feature for cargo-php to avoid dynamic linking on musl ([#645](https://github.com/extphprs/ext-php-rs/pull/645)) (by @ptondereau) [[#645](https://github.com/davidcole1340/ext-php-rs/issues/645)] 
+- *(macro)* Refactor allowed and forbidden keywords to match PHP parser ([#647](https://github.com/extphprs/ext-php-rs/pull/647)) (by @ptondereau) [[#647](https://github.com/davidcole1340/ext-php-rs/issues/647)] 
+- Handle PHP mocks and subclasses of Rust-backed classes ([#653](https://github.com/extphprs/ext-php-rs/pull/653)) (by @ptondereau) [[#653](https://github.com/davidcole1340/ext-php-rs/issues/653)] 
 ## [0.11.6](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.5...ext-php-rs-derive-v0.11.6) - 2025-12-28
 
 ### Added

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -4,7 +4,7 @@ description = "Derive macros for ext-php-rs."
 repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
-version = "0.11.6"
+version = "0.11.7"
 authors = [
     "Xenira <xenira@php.rs>",
     "David Cole <david.cole1340@gmail.com>",

--- a/crates/php-build/CHANGELOG.md
+++ b/crates/php-build/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [0.1.0](https://github.com/extphprs/ext-php-rs/releases/tag/ext-php-rs-build-v0.1.0) - 2026-01-26
+
+### Added
+- *(object)* Lazy ghost and Lazy Proxy ([#636](https://github.com/extphprs/ext-php-rs/pull/636)) (by @kakserpom) [[#636](https://github.com/davidcole1340/ext-php-rs/issues/636)] 


### PR DESCRIPTION



## 🤖 New release

* `ext-php-rs-derive`: 0.11.6 -> 0.11.7
* `ext-php-rs-build`: 0.1.0
* `ext-php-rs`: 0.15.3 -> 0.15.4 (✓ API compatible changes)
* `cargo-php`: 0.1.15 -> 0.1.16 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `ext-php-rs-derive`

<blockquote>

## [0.11.7](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.6...ext-php-rs-derive-v0.11.7) - 2026-01-26

### Added
- *(class)* Readonly and final classes ([#639](https://github.com/extphprs/ext-php-rs/pull/639)) (by @kakserpom) [[#639](https://github.com/davidcole1340/ext-php-rs/issues/639)] 

### Fixed
- *(cargo-php)* Use runtime feature for cargo-php to avoid dynamic linking on musl ([#645](https://github.com/extphprs/ext-php-rs/pull/645)) (by @ptondereau) [[#645](https://github.com/davidcole1340/ext-php-rs/issues/645)] 
- *(macro)* Refactor allowed and forbidden keywords to match PHP parser ([#647](https://github.com/extphprs/ext-php-rs/pull/647)) (by @ptondereau) [[#647](https://github.com/davidcole1340/ext-php-rs/issues/647)] 
- Handle PHP mocks and subclasses of Rust-backed classes ([#653](https://github.com/extphprs/ext-php-rs/pull/653)) (by @ptondereau) [[#653](https://github.com/davidcole1340/ext-php-rs/issues/653)]
</blockquote>

## `ext-php-rs-build`

<blockquote>

## [0.1.0](https://github.com/extphprs/ext-php-rs/releases/tag/ext-php-rs-build-v0.1.0) - 2026-01-26

### Added
- *(object)* Lazy ghost and Lazy Proxy ([#636](https://github.com/extphprs/ext-php-rs/pull/636)) (by @kakserpom) [[#636](https://github.com/davidcole1340/ext-php-rs/issues/636)]
</blockquote>

## `ext-php-rs`

<blockquote>

## [0.15.4](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.3...ext-php-rs-v0.15.4) - 2026-01-26

### Added
- *(array)* Entry API (Issue #525) ([#611](https://github.com/extphprs/ext-php-rs/pull/611)) (by @kakserpom) [[#525](https://github.com/davidcole1340/ext-php-rs/issues/525)] [[#611](https://github.com/davidcole1340/ext-php-rs/issues/611)] 
- *(class)* Readonly and final classes ([#639](https://github.com/extphprs/ext-php-rs/pull/639)) (by @kakserpom) [[#639](https://github.com/davidcole1340/ext-php-rs/issues/639)] 
- *(core)* Add observer API ([#650](https://github.com/extphprs/ext-php-rs/pull/650)) (by @ptondereau) [[#650](https://github.com/davidcole1340/ext-php-rs/issues/650)] 
- *(object)* Lazy ghost and Lazy Proxy ([#636](https://github.com/extphprs/ext-php-rs/pull/636)) (by @kakserpom) [[#636](https://github.com/davidcole1340/ext-php-rs/issues/636)] 
- *(string)* Smartstring support ([#643](https://github.com/extphprs/ext-php-rs/pull/643)) (by @kakserpom) [[#643](https://github.com/davidcole1340/ext-php-rs/issues/643)] 

### Fixed
- *(cargo-php)* Use runtime feature for cargo-php to avoid dynamic linking on musl ([#645](https://github.com/extphprs/ext-php-rs/pull/645)) (by @ptondereau) [[#645](https://github.com/davidcole1340/ext-php-rs/issues/645)] 
- *(clippy)* V1.93.0 errors ([#648](https://github.com/extphprs/ext-php-rs/pull/648)) (by @ptondereau) [[#648](https://github.com/davidcole1340/ext-php-rs/issues/648)] 
- *(deps)* Bump parking_lot required version to 0.12.3 (by @TobiasBengtsson) [[#640](https://github.com/davidcole1340/ext-php-rs/issues/640)] 
- *(doc)* Update mdbook config ([#651](https://github.com/extphprs/ext-php-rs/pull/651)) (by @ptondereau) [[#651](https://github.com/davidcole1340/ext-php-rs/issues/651)] 
- *(macro)* Refactor allowed and forbidden keywords to match PHP parser ([#647](https://github.com/extphprs/ext-php-rs/pull/647)) (by @ptondereau) [[#647](https://github.com/davidcole1340/ext-php-rs/issues/647)] 
- *(windows)* Add fallback for 404 errors in windows build ([#649](https://github.com/extphprs/ext-php-rs/pull/649)) (by @ptondereau) [[#649](https://github.com/davidcole1340/ext-php-rs/issues/649)] 
- Handle PHP mocks and subclasses of Rust-backed classes ([#653](https://github.com/extphprs/ext-php-rs/pull/653)) (by @ptondereau) [[#653](https://github.com/davidcole1340/ext-php-rs/issues/653)]
</blockquote>

## `cargo-php`

<blockquote>

## [0.1.16](https://github.com/extphprs/ext-php-rs/compare/cargo-php-v0.1.15...cargo-php-v0.1.16) - 2026-01-26

### Fixed
- *(cargo-php)* Use runtime feature for cargo-php to avoid dynamic linking on musl ([#645](https://github.com/extphprs/ext-php-rs/pull/645)) (by @ptondereau) [[#645](https://github.com/davidcole1340/ext-php-rs/issues/645)]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).