### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+## [0.15.7](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.6...ext-php-rs-v0.15.7) - 2026-03-24
+
+### Added
+- *(callable)* Named arguments ([#635](https://github.com/extphprs/ext-php-rs/pull/635)) (by @kakserpom) [[#635](https://github.com/extphprs/ext-php-rs/issues/635)] 
+- *(stubs)* Proper phpdoc-style comments in stubs #369 ([#676](https://github.com/extphprs/ext-php-rs/pull/676)) (by @kakserpom) [[#369](https://github.com/extphprs/ext-php-rs/issues/369)] [[#676](https://github.com/extphprs/ext-php-rs/issues/676)] 
+- Eval PHP code from files ([#671](https://github.com/extphprs/ext-php-rs/pull/671)) (by @ptondereau) [[#671](https://github.com/extphprs/ext-php-rs/issues/671)] 
+
+### Fixed
+- *(class)* Implement clone behavior ([#685](https://github.com/extphprs/ext-php-rs/pull/685)) (by @ptondereau) [[#685](https://github.com/extphprs/ext-php-rs/issues/685)] 
+- *(embed)* Restore ZTS embed tests ([#689](https://github.com/extphprs/ext-php-rs/pull/689)) (by @ptondereau) [[#689](https://github.com/extphprs/ext-php-rs/issues/689)] 
+- *(stubs)* Syntax error on numeric literal suffixes in defaults #492 ([#679](https://github.com/extphprs/ext-php-rs/pull/679)) (by @kakserpom) [[#492](https://github.com/extphprs/ext-php-rs/issues/492)] [[#679](https://github.com/extphprs/ext-php-rs/issues/679)] 
+- *(zval)* Handle immutable empty array in array_mut to prevent segf ([#693](https://github.com/extphprs/ext-php-rs/pull/693)) (by @ptondereau) [[#693](https://github.com/extphprs/ext-php-rs/issues/693)] 
+
+### Other
+- *(cargo-php)* Add tests and generate deterministic output ([#677](https://github.com/extphprs/ext-php-rs/pull/677)) (by @ptondereau) [[#677](https://github.com/extphprs/ext-php-rs/issues/677)] 
+- *(deps)* Update zip requirement from 7.0 to 8.0 ([#680](https://github.com/extphprs/ext-php-rs/pull/680)) (by @dependabot[bot]) [[#680](https://github.com/extphprs/ext-php-rs/issues/680)] 
+- *(showcase)* Add grpc-php-rs to usage examples ([#686](https://github.com/extphprs/ext-php-rs/pull/686)) (by @BSN4) [[#686](https://github.com/extphprs/ext-php-rs/issues/686)] 
+- *(tests)* Test to close #176 ([#675](https://github.com/extphprs/ext-php-rs/pull/675)) (by @kakserpom) [[#176](https://github.com/extphprs/ext-php-rs/issues/176)] [[#675](https://github.com/extphprs/ext-php-rs/issues/675)] 
+- Replace inline project list with awesome-ext-php-rs link ([#691](https://github.com/extphprs/ext-php-rs/pull/691)) (by @ptondereau) [[#691](https://github.com/extphprs/ext-php-rs/issues/691)] 
 ## [0.15.6](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.5...ext-php-rs-v0.15.6) - 2026-02-05
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.15.6"
+version = "0.15.7"
 authors = [
     "Pierre Tondereau <pierre.tondereau@protonmail.com>",
     "Xenira <xenira@php.rs>",
@@ -25,7 +25,7 @@ anyhow = { version = "1", optional = true }
 smartstring = { version = "1", optional = true }
 indexmap = { version = "2", optional = true }
 inventory = "0.3"
-ext-php-rs-derive = { version = "=0.11.8", path = "./crates/macros" }
+ext-php-rs-derive = { version = "=0.11.9", path = "./crates/macros" }
 
 [dev-dependencies]
 skeptic = "0.13"

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.18](https://github.com/extphprs/ext-php-rs/compare/cargo-php-v0.1.17...cargo-php-v0.1.18) - 2026-03-24
+
+### Added
+- *(stubs)* Proper phpdoc-style comments in stubs #369 ([#676](https://github.com/extphprs/ext-php-rs/pull/676)) (by @kakserpom) [[#369](https://github.com/extphprs/ext-php-rs/issues/369)] [[#676](https://github.com/extphprs/ext-php-rs/issues/676)] 
+- Eval PHP code from files ([#671](https://github.com/extphprs/ext-php-rs/pull/671)) (by @ptondereau) [[#671](https://github.com/extphprs/ext-php-rs/issues/671)] 
+
+### Other
+- *(cargo-php)* Add tests and generate deterministic output ([#677](https://github.com/extphprs/ext-php-rs/pull/677)) (by @ptondereau) [[#677](https://github.com/extphprs/ext-php-rs/issues/677)] 
 ## [0.1.17](https://github.com/extphprs/ext-php-rs/compare/cargo-php-v0.1.16...cargo-php-v0.1.17) - 2026-02-05
 
 ### Fixed

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.1.17"
+version = "0.1.18"
 authors = [
     "Xenira <xenira@php.rs>",
     "David Cole <david.cole1340@gmail.com>",

--- a/crates/macros/CHANGELOG.md
+++ b/crates/macros/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.11.9](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.8...ext-php-rs-derive-v0.11.9) - 2026-03-24
+
+### Fixed
+- *(class)* Implement clone behavior ([#685](https://github.com/extphprs/ext-php-rs/pull/685)) (by @ptondereau) [[#685](https://github.com/extphprs/ext-php-rs/issues/685)] 
+- *(stubs)* Syntax error on numeric literal suffixes in defaults #492 ([#679](https://github.com/extphprs/ext-php-rs/pull/679)) (by @kakserpom) [[#492](https://github.com/extphprs/ext-php-rs/issues/492)] [[#679](https://github.com/extphprs/ext-php-rs/issues/679)] 
+
+### Other
+- *(showcase)* Add grpc-php-rs to usage examples ([#686](https://github.com/extphprs/ext-php-rs/pull/686)) (by @BSN4) [[#686](https://github.com/extphprs/ext-php-rs/issues/686)] 
+- Replace inline project list with awesome-ext-php-rs link ([#691](https://github.com/extphprs/ext-php-rs/pull/691)) (by @ptondereau) [[#691](https://github.com/extphprs/ext-php-rs/issues/691)] 
 ## [0.11.8](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.7...ext-php-rs-derive-v0.11.8) - 2026-02-05
 
 ### Added

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -4,7 +4,7 @@ description = "Derive macros for ext-php-rs."
 repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
-version = "0.11.8"
+version = "0.11.9"
 authors = [
     "Xenira <xenira@php.rs>",
     "David Cole <david.cole1340@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `ext-php-rs-derive`: 0.11.8 -> 0.11.9
* `ext-php-rs`: 0.15.6 -> 0.15.7 (✓ API compatible changes)
* `cargo-php`: 0.1.17 -> 0.1.18 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `ext-php-rs-derive`

<blockquote>

## [0.11.9](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.8...ext-php-rs-derive-v0.11.9) - 2026-03-24

### Fixed
- *(class)* Implement clone behavior ([#685](https://github.com/extphprs/ext-php-rs/pull/685)) (by @ptondereau) [[#685](https://github.com/extphprs/ext-php-rs/issues/685)] 
- *(stubs)* Syntax error on numeric literal suffixes in defaults #492 ([#679](https://github.com/extphprs/ext-php-rs/pull/679)) (by @kakserpom) [[#492](https://github.com/extphprs/ext-php-rs/issues/492)] [[#679](https://github.com/extphprs/ext-php-rs/issues/679)] 

### Other
- *(showcase)* Add grpc-php-rs to usage examples ([#686](https://github.com/extphprs/ext-php-rs/pull/686)) (by @BSN4) [[#686](https://github.com/extphprs/ext-php-rs/issues/686)] 
- Replace inline project list with awesome-ext-php-rs link ([#691](https://github.com/extphprs/ext-php-rs/pull/691)) (by @ptondereau) [[#691](https://github.com/extphprs/ext-php-rs/issues/691)]
</blockquote>

## `ext-php-rs`

<blockquote>

## [0.15.7](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.6...ext-php-rs-v0.15.7) - 2026-03-24

### Added
- *(callable)* Named arguments ([#635](https://github.com/extphprs/ext-php-rs/pull/635)) (by @kakserpom) [[#635](https://github.com/extphprs/ext-php-rs/issues/635)] 
- *(stubs)* Proper phpdoc-style comments in stubs #369 ([#676](https://github.com/extphprs/ext-php-rs/pull/676)) (by @kakserpom) [[#369](https://github.com/extphprs/ext-php-rs/issues/369)] [[#676](https://github.com/extphprs/ext-php-rs/issues/676)] 
- Eval PHP code from files ([#671](https://github.com/extphprs/ext-php-rs/pull/671)) (by @ptondereau) [[#671](https://github.com/extphprs/ext-php-rs/issues/671)] 

### Fixed
- *(class)* Implement clone behavior ([#685](https://github.com/extphprs/ext-php-rs/pull/685)) (by @ptondereau) [[#685](https://github.com/extphprs/ext-php-rs/issues/685)] 
- *(embed)* Restore ZTS embed tests ([#689](https://github.com/extphprs/ext-php-rs/pull/689)) (by @ptondereau) [[#689](https://github.com/extphprs/ext-php-rs/issues/689)] 
- *(stubs)* Syntax error on numeric literal suffixes in defaults #492 ([#679](https://github.com/extphprs/ext-php-rs/pull/679)) (by @kakserpom) [[#492](https://github.com/extphprs/ext-php-rs/issues/492)] [[#679](https://github.com/extphprs/ext-php-rs/issues/679)] 
- *(zval)* Handle immutable empty array in array_mut to prevent segf ([#693](https://github.com/extphprs/ext-php-rs/pull/693)) (by @ptondereau) [[#693](https://github.com/extphprs/ext-php-rs/issues/693)] 

### Other
- *(cargo-php)* Add tests and generate deterministic output ([#677](https://github.com/extphprs/ext-php-rs/pull/677)) (by @ptondereau) [[#677](https://github.com/extphprs/ext-php-rs/issues/677)] 
- *(deps)* Update zip requirement from 7.0 to 8.0 ([#680](https://github.com/extphprs/ext-php-rs/pull/680)) (by @dependabot[bot]) [[#680](https://github.com/extphprs/ext-php-rs/issues/680)] 
- *(showcase)* Add grpc-php-rs to usage examples ([#686](https://github.com/extphprs/ext-php-rs/pull/686)) (by @BSN4) [[#686](https://github.com/extphprs/ext-php-rs/issues/686)] 
- *(tests)* Test to close #176 ([#675](https://github.com/extphprs/ext-php-rs/pull/675)) (by @kakserpom) [[#176](https://github.com/extphprs/ext-php-rs/issues/176)] [[#675](https://github.com/extphprs/ext-php-rs/issues/675)] 
- Replace inline project list with awesome-ext-php-rs link ([#691](https://github.com/extphprs/ext-php-rs/pull/691)) (by @ptondereau) [[#691](https://github.com/extphprs/ext-php-rs/issues/691)]
</blockquote>

## `cargo-php`

<blockquote>

## [0.1.18](https://github.com/extphprs/ext-php-rs/compare/cargo-php-v0.1.17...cargo-php-v0.1.18) - 2026-03-24

### Added
- *(stubs)* Proper phpdoc-style comments in stubs #369 ([#676](https://github.com/extphprs/ext-php-rs/pull/676)) (by @kakserpom) [[#369](https://github.com/extphprs/ext-php-rs/issues/369)] [[#676](https://github.com/extphprs/ext-php-rs/issues/676)] 
- Eval PHP code from files ([#671](https://github.com/extphprs/ext-php-rs/pull/671)) (by @ptondereau) [[#671](https://github.com/extphprs/ext-php-rs/issues/671)] 

### Other
- *(cargo-php)* Add tests and generate deterministic output ([#677](https://github.com/extphprs/ext-php-rs/pull/677)) (by @ptondereau) [[#677](https://github.com/extphprs/ext-php-rs/issues/677)]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).