### PR TITLE
feat(core): add observer API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Run rustfmt
         run: cargo fmt --all -- --check
       - name: Run clippy
-        run: cargo clippy --workspace --all-targets --features closure,embed,anyhow -- -W clippy::pedantic -D warnings
+        run: cargo clippy --workspace --all-targets --features closure,embed,anyhow,observer -- -W clippy::pedantic -D warnings
       # Docs
       - name: Run rustdoc
         run: cargo rustdoc -- -D warnings
@@ -162,12 +162,12 @@ jobs:
       - name: Build
         env:
           EXT_PHP_RS_TEST: ""
-        run: cargo build --release --features closure,anyhow,runtime --workspace
+        run: cargo build --release --features closure,anyhow,runtime,observer --workspace
       # Test
       - name: Test inline examples
         # Macos fails on unstable rust. We skip the inline examples test for now.
         if: "!(contains(matrix.os, 'macos') && matrix.rust == 'nightly')"
-        run: cargo test --release --workspace --features closure,anyhow,runtime --no-fail-fast
+        run: cargo test --release --workspace --features closure,anyhow,runtime,observer --no-fail-fast
   test-embed:
     name: Test with embed (NTS)
     runs-on: ubuntu-latest
@@ -224,7 +224,7 @@ jobs:
           echo "LLVM_CONFIG_PATH=${{ runner.temp }}/llvm-${{ env.clang }}/bin/llvm-config" >> $GITHUB_ENV
 
       - name: Test with embed feature
-        run: cargo test --workspace --release --features closure,embed,anyhow,smartstring --no-fail-fast
+        run: cargo test --workspace --release --features closure,embed,anyhow,smartstring,observer --no-fail-fast
 
   build-musl:
     name: musl / ${{ matrix.php }} / ${{ matrix.phpts[1] }}
@@ -259,11 +259,11 @@ jobs:
             -v $(pwd):/workspace \
             -w /workspace \
             extphprs/ext-php-rs:musl-${{ matrix.php }}-${{ matrix.phpts[1] }} \
-            build --release --features closure,anyhow,runtime --workspace
+            build --release --features closure,anyhow,runtime,observer --workspace
       - name: Run tests
         run: |
           docker run \
             -v $(pwd):/workspace \
             -w /workspace \
             extphprs/ext-php-rs:musl-${{ matrix.php }}-${{ matrix.phpts[1] }} \
-            test --workspace --release --features closure,anyhow,runtime --no-fail-fast
+            test --workspace --release --features closure,anyhow,runtime,observer --no-fail-fast

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -62,6 +62,6 @@ jobs:
           cargo tarpaulin --version
       - name: Run tests
         run: |
-          cargo tarpaulin --engine llvm --workspace --features closure,embed,anyhow --tests --exclude tests --exclude-files docsrs_bindings.rs --exclude-files "crates/macros/tests/expand/*.expanded.rs" --timeout 120 --out Xml
+          cargo tarpaulin --engine llvm --workspace --features closure,embed,anyhow,observer --tests --exclude tests --exclude-files docsrs_bindings.rs --exclude-files "crates/macros/tests/expand/*.expanded.rs" --timeout 120 --out Xml
       - name: Upload coverage
         uses: coverallsapp/github-action@v2

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -8,7 +8,7 @@ pre-commit:
         - "crates/macros/tests/expand/*.expanded.rs"
       stage_fixed: true
     - name: clippy
-      run: cargo clippy --workspace --all-targets --features closure,embed,anyhow -- -W clippy::pedantic -D warnings
+      run: cargo clippy --workspace --all-targets --features closure,embed,anyhow,observer -- -W clippy::pedantic -D warnings
       glob: "*.rs"
     - name: bindings
       run: tools/update_bindings.sh && git diff --exit-code docsrs_bindings.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ embed = []
 anyhow = ["dep:anyhow"]
 smartstring = ["dep:smartstring"]
 enum = []
+observer = []
 runtime = ["bindgen/runtime"]
 static = ["bindgen/static"]
 
@@ -68,6 +69,11 @@ missing_docs = "warn"
 [[example]]
 name = "hello_world"
 crate-type = ["cdylib"]
+
+[[example]]
+name = "observer"
+crate-type = ["cdylib"]
+required-features = ["observer"]
 
 [[test]]
 name = "guide_tests"

