### PR TITLE
fix(macro): refactor allowed and forbidden keywords to match PHP parser

### DIFF
--- a/tests/src/integration/class/class.php
+++ b/tests/src/integration/class/class.php
@@ -156,3 +156,35 @@ $output = ob_get_clean();
 assert(strpos($output, 'publicNum') !== false, 'var_dump should show public property');
 // Private properties should show as ClassName::propertyName in var_dump
 // Protected properties should show with * prefix
+
+// Test reserved keyword method names
+$keywordObj = new TestReservedKeywordMethods();
+
+$result = $keywordObj->new('test value');
+assert($result === 'new called with: test value', 'Method named "new" should work');
+
+$result = $keywordObj->default();
+assert($result === 'default value', 'Method named "default" should work');
+
+$result = $keywordObj->class();
+assert($result === 'TestReservedKeywordMethods', 'Method named "class" should work');
+
+$result = $keywordObj->match('test');
+assert($result === true, 'Method named "match" should work');
+$result = $keywordObj->match('notfound');
+assert($result === false, 'Method named "match" should work with non-matching pattern');
+
+$result = $keywordObj->return();
+assert($result === 'test value', 'Method named "return" should work');
+
+$result = $keywordObj->static();
+assert($result === 'not actually static', 'Method named "static" should work');
+
+$reflection = new ReflectionClass(TestReservedKeywordMethods::class);
+$methodNames = array_map(fn($m) => $m->getName(), $reflection->getMethods());
+assert(in_array('new', $methodNames), 'Method "new" should exist in reflection');
+assert(in_array('default', $methodNames), 'Method "default" should exist in reflection');
+assert(in_array('class', $methodNames), 'Method "class" should exist in reflection');
+assert(in_array('match', $methodNames), 'Method "match" should exist in reflection');
+assert(in_array('return', $methodNames), 'Method "return" should exist in reflection');
+assert(in_array('static', $methodNames), 'Method "static" should exist in reflection');

--- a/tests/src/integration/class/mod.rs
+++ b/tests/src/integration/class/mod.rs
@@ -277,7 +277,49 @@ impl FluentBuilder {
     }
 }
 
-/// Test class for property visibility (Issue #375)
+/// Test class for reserved keyword method names
+#[php_class]
+pub struct TestReservedKeywordMethods {
+    value: String,
+}
+
+#[php_impl]
+impl TestReservedKeywordMethods {
+    pub fn __construct() -> Self {
+        Self {
+            value: String::from("initial"),
+        }
+    }
+
+    #[allow(clippy::wrong_self_convention, clippy::new_ret_no_self)]
+    pub fn r#new(&mut self, value: String) -> String {
+        let result = format!("new called with: {value}");
+        self.value = value;
+        result
+    }
+
+    pub fn r#default(&self) -> String {
+        String::from("default value")
+    }
+
+    pub fn r#class(&self) -> String {
+        String::from("TestReservedKeywordMethods")
+    }
+
+    pub fn r#match(&self, pattern: String) -> bool {
+        self.value.contains(&pattern)
+    }
+
+    pub fn r#return(&self) -> String {
+        self.value.clone()
+    }
+
+    pub fn r#static(&self) -> String {
+        String::from("not actually static")
+    }
+}
+
+/// Test class for property visibility
 #[php_class]
 pub struct TestPropertyVisibility {
     /// Public property - accessible from anywhere
@@ -333,6 +375,7 @@ pub fn build_module(builder: ModuleBuilder) -> ModuleBuilder {
         .class::<TestStaticProps>()
         .class::<FluentBuilder>()
         .class::<TestPropertyVisibility>()
+        .class::<TestReservedKeywordMethods>()
         .function(wrap_function!(test_class))
         .function(wrap_function!(throw_exception))
 }


### PR DESCRIPTION
## Description

Fix #646 
