### PR TITLE
fix: handle PHP mocks and subclasses of Rust-backed classes

### DIFF
--- a/src/class.rs
+++ b/src/class.rs
@@ -87,6 +87,21 @@ pub trait RegisteredClass: Sized + 'static {
     )] {
         &[]
     }
+
+    /// Returns a default instance of the class for immediate initialization.
+    ///
+    /// This is used when PHP creates an object without calling the constructor,
+    /// such as when throwing exceptions via `zend_throw_exception_ex`. For types
+    /// that derive `Default`, this will return `Some(Self::default())`, allowing
+    /// the object to be properly initialized even without a constructor call.
+    ///
+    /// # Returns
+    ///
+    /// `Some(Self)` if the type can be default-initialized, `None` otherwise.
+    #[must_use]
+    fn default_init() -> Option<Self> {
+        None
+    }
 }
 
 /// Stores metadata about a classes Rust constructor, including the function

--- a/src/zend/ex.rs
+++ b/src/zend/ex.rs
@@ -176,6 +176,21 @@ impl ExecuteData {
         ZendClassObject::from_zend_obj_mut(self.get_self()?)
     }
 
+    /// Attempts to retrieve the 'this' object, even if the Rust backing
+    /// is not yet initialized. This is used internally by the constructor
+    /// to get access to the object before calling `initialize()`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the returned object is not dereferenced
+    /// to `T` until after `initialize()` is called. Only `initialize()` should
+    /// be called on the returned object.
+    pub(crate) fn get_object_uninit<T: RegisteredClass>(
+        &mut self,
+    ) -> Option<&mut ZendClassObject<T>> {
+        ZendClassObject::from_zend_obj_mut_uninit(self.get_self()?)
+    }
+
     /// Attempts to retrieve the 'this' object, which can be used in class
     /// methods to retrieve the underlying Zend object.
     ///


### PR DESCRIPTION
## Description

Fixes panics when PHPUnit mocks or subclasses don't call the parent constructor.

- Add the `default_init()` trait method for types deriving Default
- Fall back to standard PHP handlers for uninitialized objects
- Add `from_zend_obj_mut_uninit` for constructor access
- Check the handler's pointer to reject non-native objects