--- a/allowed_bindings.rs
+++ b/allowed_bindings.rs
@@ -360,5 +360,13 @@ bind! {
     php_ini_builder_unquoted,
     php_ini_builder_quoted,
     php_ini_builder_define,
-    php_output_write
+    php_output_write,
+    zend_observer_fcall_handlers,
+    _zend_observer_fcall_handlers,
+    zend_observer_fcall_begin_handler,
+    zend_observer_fcall_end_handler,
+    zend_observer_fcall_init,
+    zend_observer_fcall_register,
+    zend_function,
+    zend_op_array
 }

--- a/examples/observer.rs
+++ b/examples/observer.rs
@@ -1,0 +1,48 @@
+//! Example: Observer API for function call profiling.
+//!
+//! Build: `cargo build --example observer --features observer`
+
+#![allow(missing_docs, clippy::must_use_candidate)]
+#![cfg_attr(windows, feature(abi_vectorcall))]
+
+use ext_php_rs::prelude::*;
+use ext_php_rs::types::Zval;
+use ext_php_rs::zend::ExecuteData;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Simple profiler that counts user function calls.
+pub struct SimpleProfiler {
+    call_count: AtomicU64,
+}
+
+impl SimpleProfiler {
+    fn new() -> Self {
+        Self {
+            call_count: AtomicU64::new(0),
+        }
+    }
+}
+
+impl FcallObserver for SimpleProfiler {
+    fn should_observe(&self, info: &FcallInfo) -> bool {
+        !info.is_internal
+    }
+
+    fn begin(&self, _execute_data: &ExecuteData) {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn end(&self, _execute_data: &ExecuteData, _retval: Option<&Zval>) {}
+}
+
+#[php_function]
+pub fn observer_get_call_count() -> u64 {
+    0
+}
+
+#[php_module]
+pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
+    module
+        .fcall_observer(SimpleProfiler::new)
+        .function(wrap_function!(observer_get_call_count))
+}

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -43,6 +43,7 @@
 
 - [Async](./advanced/async_impl.md)
 - [Bailout Guard](./advanced/bailout_guard.md)
+- [Observer API](./advanced/observer.md)
 - [Allowed Bindings](./advanced/allowed_bindings.md)
 
 # Migration Guides

