### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+## [0.15.6](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.5...ext-php-rs-v0.15.6) - 2026-02-05
+
+### Added
+- *(class)* Getter/setter implementation #325 ([#624](https://github.com/extphprs/ext-php-rs/pull/624)) (by @kakserpom) [[#325](https://github.com/extphprs/ext-php-rs/issues/325)] [[#624](https://github.com/extphprs/ext-php-rs/issues/624)] 
+- *(class)* Abstract and final methods ([#656](https://github.com/extphprs/ext-php-rs/pull/656)) (by @kakserpom) [[#656](https://github.com/extphprs/ext-php-rs/issues/656)] 
+- *(interface)* Php_impl_interface macro #590 ([#621](https://github.com/extphprs/ext-php-rs/pull/621)) (by @kakserpom) [[#590](https://github.com/extphprs/ext-php-rs/issues/590)] [[#621](https://github.com/extphprs/ext-php-rs/issues/621)] 
+- *(observer)* Add error and exception tracking ([#669](https://github.com/extphprs/ext-php-rs/pull/669)) (by @ptondereau) [[#669](https://github.com/extphprs/ext-php-rs/issues/669)] 
+- *(oop)* Simplified form of `extends` and `implements`  #173 ([#667](https://github.com/extphprs/ext-php-rs/pull/667)) (by @kakserpom) [[#173](https://github.com/extphprs/ext-php-rs/issues/173)] [[#667](https://github.com/extphprs/ext-php-rs/issues/667)] 
+- *(types)* Indexmap feature #522 ([#670](https://github.com/extphprs/ext-php-rs/pull/670)) (by @kakserpom) [[#522](https://github.com/extphprs/ext-php-rs/issues/522)] [[#670](https://github.com/extphprs/ext-php-rs/issues/670)] 
+- *(zval)* Zval coercion ([#632](https://github.com/extphprs/ext-php-rs/pull/632)) (by @kakserpom) [[#632](https://github.com/extphprs/ext-php-rs/issues/632)] 
+
+### Fixed
+- *(stubs)* Proper stub generation for interfaces ([#662](https://github.com/extphprs/ext-php-rs/pull/662)) (by @kakserpom) [[#662](https://github.com/extphprs/ext-php-rs/issues/662)] 
+
+### Other
+- *(cargo-php)* Custom Allocators #523 ([#618](https://github.com/extphprs/ext-php-rs/pull/618)) (by @kakserpom) [[#523](https://github.com/extphprs/ext-php-rs/issues/523)] [[#618](https://github.com/extphprs/ext-php-rs/issues/618)] 
+- *(deps)* Update convert_case requirement from 0.10.0 to 0.11.0 ([#666](https://github.com/extphprs/ext-php-rs/pull/666)) (by @dependabot[bot]) [[#666](https://github.com/extphprs/ext-php-rs/issues/666)] 
+- Add context7 claim ([#664](https://github.com/extphprs/ext-php-rs/pull/664)) (by @ptondereau) [[#664](https://github.com/extphprs/ext-php-rs/issues/664)] 
 ### BREAKING CHANGES
 
 - *(macro)* [**breaking**] Functions and methods without an explicit return type now declare `void` as their PHP return type instead of having no return type (implicit `mixed`). This improves type safety but may cause errors if your function actually returns a value without declaring it. Magic methods `__destruct` and `__clone` are excluded as PHP forbids return types on them. See [migration guide](guide/src/migration-guides/v0.16.md).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.15.5"
+version = "0.15.6"
 authors = [
     "Pierre Tondereau <pierre.tondereau@protonmail.com>",
     "Xenira <xenira@php.rs>",
@@ -25,7 +25,7 @@ anyhow = { version = "1", optional = true }
 smartstring = { version = "1", optional = true }
 indexmap = { version = "2", optional = true }
 inventory = "0.3"
-ext-php-rs-derive = { version = "=0.11.7", path = "./crates/macros" }
+ext-php-rs-derive = { version = "=0.11.8", path = "./crates/macros" }
 
 [dev-dependencies]
 skeptic = "0.13"

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.17](https://github.com/extphprs/ext-php-rs/compare/cargo-php-v0.1.16...cargo-php-v0.1.17) - 2026-02-05
+
+### Fixed
+- *(stubs)* Proper stub generation for interfaces ([#662](https://github.com/extphprs/ext-php-rs/pull/662)) (by @kakserpom) [[#662](https://github.com/extphprs/ext-php-rs/issues/662)] 
 ## [0.1.16](https://github.com/extphprs/ext-php-rs/compare/cargo-php-v0.1.15...cargo-php-v0.1.16) - 2026-01-26
 
 ### Fixed

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.1.16"
+version = "0.1.17"
 authors = [
     "Xenira <xenira@php.rs>",
     "David Cole <david.cole1340@gmail.com>",

--- a/crates/macros/CHANGELOG.md
+++ b/crates/macros/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.11.8](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.7...ext-php-rs-derive-v0.11.8) - 2026-02-05
+
+### Added
+- *(class)* Getter/setter implementation #325 ([#624](https://github.com/extphprs/ext-php-rs/pull/624)) (by @kakserpom) [[#325](https://github.com/extphprs/ext-php-rs/issues/325)] [[#624](https://github.com/extphprs/ext-php-rs/issues/624)] 
+- *(class)* Abstract and final methods ([#656](https://github.com/extphprs/ext-php-rs/pull/656)) (by @kakserpom) [[#656](https://github.com/extphprs/ext-php-rs/issues/656)] 
+- *(interface)* Php_impl_interface macro #590 ([#621](https://github.com/extphprs/ext-php-rs/pull/621)) (by @kakserpom) [[#590](https://github.com/extphprs/ext-php-rs/issues/590)] [[#621](https://github.com/extphprs/ext-php-rs/issues/621)] 
+- *(oop)* Simplified form of `extends` and `implements`  #173 ([#667](https://github.com/extphprs/ext-php-rs/pull/667)) (by @kakserpom) [[#173](https://github.com/extphprs/ext-php-rs/issues/173)] [[#667](https://github.com/extphprs/ext-php-rs/issues/667)] 
+- *(zval)* Zval coercion ([#632](https://github.com/extphprs/ext-php-rs/pull/632)) (by @kakserpom) [[#632](https://github.com/extphprs/ext-php-rs/issues/632)] 
+
+### Fixed
+- *(stubs)* Proper stub generation for interfaces ([#662](https://github.com/extphprs/ext-php-rs/pull/662)) (by @kakserpom) [[#662](https://github.com/extphprs/ext-php-rs/issues/662)] 
+
+### Other
+- *(deps)* Update convert_case requirement from 0.10.0 to 0.11.0 ([#666](https://github.com/extphprs/ext-php-rs/pull/666)) (by @dependabot[bot]) [[#666](https://github.com/extphprs/ext-php-rs/issues/666)] 
 ## [0.11.7](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.6...ext-php-rs-derive-v0.11.7) - 2026-01-26
 
 ### Added

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -4,7 +4,7 @@ description = "Derive macros for ext-php-rs."
 repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
-version = "0.11.7"
+version = "0.11.8"
 authors = [
     "Xenira <xenira@php.rs>",
     "David Cole <david.cole1340@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `ext-php-rs-derive`: 0.11.7 -> 0.11.8
* `ext-php-rs`: 0.15.5 -> 0.15.6 (✓ API compatible changes)
* `cargo-php`: 0.1.16 -> 0.1.17 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `ext-php-rs-derive`

<blockquote>

## [0.11.8](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.7...ext-php-rs-derive-v0.11.8) - 2026-02-05

### Added
- *(class)* Getter/setter implementation #325 ([#624](https://github.com/extphprs/ext-php-rs/pull/624)) (by @kakserpom) [[#325](https://github.com/extphprs/ext-php-rs/issues/325)] [[#624](https://github.com/extphprs/ext-php-rs/issues/624)] 
- *(class)* Abstract and final methods ([#656](https://github.com/extphprs/ext-php-rs/pull/656)) (by @kakserpom) [[#656](https://github.com/extphprs/ext-php-rs/issues/656)] 
- *(interface)* Php_impl_interface macro #590 ([#621](https://github.com/extphprs/ext-php-rs/pull/621)) (by @kakserpom) [[#590](https://github.com/extphprs/ext-php-rs/issues/590)] [[#621](https://github.com/extphprs/ext-php-rs/issues/621)] 
- *(oop)* Simplified form of `extends` and `implements`  #173 ([#667](https://github.com/extphprs/ext-php-rs/pull/667)) (by @kakserpom) [[#173](https://github.com/extphprs/ext-php-rs/issues/173)] [[#667](https://github.com/extphprs/ext-php-rs/issues/667)] 
- *(zval)* Zval coercion ([#632](https://github.com/extphprs/ext-php-rs/pull/632)) (by @kakserpom) [[#632](https://github.com/extphprs/ext-php-rs/issues/632)] 

### Fixed
- *(stubs)* Proper stub generation for interfaces ([#662](https://github.com/extphprs/ext-php-rs/pull/662)) (by @kakserpom) [[#662](https://github.com/extphprs/ext-php-rs/issues/662)] 

### Other
- *(deps)* Update convert_case requirement from 0.10.0 to 0.11.0 ([#666](https://github.com/extphprs/ext-php-rs/pull/666)) (by @dependabot[bot]) [[#666](https://github.com/extphprs/ext-php-rs/issues/666)]
</blockquote>

## `ext-php-rs`

<blockquote>

## [0.15.6](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.5...ext-php-rs-v0.15.6) - 2026-02-05

### Added
- *(class)* Getter/setter implementation #325 ([#624](https://github.com/extphprs/ext-php-rs/pull/624)) (by @kakserpom) [[#325](https://github.com/extphprs/ext-php-rs/issues/325)] [[#624](https://github.com/extphprs/ext-php-rs/issues/624)] 
- *(class)* Abstract and final methods ([#656](https://github.com/extphprs/ext-php-rs/pull/656)) (by @kakserpom) [[#656](https://github.com/extphprs/ext-php-rs/issues/656)] 
- *(interface)* Php_impl_interface macro #590 ([#621](https://github.com/extphprs/ext-php-rs/pull/621)) (by @kakserpom) [[#590](https://github.com/extphprs/ext-php-rs/issues/590)] [[#621](https://github.com/extphprs/ext-php-rs/issues/621)] 
- *(observer)* Add error and exception tracking ([#669](https://github.com/extphprs/ext-php-rs/pull/669)) (by @ptondereau) [[#669](https://github.com/extphprs/ext-php-rs/issues/669)] 
- *(oop)* Simplified form of `extends` and `implements`  #173 ([#667](https://github.com/extphprs/ext-php-rs/pull/667)) (by @kakserpom) [[#173](https://github.com/extphprs/ext-php-rs/issues/173)] [[#667](https://github.com/extphprs/ext-php-rs/issues/667)] 
- *(types)* Indexmap feature #522 ([#670](https://github.com/extphprs/ext-php-rs/pull/670)) (by @kakserpom) [[#522](https://github.com/extphprs/ext-php-rs/issues/522)] [[#670](https://github.com/extphprs/ext-php-rs/issues/670)] 
- *(zval)* Zval coercion ([#632](https://github.com/extphprs/ext-php-rs/pull/632)) (by @kakserpom) [[#632](https://github.com/extphprs/ext-php-rs/issues/632)] 

### Fixed
- *(stubs)* Proper stub generation for interfaces ([#662](https://github.com/extphprs/ext-php-rs/pull/662)) (by @kakserpom) [[#662](https://github.com/extphprs/ext-php-rs/issues/662)] 

### Other
- *(cargo-php)* Custom Allocators #523 ([#618](https://github.com/extphprs/ext-php-rs/pull/618)) (by @kakserpom) [[#523](https://github.com/extphprs/ext-php-rs/issues/523)] [[#618](https://github.com/extphprs/ext-php-rs/issues/618)] 
- *(deps)* Update convert_case requirement from 0.10.0 to 0.11.0 ([#666](https://github.com/extphprs/ext-php-rs/pull/666)) (by @dependabot[bot]) [[#666](https://github.com/extphprs/ext-php-rs/issues/666)] 
- Add context7 claim ([#664](https://github.com/extphprs/ext-php-rs/pull/664)) (by @ptondereau) [[#664](https://github.com/extphprs/ext-php-rs/issues/664)] 
### BREAKING CHANGES

- *(macro)* [**breaking**] Functions and methods without an explicit return type now declare `void` as their PHP return type instead of having no return type (implicit `mixed`). This improves type safety but may cause errors if your function actually returns a value without declaring it. Magic methods `__destruct` and `__clone` are excluded as PHP forbids return types on them. See [migration guide](guide/src/migration-guides/v0.16.md).

### Added

- *(interface)* `#[php_impl_interface]` macro for implementing PHP interfaces via Rust traits [[#590](https://github.com/davidcole1340/ext-php-rs/issues/590)]
</blockquote>

## `cargo-php`

<blockquote>

## [0.1.17](https://github.com/extphprs/ext-php-rs/compare/cargo-php-v0.1.16...cargo-php-v0.1.17) - 2026-02-05

### Fixed
- *(stubs)* Proper stub generation for interfaces ([#662](https://github.com/extphprs/ext-php-rs/pull/662)) (by @kakserpom) [[#662](https://github.com/extphprs/ext-php-rs/issues/662)]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).