### PR TITLE
fix(cargo-php): use runtime feature to avoid dy linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,22 @@ best resource at the moment. This can be viewed at [docs.rs].
 
 ### Alpine Linux (musl)
 
-Building for Alpine Linux (musl libc) is supported on stable Rust with dynamic linking
-thanks to `runtime` feature flag from `bindgen`.
+Building on Alpine Linux (musl libc) is supported thanks to the `runtime` feature flag.
 
-**Note**: Building for musl requires dynamic CRT linking (`-crt-static` flag) to produce
-the `cdylib` output required for PHP extensions.
-If you want to build statically, you'll need full LLVM + Clang toolchain.
-Please read: <https://github.com/KyleMayes/clang-sys#static>
+```sh
+# Install dependencies and cargo-php
+apk add clang16-libclang
+cargo install cargo-php
+```
+
+When building your own extensions, add to your project's `.cargo/config.toml`:
+
+```toml
+[target.'cfg(target_env = "musl")']
+rustflags = ["-C", "target-feature=-crt-static"]
+```
+
+For static linking, see: <https://github.com/KyleMayes/clang-sys#static>
 
 ### Windows Requirements
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2024"
 categories = ["api-bindings", "command-line-interface"]
 
 [dependencies]
-ext-php-rs = { version = "0.15", default-features = false, path = "../../" }
+ext-php-rs = { version = "0.15", default-features = false, features = ["runtime"], path = "../../" }
 
 clap = { version = "4.0", features = ["derive"] }
 anyhow = "1"
@@ -30,3 +30,5 @@ missing_docs = "warn"
 [features]
 default = ["enum"]
 enum = ["ext-php-rs/enum"]
+runtime = ["ext-php-rs/runtime"]
+static = ["ext-php-rs/static"]


### PR DESCRIPTION
## Description

Fix #644 