--- a/guide/src/advanced/observer.md
+++ b/guide/src/advanced/observer.md
@@ -1,0 +1,209 @@
+# Observer API
+
+The Observer API allows you to build profilers, tracers, and instrumentation tools
+that observe PHP function calls. This is useful for:
+
+- Performance profiling
+- Request tracing (APM)
+- Code coverage tools
+- Debugging tools
+
+## Enabling the Feature
+
+The Observer API is behind a feature flag. Add it to your `Cargo.toml`:
+
+```toml
+[dependencies]
+ext-php-rs = { version = "0.15", features = ["observer"] }
+```
+
+## Basic Usage
+
+Implement the `FcallObserver` trait to create an observer:
+
+```rust,ignore
+use ext_php_rs::prelude::*;
+use ext_php_rs::types::Zval;
+use ext_php_rs::zend::ExecuteData;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// A simple profiler that counts function calls.
+struct CallCounter {
+    count: AtomicU64,
+}
+
+impl CallCounter {
+    fn new() -> Self {
+        Self {
+            count: AtomicU64::new(0),
+        }
+    }
+}
+
+impl FcallObserver for CallCounter {
+    fn should_observe(&self, info: &FcallInfo) -> bool {
+        // Only observe user-defined functions (not internal PHP functions)
+        !info.is_internal
+    }
+
+    fn begin(&self, _execute_data: &ExecuteData) {
+        self.count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn end(&self, _execute_data: &ExecuteData, _retval: Option<&Zval>) {
+        // Called when the function returns
+    }
+}
+
+#[php_module]
+pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
+    module.fcall_observer(CallCounter::new)
+}
+```
+
+## The `FcallObserver` Trait
+
+The trait has three methods:
+
+### `should_observe`
+
+```rust,ignore
+fn should_observe(&self, info: &FcallInfo) -> bool;
+```
+
+Called once per unique function to determine if it should be observed.
+The result is cached by PHP, so this is only called once per function definition.
+
+Return `true` to observe the function, `false` to skip it.
+
+### `begin`
+
+```rust,ignore
+fn begin(&self, execute_data: &ExecuteData);
+```
+
+Called when an observed function begins execution. Use this to:
+- Record start timestamps for profiling
+- Push to a call stack for tracing
+- Log function entry
+
+### `end`
+
+```rust,ignore
+fn end(&self, execute_data: &ExecuteData, retval: Option<&Zval>);
+```
+
+Called when an observed function ends execution. This is called even if
+the function throws an exception. Use this to:
+- Calculate execution duration
+- Pop from a call stack
+- Record return values
+
+## `FcallInfo` - Function Metadata
+
+The `FcallInfo` struct provides metadata about the function being called:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `function_name` | `Option<&str>` | Function name (None for anonymous/main) |
+| `class_name` | `Option<&str>` | Class name for methods |
+| `filename` | `Option<&str>` | Source file (None for internal functions) |
+| `lineno` | `u32` | Line number (0 for internal functions) |
+| `is_internal` | `bool` | True for built-in PHP functions |
+
+## Thread Safety
+
+The observer is created once during MINIT and stored as a global singleton
+shared across all requests. The observer must implement `Send + Sync` because:
+
+- **NTS (Non-Thread-Safe)**: A single global observer instance handles all requests
+- **ZTS (Thread-Safe)**: The same observer instance may be called from different threads
+
+Use thread-safe primitives like `AtomicU64`, `Mutex`, or `RwLock` for
+any mutable state in your observer.
+
+## Example: Simple Profiler
+
+Here's a more complete example that tracks function timing:
+
+```rust,ignore
+use ext_php_rs::prelude::*;
+use ext_php_rs::types::Zval;
+use ext_php_rs::zend::ExecuteData;
+use std::sync::Mutex;
+use std::time::Instant;
+use std::collections::HashMap;
+
+struct TimingProfiler {
+    // Track start times per call (thread-safe)
+    call_stack: Mutex<Vec<(String, Instant)>>,
+    // Accumulated timings
+    timings: Mutex<HashMap<String, u128>>,
+}
+
+impl TimingProfiler {
+    fn new() -> Self {
+        Self {
+            call_stack: Mutex::new(Vec::new()),
+            timings: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl FcallObserver for TimingProfiler {
+    fn should_observe(&self, info: &FcallInfo) -> bool {
+        // Only observe user functions
+        !info.is_internal
+    }
+
+    fn begin(&self, execute_data: &ExecuteData) {
+        let func_name = execute_data
+            .get_function_name()
+            .unwrap_or_else(|| "unknown".to_string());
+
+        if let Ok(mut stack) = self.call_stack.lock() {
+            stack.push((func_name, Instant::now()));
+        }
+    }
+
+    fn end(&self, _execute_data: &ExecuteData, _retval: Option<&Zval>) {
+        if let Ok(mut stack) = self.call_stack.lock() {
+            if let Some((func_name, start)) = stack.pop() {
+                let duration = start.elapsed().as_micros();
+
+                if let Ok(mut timings) = self.timings.lock() {
+                    *timings.entry(func_name).or_insert(0) += duration;
+                }
+            }
+        }
+    }
+}
+
+#[php_module]
+pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
+    module.fcall_observer(TimingProfiler::new)
+}
+```
+
+## Best Practices
+
+1. **Keep observers lightweight**: The `begin` and `end` methods are called
+   for every function invocation. Avoid heavy computations or I/O.
+
+2. **Use `should_observe` wisely**: Filter out functions you don't need
+   to observe. This is cached by PHP, so complex logic here is acceptable.
+
+3. **Handle errors gracefully**: Don't panic in observer methods. Use
+   `Result` types and log errors instead.
+
+4. **Consider memory usage**: If storing call data, implement limits or
+   periodic flushing to avoid unbounded memory growth.
+
+5. **Test with real workloads**: Profile your observer itself to ensure
+   it doesn't add significant overhead.
+
+## Limitations
+
+- Only function calls can be observed (not opcodes or other events)
+- The observer is registered globally for the entire PHP process
+- Only one observer can be registered per extension

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,12 @@ pub mod describe;
 pub mod embed;
 #[cfg(feature = "enum")]
 pub mod enum_;
+#[cfg(feature = "observer")]
+#[cfg_attr(docs, doc(cfg(feature = "observer")))]
+pub mod observer {
+    //! Observer API for function call profiling and tracing.
+    pub use crate::zend::observer::{FcallInfo, FcallObserver};
+}
 #[doc(hidden)]
 pub mod internal;
 pub mod props;
