### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.15.5](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.4...ext-php-rs-v0.15.5) - 2026-01-28
+
+### Fixed
+- *(bindgen)* Use fork from ext-php-rs ([#659](https://github.com/extphprs/ext-php-rs/pull/659)) (by @ptondereau) [[#659](https://github.com/davidcole1340/ext-php-rs/issues/659)] 
+
+### Other
+- *(guide)* Customize favicon ([#654](https://github.com/extphprs/ext-php-rs/pull/654)) (by @c14n) [[#654](https://github.com/davidcole1340/ext-php-rs/issues/654)] 
 ## [0.15.4](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.3...ext-php-rs-v0.15.4) - 2026-01-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.15.4"
+version = "0.15.5"
 authors = [
     "Pierre Tondereau <pierre.tondereau@protonmail.com>",
     "Xenira <xenira@php.rs>",
@@ -36,7 +36,7 @@ ext-php-rs-bindgen = { version = "0.72.1-extphprs.1", default-features = false, 
 ] }
 cc = "1.2"
 skeptic = "0.13"
-ext-php-rs-build = { version = "0.1.0", path = "./crates/php-build" }
+ext-php-rs-build = { version = "0.1.1", path = "./crates/php-build" }
 
 [target.'cfg(windows)'.build-dependencies]
 ureq = { version = "3.0", features = [

--- a/crates/php-build/CHANGELOG.md
+++ b/crates/php-build/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.1](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-build-v0.1.0...ext-php-rs-build-v0.1.1) - 2026-01-28
+
+### Other
+- Release (by @Xenira)
 ## [0.1.0](https://github.com/extphprs/ext-php-rs/releases/tag/ext-php-rs-build-v0.1.0) - 2026-01-26
 
 ### Added

--- a/crates/php-build/Cargo.toml
+++ b/crates/php-build/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend", "build"]
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "Pierre Tondereau <pierre.tondereau@protonmail.com>",
     "Xenira <xenira@php.rs>",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,7 +12,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(php84)'] }
 ext-php-rs = { path = "../", default-features = false }
 
 [build-dependencies]
-ext-php-rs-build = { version = "0.1.0", path = "../crates/php-build" }
+ext-php-rs-build = { version = "0.1.1", path = "../crates/php-build" }
 
 [features]
 default = ["enum", "runtime", "closure"]


### PR DESCRIPTION



## 🤖 New release

* `ext-php-rs-build`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `ext-php-rs`: 0.15.4 -> 0.15.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `ext-php-rs-build`

<blockquote>

## [0.1.1](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-build-v0.1.0...ext-php-rs-build-v0.1.1) - 2026-01-28

### Other
- Release (by @Xenira)
</blockquote>

## `ext-php-rs`

<blockquote>

## [0.15.5](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.4...ext-php-rs-v0.15.5) - 2026-01-28

### Fixed
- *(bindgen)* Use fork from ext-php-rs ([#659](https://github.com/extphprs/ext-php-rs/pull/659)) (by @ptondereau) [[#659](https://github.com/davidcole1340/ext-php-rs/issues/659)] 

### Other
- *(guide)* Customize favicon ([#654](https://github.com/extphprs/ext-php-rs/pull/654)) (by @c14n) [[#654](https://github.com/davidcole1340/ext-php-rs/issues/654)]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).