### PR TITLE
feat: eval PHP code from files

### DIFF
--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -5,4 +5,11 @@
 
 fn main() {
     println!("cargo:rustc-link-arg-bins=-rdynamic");
+
+    // ext-php-rs wrapper.c includes functions that call Zend engine symbols
+    // only available inside a running PHP process. cargo-php never calls
+    // these functions, but the linker still sees the references. Allow them
+    // to remain unresolved.
+    #[cfg(target_os = "linux")]
+    println!("cargo:rustc-link-arg-bins=-Wl,--unresolved-symbols=ignore-in-object-files");
 }

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -45,6 +45,7 @@
 - [Async](./advanced/async_impl.md)
 - [Bailout Guard](./advanced/bailout_guard.md)
 - [Observer API](./advanced/observer.md)
+- [Embedded PHP](./advanced/embedded_php.md)
 - [Allowed Bindings](./advanced/allowed_bindings.md)
 
 # Migration Guides

--- a/guide/src/advanced/embedded_php.md
+++ b/guide/src/advanced/embedded_php.md
@@ -1,0 +1,162 @@
+# Embedded PHP Execution
+
+Extensions sometimes need to execute PHP code at runtime for setup tasks
+like registering autoloaders, defining helper classes, or configuring error
+handlers. The `php_eval` module lets you embed `.php` files into your
+extension binary at compile time and execute them from Rust.
+
+## Why Not `eval`?
+
+This module uses `zend_compile_string` + `zend_execute` instead of
+`zend_eval_string` because:
+
+- `zend_eval_string` triggers security scanner false positives (eval-like
+  semantics)
+- Some hardened PHP builds disable eval-like functionality
+- The embedded code is static bytes in the binary -- there is no injection risk
+
+## Basic Usage
+
+### 1. Write your PHP file
+
+Create a normal `.php` file with full IDE support (syntax highlighting,
+linting, static analysis):
+
+```php
+<?php
+// php/setup.php
+
+spl_autoload_register(function (string $class): void {
+    $prefix = 'Acme\\Encryption\\';
+    if (str_starts_with($class, $prefix)) {
+        $relative = substr($class, strlen($prefix));
+        $file = __DIR__ . '/src/' . str_replace('\\', '/', $relative) . '.php';
+        if (file_exists($file)) {
+            require $file;
+        }
+    }
+});
+
+function acme_encrypt_version(): string {
+    return '1.0.0';
+}
+```
+
+### 2. Embed and execute from Rust
+
+Use `include_bytes!` or `include_str!` to embed the file at compile time,
+then call `php_eval::execute()` from whatever lifecycle hook fits your target
+SAPI. The function accepts any type that implements `AsRef<[u8]>`:
+
+```rust,ignore
+use ext_php_rs::prelude::*;
+use ext_php_rs::php_eval;
+
+// Both forms work:
+const SETUP: &[u8] = include_bytes!("../php/setup.php");
+// const SETUP: &str = include_str!("../php/setup.php");
+
+unsafe extern "C" fn on_request_start(
+    _type: i32,
+    _module_number: i32,
+) -> i32 {
+    if let Err(e) = php_eval::execute(SETUP) {
+        eprintln!("Failed to run embedded PHP setup: {:?}", e);
+    }
+    0
+}
+
+#[php_module]
+pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
+    module.request_startup_function(on_request_start)
+}
+```
+
+## API Reference
+
+### `php_eval::execute(code: impl AsRef<[u8]>) -> Result<(), PhpEvalError>`
+
+Compiles and executes the given PHP source within the running PHP engine.
+
+**Arguments:**
+
+- `code` -- Raw PHP source, typically from `include_bytes!` or `include_str!`.
+  Any type implementing `AsRef<[u8]>` is accepted (`&[u8]`, `&str`,
+  `String`, `Vec<u8>`, etc.).
+
+**Returns:**
+
+- `Ok(())` on success.
+- `Err(PhpEvalError::MissingOpenTag)` if the code does not start with
+  `<?php` (case-insensitive).
+- `Err(PhpEvalError::CompilationFailed)` if PHP cannot compile the code
+  (syntax error).
+- `Err(PhpEvalError::ExecutionFailed)` if the code throws an unhandled
+  exception.
+- `Err(PhpEvalError::Bailout)` if a PHP fatal error occurs.
+
+### Input handling
+
+The code **must** start with a `<?php` opening tag (case-insensitive).
+The tag is stripped before compilation.
+
+| Input | Handling |
+|-------|----------|
+| `<?php` opening tag | **Required** (case-insensitive), stripped before compilation |
+| UTF-8 BOM (`0xEF 0xBB 0xBF`) | Stripped before compilation |
+| Empty after tag (e.g. `<?php`) | Returns `Ok(())` immediately |
+| No `<?php` tag (including empty input) | Returns `Err(MissingOpenTag)` |
+
+## Lifecycle Hooks
+
+The module does not prescribe *when* to run embedded PHP. The SAPI landscape
+is fragmented -- FrankenPHP in worker mode does not trigger RINIT per request,
+for example. Choose the hook that fits your target:
+
+| Hook | Use case |
+|------|----------|
+| RINIT (`request_startup_function`) | Per-request setup (classic php-fpm / mod_php) |
+| MINIT (`startup_function`) | One-time global setup |
+| Custom SAPI callback | Worker-mode runtimes (FrankenPHP, RoadRunner) |
+
+## Error Handling
+
+Errors during embedded PHP execution should not crash the host process.
+The recommended pattern is to log and continue:
+
+```rust,ignore
+if let Err(e) = php_eval::execute(SETUP_CODE) {
+    match e {
+        PhpEvalError::MissingOpenTag => {
+            eprintln!("embedded PHP missing <?php open tag");
+        }
+        PhpEvalError::CompilationFailed => {
+            eprintln!("embedded PHP syntax error");
+        }
+        PhpEvalError::ExecutionFailed => {
+            eprintln!("embedded PHP threw an exception");
+        }
+        PhpEvalError::Bailout => {
+            eprintln!("embedded PHP fatal error");
+        }
+    }
+}
+```
+
+## How It Works
+
+1. **Build time**: `include_bytes!` embeds the `.php` file contents into the
+   extension binary as a `&[u8]` constant.
+
+2. **Runtime**: `php_eval::execute()` strips the `<?php` tag and BOM, then
+   calls two C wrapper functions in `wrapper.c`:
+   - `ext_php_rs_zend_compile_string` -- compiles the source into an op_array.
+     On PHP 8.2+ it passes `ZEND_COMPILE_POSITION_AFTER_OPEN_TAG` so the
+     scanner starts directly in PHP mode. On PHP 8.1 the two-argument form
+     is used.
+   - `ext_php_rs_zend_execute` -- executes the op_array, sets the execution
+     scope, then cleans up static vars and frees the op_array.
+
+3. **Safety**: The entire execution is wrapped in `try_catch` to catch PHP
+   bailouts (longjmp) without unwinding the Rust stack. Error reporting is
+   suppressed during execution and restored afterward.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -44,6 +44,11 @@ unsafe extern "C" {
     ) -> bool;
 
     pub fn ext_php_rs_zend_bailout() -> !;