@@ -57,6 +63,8 @@ pub mod prelude {
     pub use crate::php_write;
     pub use crate::types::ZendCallable;
     pub use crate::zend::BailoutGuard;
+    #[cfg(feature = "observer")]
+    pub use crate::zend::{FcallInfo, FcallObserver};
     pub use crate::{
         ZvalConvert, php_class, php_const, php_extern, php_function, php_impl, php_interface,
         php_module, wrap_constant, wrap_function, zend_fastcall,

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -38,6 +38,7 @@
 #include "zend_interfaces.h"
 #include "php_variables.h"
 #include "zend_ini.h"
+#include "zend_observer.h"
 #include "main/SAPI.h"
 
 zend_string *ext_php_rs_zend_string_init(const char *str, size_t len, bool persistent);

--- a/src/zend/mod.rs
+++ b/src/zend/mod.rs
@@ -11,6 +11,8 @@ mod handlers;
 mod ini_entry_def;
 mod linked_list;
 mod module;
+#[cfg(feature = "observer")]
+pub(crate) mod observer;
 mod streams;
 mod try_catch;
 
@@ -39,6 +41,8 @@ pub use handlers::ZendObjectHandlers;
 pub use ini_entry_def::IniEntryDef;
 pub use linked_list::ZendLinkedList;
 pub use module::ModuleEntry;
+#[cfg(feature = "observer")]
+pub use observer::{FcallInfo, FcallObserver};
 pub use streams::*;
 #[cfg(feature = "embed")]
 pub(crate) use try_catch::panic_wrapper;

--- a/src/zend/observer.rs
+++ b/src/zend/observer.rs
@@ -1,0 +1,278 @@
+//! Zend Observer API bindings for function call observation.
+//!
+//! Enables creation of profilers, tracers, and instrumentation tools.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use ext_php_rs::prelude::*;
+//!
+//! struct MyProfiler;
+//!
+//! impl FcallObserver for MyProfiler {
+//!     fn should_observe(&self, info: &FcallInfo) -> bool {
+//!         !info.is_internal
+//!     }
+//!
+//!     fn begin(&self, _execute_data: &ExecuteData) {}
+//!     fn end(&self, _execute_data: &ExecuteData, _retval: Option<&Zval>) {}
+//! }
+//! ```
+
+use std::sync::OnceLock;
+
+use crate::ffi;
+use crate::types::Zval;
+use crate::zend::ExecuteData;
+
+/// Metadata about a function being called.
+#[derive(Debug, Clone)]
+pub struct FcallInfo<'a> {
+    /// Function name (`None` for anonymous functions or main script).
+    pub function_name: Option<&'a str>,
+    /// Class name for method calls.
+    pub class_name: Option<&'a str>,
+    /// Source filename (`None` for internal functions).
+    pub filename: Option<&'a str>,
+    /// Line number (0 for internal functions).
+    pub lineno: u32,
+    /// Whether this is an internal (built-in) PHP function.
+    pub is_internal: bool,
+}
+
+impl FcallInfo<'_> {
+    fn empty() -> Self {
+        Self {
+            function_name: None,
+            class_name: None,
+            filename: None,
+            lineno: 0,
+            is_internal: false,
+        }
+    }
+}
+
+/// Trait for observing PHP function calls.
+///
+/// # Lifecycle
+///
+/// 1. `should_observe` is called once per unique function (cached by PHP)
+/// 2. If `true`, `begin` is called at function entry
+/// 3. `end` is called at function exit (even on exceptions)
+///
+/// # Thread Safety
+///
+/// Observer must be `Send + Sync`. Use thread-safe primitives for mutable state.
+pub trait FcallObserver: 'static {
+    /// Whether to observe a specific function (result is cached by PHP).
+    fn should_observe(&self, info: &FcallInfo) -> bool;
+
+    /// Called when an observed function begins execution.
+    fn begin(&self, execute_data: &ExecuteData);
+
+    /// Called when an observed function ends execution (even on exceptions).
+    fn end(&self, execute_data: &ExecuteData, retval: Option<&Zval>);
+}
+
+type ObserverFactory = Box<dyn Fn() -> Box<dyn FcallObserver + Send + Sync> + Send + Sync>;
+
+static OBSERVER_FACTORY: OnceLock<ObserverFactory> = OnceLock::new();
+static OBSERVER_INSTANCE: OnceLock<Box<dyn FcallObserver + Send + Sync>> = OnceLock::new();
+
+impl FcallInfo<'_> {
+    /// # Safety
+    ///
+    /// `execute_data` must be a valid pointer.
+    pub(crate) unsafe fn from_execute_data(
+        execute_data: *mut ffi::zend_execute_data,
+    ) -> FcallInfo<'static> {
+        if execute_data.is_null() {
+            return FcallInfo::empty();
+        }
+
+        let func = unsafe { (*execute_data).func };
+        if func.is_null() {
+            return FcallInfo::empty();
+        }
+
+        let common = unsafe { &(*func).common };
+        let func_type = common.type_;
+        #[allow(clippy::cast_possible_truncation)]
+        let is_internal = func_type == ffi::ZEND_INTERNAL_FUNCTION as u8;
+
+        let function_name = if common.function_name.is_null() {
+            None
+        } else {
+            unsafe { zend_string_to_str(common.function_name) }
+        };
+
+        let class_name = if common.scope.is_null() {
+            None
+        } else {
+            let ce = unsafe { &*common.scope };
+            if ce.name.is_null() {
+                None
+            } else {
+                unsafe { zend_string_to_str(ce.name) }
+            }
+        };
+
+        let (filename, lineno) = if is_internal {
+            (None, 0)
+        } else {
+            let op_array = unsafe { &(*func).op_array };
+            let filename = if op_array.filename.is_null() {
+                None
+            } else {
+                unsafe { zend_string_to_str(op_array.filename) }
+            };
+            (filename, op_array.line_start)
+        };
+
+        FcallInfo {
+            function_name,
+            class_name,
+            filename,
+            lineno,
+            is_internal,
+        }
+    }
+}
+
+/// # Safety
+///
+/// Pointer must be valid and string must be valid UTF-8.
+unsafe fn zend_string_to_str(zs: *mut ffi::zend_string) -> Option<&'static str> {
+    if zs.is_null() {
+        return None;
+    }
+    let len = unsafe { (*zs).len };
+    let ptr = unsafe { (*zs).val.as_ptr() };
+    let slice = unsafe { std::slice::from_raw_parts(ptr.cast::<u8>(), len) };
+    std::str::from_utf8(slice).ok()
+}
+
+fn get_observer() -> Option<&'static (dyn FcallObserver + Send + Sync)> {
+    OBSERVER_INSTANCE.get().map(std::convert::AsRef::as_ref)
+}
+
+/// # Safety
+///
+/// Called from PHP's C code.
+unsafe extern "C" fn observer_fcall_init(
+    execute_data: *mut ffi::zend_execute_data,
+) -> ffi::zend_observer_fcall_handlers {
+    let empty = ffi::zend_observer_fcall_handlers {
+        begin: None,
+        end: None,
+    };
+
+    let Some(observer) = get_observer() else {
+        return empty;
+    };
+
+    let info = unsafe { FcallInfo::from_execute_data(execute_data) };
+
+    if observer.should_observe(&info) {
+        ffi::zend_observer_fcall_handlers {
+            begin: Some(observer_begin),
+            end: Some(observer_end),
+        }
+    } else {
+        empty
+    }
+}
+
+/// # Safety
+///
+/// Called from PHP's C code.
+unsafe extern "C" fn observer_begin(execute_data: *mut ffi::zend_execute_data) {
+    if let Some(observer) = get_observer()
+        && let Some(ex) = unsafe { execute_data.as_ref() }
+    {
+        observer.begin(ex);
+    }
+}
+
+/// # Safety
+///
+/// Called from PHP's C code.
+unsafe extern "C" fn observer_end(
+    execute_data: *mut ffi::zend_execute_data,
+    retval: *mut ffi::zval,
+) {
+    if let Some(observer) = get_observer()
+        && let Some(ex) = unsafe { execute_data.as_ref() }
+    {
+        let retval_ref = if retval.is_null() {
+            None
+        } else {
+            Some(unsafe { &*retval.cast_const().cast::<Zval>() })
+        };
+        observer.end(ex, retval_ref);
+    }
+}
+
+/// # Panics
+///
+/// Panics if called more than once.
+pub(crate) fn register_fcall_observer_factory(factory: ObserverFactory) {
+    assert!(
+        OBSERVER_FACTORY.set(factory).is_ok(),
+        "fcall_observer can only be registered once per extension"
+    );
+}
+
+/// # Safety
+///
+/// Must be called during MINIT phase only.
+pub(crate) unsafe fn observer_startup() {
+    if let Some(factory) = OBSERVER_FACTORY.get() {
+        if OBSERVER_INSTANCE.set(factory()).is_err() {
+            return;
+        }
+        unsafe { ffi::zend_observer_fcall_register(Some(observer_fcall_init)) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestObserver {
+        observe_all: bool,
+    }
+
+    unsafe impl Send for TestObserver {}
+    unsafe impl Sync for TestObserver {}
+
+    impl FcallObserver for TestObserver {
+        fn should_observe(&self, _info: &FcallInfo) -> bool {
+            self.observe_all
+        }
+
+        fn begin(&self, _execute_data: &ExecuteData) {}
+
+        fn end(&self, _execute_data: &ExecuteData, _retval: Option<&Zval>) {}
+    }
+
+    #[test]
+    fn test_fcall_info_empty() {
+        let info = FcallInfo::empty();
+        assert!(info.function_name.is_none());
+        assert!(info.class_name.is_none());
+        assert!(info.filename.is_none());
+        assert_eq!(info.lineno, 0);
+        assert!(!info.is_internal);
+    }
+
+    #[test]
+    fn test_observer_trait_impl() {
+        let observer = TestObserver { observe_all: true };
+        let info = FcallInfo::empty();
+        assert!(observer.should_observe(&info));
+
+        let observer = TestObserver { observe_all: false };
+        assert!(!observer.should_observe(&info));
+    }
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -21,6 +21,7 @@ anyhow = ["ext-php-rs/anyhow"]
 runtime = ["ext-php-rs/runtime"]
 closure = ["ext-php-rs/closure"]
 static = ["ext-php-rs/static"]
+observer = ["ext-php-rs/observer"]
 
 [lib]
 crate-type = ["cdylib"]

--- a/tests/src/integration/mod.rs
+++ b/tests/src/integration/mod.rs
@@ -16,6 +16,8 @@ pub mod magic_method;
 pub mod nullable;
 pub mod number;
 pub mod object;
+#[cfg(feature = "observer")]
+pub mod observer;
 pub mod persistent_string;
 pub mod string;
 pub mod types;
@@ -55,6 +57,8 @@ mod test {
                 features.push("runtime");
                 #[cfg(feature = "static")]
                 features.push("static");
+                #[cfg(feature = "observer")]
+                features.push("observer");
 
                 if !features.is_empty() {
                     command.arg("--no-default-features");

--- a/tests/src/integration/observer/mod.rs
+++ b/tests/src/integration/observer/mod.rs
@@ -1,0 +1,109 @@
+//! Integration tests for the Observer API.
+
+use ext_php_rs::prelude::*;
+use ext_php_rs::types::Zval;
+use ext_php_rs::zend::ExecuteData;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Test observer that counts user function calls.
+pub struct TestObserver {
+    call_count: AtomicU64,
+    end_count: AtomicU64,
+}
+
+impl TestObserver {
+    fn new() -> Self {
+        Self {
+            call_count: AtomicU64::new(0),
+            end_count: AtomicU64::new(0),
+        }
+    }
+
+    fn get_call_count(&self) -> u64 {
+        self.call_count.load(Ordering::Relaxed)
+    }
+
+    fn get_end_count(&self) -> u64 {
+        self.end_count.load(Ordering::Relaxed)
+    }
+}
+
+impl FcallObserver for TestObserver {
+    fn should_observe(&self, info: &FcallInfo) -> bool {
+        // Only observe user-defined functions, not internal PHP functions
+        !info.is_internal
+    }
+
+    fn begin(&self, _execute_data: &ExecuteData) {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn end(&self, _execute_data: &ExecuteData, _retval: Option<&Zval>) {
+        self.end_count.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+// Static observer instance for testing (needed to access counts from PHP functions)
+static OBSERVER: std::sync::OnceLock<TestObserver> = std::sync::OnceLock::new();
+
+fn get_or_init_observer() -> &'static TestObserver {
+    OBSERVER.get_or_init(TestObserver::new)
+}
+
+/// Get the current call count from the observer.
+#[php_function]
+pub fn observer_test_get_call_count() -> u64 {
+    get_or_init_observer().get_call_count()
+}
+
+/// Get the current end count from the observer.
+#[php_function]
+pub fn observer_test_get_end_count() -> u64 {
+    get_or_init_observer().get_end_count()
+}
+
+/// Reset the observer counters.
+#[php_function]
+pub fn observer_test_reset() {
+    let observer = get_or_init_observer();
+    observer.call_count.store(0, Ordering::Relaxed);
+    observer.end_count.store(0, Ordering::Relaxed);
+}
+
+pub fn build_module(builder: ModuleBuilder) -> ModuleBuilder {
+    // Register the observer factory
+    let builder = builder.fcall_observer(|| {
+        // Return a wrapper that delegates to the static observer
+        TestObserverWrapper
+    });
+
+    builder
+        .function(wrap_function!(observer_test_get_call_count))
+        .function(wrap_function!(observer_test_get_end_count))
+        .function(wrap_function!(observer_test_reset))
+}
+
+/// Wrapper observer that delegates to the static instance.
+struct TestObserverWrapper;
+
+impl FcallObserver for TestObserverWrapper {
+    fn should_observe(&self, info: &FcallInfo) -> bool {
+        get_or_init_observer().should_observe(info)
+    }
+
+    fn begin(&self, execute_data: &ExecuteData) {
+        get_or_init_observer().begin(execute_data);
+    }
+
+    fn end(&self, execute_data: &ExecuteData, retval: Option<&Zval>) {
+        get_or_init_observer().end(execute_data, retval);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn observer_works() {
+        assert!(crate::integration::test::run_php("observer/observer.php"));
+    }
+}

--- a/tests/src/integration/observer/observer.php
+++ b/tests/src/integration/observer/observer.php
@@ -1,0 +1,67 @@
+<?php
+
+// Reset counters at the start
+observer_test_reset();
+
+// Define a user function to observe
+function my_test_function(): string
+{
+    return "hello";
+}
+
+// Define another user function
+function another_function(int $x): int
+{
+    return $x * 2;
+}
+
+// Get initial counts (should be 0 after reset)
+$initial_call_count = observer_test_get_call_count();
+$initial_end_count = observer_test_get_end_count();
+
+// Note: The observer functions themselves are internal (Rust) functions,
+// so they should NOT be counted by our observer which filters to user functions only.
+
+// Call user functions
+my_test_function();
+another_function(5);
+my_test_function();
+
+// Get counts after calling user functions
+$call_count = observer_test_get_call_count();
+$end_count = observer_test_get_end_count();
+
+// We called 3 user functions, so we expect:
+// - call_count should have increased by 3
+// - end_count should have increased by 3
+assert($call_count >= 3, "Expected at least 3 calls, got: " . $call_count);
+assert($end_count >= 3, "Expected at least 3 ends, got: " . $end_count);
+assert($call_count === $end_count, "Call count and end count should match");
+
+// Test nested function calls
+function outer(): int
+{
+    return inner();
+}
+
+function inner(): int
+{
+    return 42;
+}
+
+observer_test_reset();
+$result = outer();
+assert($result === 42, "Nested call should return 42");
+
+$nested_call_count = observer_test_get_call_count();
+$nested_end_count = observer_test_get_end_count();
+
+// outer() calls inner(), so we expect 2 calls
+assert(
+    $nested_call_count >= 2,
+    "Expected at least 2 nested calls, got: " . $nested_call_count,
+);
+assert(
+    $nested_end_count >= 2,
+    "Expected at least 2 nested ends, got: " . $nested_end_count,
+);

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -30,6 +30,10 @@ pub fn build_module(module: ModuleBuilder) -> ModuleBuilder {
     module = integration::nullable::build_module(module);
     module = integration::number::build_module(module);
     module = integration::object::build_module(module);
+    #[cfg(feature = "observer")]
+    {
+        module = integration::observer::build_module(module);
+    }
     module = integration::persistent_string::build_module(module);
     module = integration::string::build_module(module);
     module = integration::variadic_args::build_module(module);


### PR DESCRIPTION
## Description

We add Zend Observer API bindings behind the `observer` feature flag for building profilers, tracers, and instrumentation tools.

The implementation provides a `FcallObserver` trait with three methods: `should_observe` to filter which functions to observe (result is cached by PHP), `begin` called at function entry, and `end` called at function exit even on exceptions. `FcallInfo` provides metadata including function name, class name, filename, line number, and whether the function is internal.

The observer uses a factory pattern with `Send + Sync` requirements for thread safety in both NTS and ZTS PHP builds. Registration happens via `ModuleBuilder::fcall_observer ` during module setup.
                                                                                                                                     