+    pub fn ext_php_rs_zend_compile_string(
+        source: *mut zend_string,
+        filename: *const c_char,
+    ) -> *mut zend_op_array;
+    pub fn ext_php_rs_zend_execute(op_array: *mut zend_op_array);
 }
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod describe;
 pub mod embed;
 #[cfg(feature = "enum")]
 pub mod enum_;
+pub mod php_eval;
 #[cfg(feature = "observer")]
 #[cfg_attr(docs, doc(cfg(feature = "observer")))]
 pub mod observer {

--- a/src/php_eval.rs
+++ b/src/php_eval.rs
@@ -1,0 +1,322 @@
+//! Execute embedded PHP code within a running PHP extension.
+//!
+//! This module provides a way to compile and execute PHP code that has been
+//! embedded into the extension binary at compile time using `include_bytes!`.
+//!
+//! Uses `zend_compile_string` + `zend_execute` (not `zend_eval_string`)
+//! to avoid security scanner false positives and compatibility issues
+//! with hardened PHP configurations.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use ext_php_rs::php_eval;
+//!
+//! // Both include_bytes! and include_str! are supported:
+//! const SETUP_BYTES: &[u8] = include_bytes!("../php/setup.php");
+//! const SETUP_STR: &str = include_str!("../php/setup.php");
+//!
+//! php_eval::execute(SETUP_BYTES).expect("failed to execute embedded PHP");
+//! php_eval::execute(SETUP_STR).expect("failed to execute embedded PHP");
+//! ```
+
+use crate::ffi;
+use crate::types::ZendStr;
+use crate::zend::try_catch;
+use std::fmt;
+use std::mem;
+use std::panic::AssertUnwindSafe;
+
+/// Errors that can occur when executing embedded PHP code.
+#[derive(Debug)]
+pub enum PhpEvalError {
+    /// The code does not start with a `<?php` open tag.
+    MissingOpenTag,
+    /// PHP failed to compile the code (syntax error).
+    CompilationFailed,
+    /// The code executed but threw an unhandled exception.
+    ExecutionFailed,
+    /// A PHP fatal error (bailout) occurred during execution.
+    Bailout,
+}
+
+impl fmt::Display for PhpEvalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PhpEvalError::MissingOpenTag => {
+                write!(f, "PHP code must start with a <?php open tag")
+            }
+            PhpEvalError::CompilationFailed => write!(f, "PHP compilation failed (syntax error)"),
+            PhpEvalError::ExecutionFailed => {
+                write!(f, "PHP execution threw an unhandled exception")
+            }
+            PhpEvalError::Bailout => write!(f, "PHP fatal error (bailout) during execution"),
+        }
+    }
+}
+
+impl std::error::Error for PhpEvalError {}
+
+/// Execute embedded PHP code within the running PHP engine.
+///
+/// The code **must** start with a `<?php` opening tag (case-insensitive),
+/// optionally preceded by a UTF-8 BOM and/or whitespace. The tag is
+/// stripped before compilation. The C wrapper uses
+/// `ZEND_COMPILE_POSITION_AFTER_OPEN_TAG` (on PHP 8.2+) so the scanner
+/// starts directly in PHP mode.
+///
+/// Error reporting is suppressed during execution and restored afterward,
+/// matching the pattern used by production PHP extensions like Blackfire.
+///
+/// # Arguments
+///
+/// * `code` - Raw PHP source, typically from `include_bytes!` or
+///   `include_str!`. Any type implementing `AsRef<[u8]>` is accepted.
+///
+/// # Errors
+///
+/// Returns [`PhpEvalError::MissingOpenTag`] if the code does not start
+/// with `<?php`. Returns other [`PhpEvalError`] variants if compilation
+/// fails, an exception is thrown, or a fatal error occurs.
+pub fn execute(code: impl AsRef<[u8]>) -> Result<(), PhpEvalError> {
+    let code = strip_bom(code.as_ref());
+    let code = strip_php_open_tag(code).ok_or(PhpEvalError::MissingOpenTag)?;
+
+    if code.is_empty() {
+        return Ok(());
+    }
+
+    let source = ZendStr::new(code, false);
+
+    // Suppress error reporting so compilation warnings from embedded
+    // code don't bubble up to the application's error handler.
+    // Saved outside `try_catch` so it is always restored, even on bailout.
+    let eg = unsafe { ffi::ext_php_rs_executor_globals() };
+    let prev_error_reporting = unsafe { mem::replace(&mut (*eg).error_reporting, 0) };
+
+    let result = try_catch(AssertUnwindSafe(|| unsafe {
+        let op_array = ffi::ext_php_rs_zend_compile_string(
+            source.as_ptr().cast_mut(),
+            c"embedded_php".as_ptr(),
+        );
+
+        if op_array.is_null() {
+            return Err(PhpEvalError::CompilationFailed);
+        }
+
+        ffi::ext_php_rs_zend_execute(op_array);
+
+        if !(*eg).exception.is_null() {
+            return Err(PhpEvalError::ExecutionFailed);
+        }
+
+        Ok(())
+    }));
+
+    unsafe { (*eg).error_reporting = prev_error_reporting };
+
+    match result {
+        Err(_) => Err(PhpEvalError::Bailout),
+        Ok(inner) => inner,
+    }
+}
+
+fn strip_bom(code: &[u8]) -> &[u8] {
+    if code.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        &code[3..]
+    } else {
+        code
+    }
+}
+
+fn strip_php_open_tag(code: &[u8]) -> Option<&[u8]> {
+    let trimmed = match code.iter().position(|b| !b.is_ascii_whitespace()) {
+        Some(pos) => &code[pos..],
+        None => return None,
+    };
+
+    if trimmed.len() >= 5 && trimmed[..5].eq_ignore_ascii_case(b"<?php") {
+        Some(trimmed[5..].trim_ascii_start())
+    } else {
+        None
+    }
+}
+
+#[cfg(feature = "embed")]
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use crate::embed::Embed;
+
+    #[test]
+    fn test_execute_with_php_open_tag() {
+        Embed::run(|| {
+            let result = execute(b"<?php $x = 42;");
+            assert!(result.is_ok());
+        });
+    }
+
+    #[test]
+    fn test_execute_with_php_open_tag_and_newline() {
+        Embed::run(|| {
+            let result = execute(b"<?php\n$x = 42;");
+            assert!(result.is_ok());
+        });
+    }
+
+    #[test]
+    fn test_execute_tag_only() {
+        Embed::run(|| {
+            let result = execute(b"<?php");
+            assert!(result.is_ok());
+        });
+    }
+
+    #[test]
+    fn test_execute_exception() {
+        Embed::run(|| {
+            let result = execute(b"<?php throw new \\RuntimeException('test');");
+            assert!(matches!(result, Err(PhpEvalError::ExecutionFailed)));
+        });
+    }
+
+    #[test]
+    fn test_execute_missing_open_tag() {
+        Embed::run(|| {
+            let result = execute(b"$x = 1 + 2;");
+            assert!(matches!(result, Err(PhpEvalError::MissingOpenTag)));
+        });
+    }
+
+    #[test]
+    fn test_execute_compilation_error() {
+        Embed::run(|| {
+            let result = execute(b"<?php this is not valid php {{{");
+            assert!(matches!(result, Err(PhpEvalError::CompilationFailed)));
+        });
+    }
+
+    #[test]
+    fn test_execute_with_bom() {
+        Embed::run(|| {
+            let mut code = vec![0xEF, 0xBB, 0xBF];
+            code.extend_from_slice(b"<?php $x = 'bom_test';");
+            let result = execute(&code);
+            assert!(result.is_ok());
+        });
+    }
+
+    #[test]
+    fn test_execute_defines_variable() {
+        Embed::run(|| {
+            let result = execute(b"<?php $embed_test = 'hello from embedded php';");
+            assert!(result.is_ok());
+
+            let val = Embed::eval("$embed_test;");
+            assert!(val.is_ok());
+            assert_eq!(val.unwrap().string().unwrap(), "hello from embedded php");
+        });
+    }
+
+    #[test]
+    fn test_execute_empty_code() {
+        Embed::run(|| {
+            let result = execute(b"");
+            assert!(matches!(result, Err(PhpEvalError::MissingOpenTag)));
+        });
+    }
+
+    #[test]
+    fn test_execute_include_bytes_pattern() {
+        Embed::run(|| {
+            let code: &[u8] = b"<?php\n\
+                $embedded_value = 42;\n\
+                define('EMBEDDED_CONST', true);\n";
+            let result = execute(code);
+            assert!(result.is_ok());
+        });
+    }
+
+    #[test]
+    fn test_execute_with_str() {
+        Embed::run(|| {
+            let code: &str = "<?php $str_test = 'from_str';";
+            let result = execute(code);
+            assert!(result.is_ok());
+
+            let val = Embed::eval("$str_test;");
+            assert!(val.is_ok());
+            assert_eq!(val.unwrap().string().unwrap(), "from_str");
+        });
+    }
+
+    #[test]
+    fn test_execute_with_string() {
+        Embed::run(|| {
+            let code = String::from("<?php $string_test = 'from_string';");
+            let result = execute(code);
+            assert!(result.is_ok());
+
+            let val = Embed::eval("$string_test;");
+            assert!(val.is_ok());
+            assert_eq!(val.unwrap().string().unwrap(), "from_string");
+        });
+    }
+
+    #[test]
+    fn test_execute_with_vec() {
+        Embed::run(|| {
+            let code: Vec<u8> = b"<?php $vec_test = 'from_vec';".to_vec();
+            let result = execute(code);
+            assert!(result.is_ok());
+
+            let val = Embed::eval("$vec_test;");
+            assert!(val.is_ok());
+            assert_eq!(val.unwrap().string().unwrap(), "from_vec");
+        });
+    }
+
+    #[test]
+    fn test_strip_bom() {
+        let cases: &[(&[u8], &[u8])] = &[
+            (&[0xEF, 0xBB, 0xBF, b'h', b'i'], b"hi"),
+            (b"hello", b"hello"),
+            (b"", b""),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                super::strip_bom(input),
+                *expected,
+                "input: {:?}",
+                String::from_utf8_lossy(input)
+            );
+        }
+    }
+
+    #[test]
+    fn test_strip_php_open_tag() {
+        let cases: &[(&[u8], Option<&[u8]>)] = &[
+            (b"<?php $x;", Some(b"$x;")),
+            (b"<?php\n$x;", Some(b"$x;")),
+            (b"<?php\r\n$x;", Some(b"$x;")),
+            (b"<?php\t\n  $x;", Some(b"$x;")),
+            (b"<?php", Some(b"")),
+            (b"  <?php $x;", Some(b"$x;")),
+            (b"<?PHP $x;", Some(b"$x;")),
+            (b"<?Php\n$x;", Some(b"$x;")),
+            (b"", None),
+            (b"   ", None),
+            (b"$x = 1;", None),
+            (b"hello", None),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                super::strip_php_open_tag(input),
+                *expected,
+                "input: {:?}",
+                String::from_utf8_lossy(input)
+            );
+        }
+    }
+}

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -57,3 +57,5 @@ sapi_module_struct *ext_php_rs_sapi_module();
 bool ext_php_rs_zend_try_catch(void* (*callback)(void *), void *ctx, void **result);
 bool ext_php_rs_zend_first_try_catch(void* (*callback)(void *), void *ctx, void **result);
 void ext_php_rs_zend_bailout();
+zend_op_array *ext_php_rs_zend_compile_string(zend_string *source, const char *filename);
+void ext_php_rs_zend_execute(zend_op_array *op_array);


### PR DESCRIPTION
## Description

PHP extensions often need to run PHP code at startup for bootstrapping tasks like registering autoloaders, defining helper functions, and configuring error handlers. We have no way to do this. The existing embed module is for the embed SAPI (running PHP from a standalone Rust binary), not for executing PHP snippets from within a loaded extension.

This adds `php_eval::execute()` so extension authors can embed .php files with `include_bytes!` and run them from any lifecycle hook they choose.
