### PR TITLE
chore(cargo-php): add tests and generate deterministic output

### DIFF
--- a/allowed_bindings.rs
+++ b/allowed_bindings.rs
@@ -373,5 +373,10 @@ bind! {
     zend_observer_error_register,
     zend_function,
     zend_op_array,
-    zend_throw_exception_hook
+    zend_throw_exception_hook,
+    zend_compile_string,
+    zend_execute,
+    zend_get_executed_scope,
+    zend_destroy_static_vars,
+    destroy_op_array
 }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,3 +33,6 @@ default = ["enum"]
 enum = ["ext-php-rs/enum"]
 runtime = ["ext-php-rs/runtime"]
 static = ["ext-php-rs/static"]
+
+[dev-dependencies]
+insta = "1"

--- a/crates/cli/tests/snapshots/stubs_snapshot__hello_world_stubs.snap
+++ b/crates/cli/tests/snapshots/stubs_snapshot__hello_world_stubs.snap
@@ -1,0 +1,38 @@
+---
+source: crates/cli/tests/stubs_snapshot.rs
+assertion_line: 69
+expression: stubs
+---
+<?php
+
+// Stubs for ext-php-rs
+
+namespace {
+    class TestClass {
+        const NEW_CONSTANT_NAME = 5;
+
+        const SOME_OTHER_STR = 'Hello, world!';
+
+        public $a;
+
+        public $b;
+
+        public function __construct(int $a, int $b) {}
+
+        public function builderPattern(): \TestClass {}
+
+        public function testCamelCase(int $a = 5, int $test = 100): void {}
+
+        public static function x(): int {}
+    }
+
+    const CONST_NAME = 100;
+
+    const HELLO_WORLD = 100;
+
+    function get_zval_convert(object $z): int {}
+
+    function hello_world(): string {}
+
+    function new_class(): \TestClass {}
+}

--- a/crates/cli/tests/stubs_snapshot.rs
+++ b/crates/cli/tests/stubs_snapshot.rs
@@ -1,0 +1,75 @@
+#![cfg(not(windows))]
+#![allow(missing_docs)]
+
+use std::io::BufReader;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use cargo_metadata::Message;
+
+#[test]
+fn hello_world_stubs() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("Failed to find workspace root");
+
+    // Use a separate target directory to avoid polluting the main target/
+    // with artifacts built under different feature sets (which causes
+    // "multiple candidates for rmeta dependency" errors in other tests).
+    let target_dir = workspace_root.join("target").join("tests");
+
+    // Build the hello_world example as cdylib
+    let build_output = Command::new("cargo")
+        .current_dir(workspace_root)
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .args([
+            "build",
+            "--example",
+            "hello_world",
+            "--message-format=json-render-diagnostics",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .output()
+        .expect("Failed to run cargo build");
+
+    assert!(
+        build_output.status.success(),
+        "Failed to build hello_world example: {}",
+        String::from_utf8_lossy(&build_output.stdout)
+    );
+
+    let reader = BufReader::new(build_output.stdout.as_slice());
+    let lib_path = Message::parse_stream(reader)
+        .filter_map(Result::ok)
+        .find_map(|msg| match msg {
+            Message::CompilerArtifact(artifact) if artifact.target.name == "hello_world" => {
+                artifact
+                    .filenames
+                    .into_iter()
+                    .find(|f| f.extension() == Some(std::env::consts::DLL_EXTENSION))
+            }
+            _ => None,
+        })
+        .expect("Failed to find hello_world cdylib artifact in cargo output");
+
+    // Run cargo-php stubs --stdout against the built cdylib
+    let stubs_output = Command::new("cargo")
+        .current_dir(workspace_root)
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .args(["run", "-p", "cargo-php", "--", "stubs", "--stdout"])
+        .arg(lib_path.as_str())
+        .output()
+        .expect("Failed to run cargo-php stubs");
+
+    assert!(
+        stubs_output.status.success(),
+        "cargo-php stubs failed: {}",
+        String::from_utf8_lossy(&stubs_output.stderr)
+    );
+
+    let stubs = String::from_utf8(stubs_output.stdout).expect("Invalid UTF-8 in stubs output");
+    insta::assert_snapshot!(stubs);
+}

--- a/docsrs_bindings.rs
+++ b/docsrs_bindings.rs
@@ -2273,6 +2273,26 @@ pub struct _zend_executor_globals {
     pub strtod_state: zend_strtod_state,
     pub reserved: [*mut ::std::os::raw::c_void; 6usize],
 }
+pub const _zend_compile_position_ZEND_COMPILE_POSITION_AT_SHEBANG: _zend_compile_position = 0;
+pub const _zend_compile_position_ZEND_COMPILE_POSITION_AT_OPEN_TAG: _zend_compile_position = 1;
+pub const _zend_compile_position_ZEND_COMPILE_POSITION_AFTER_OPEN_TAG: _zend_compile_position = 2;
+pub type _zend_compile_position = ::std::os::raw::c_uint;
+pub use self::_zend_compile_position as zend_compile_position;
+unsafe extern "C" {
+    pub static mut zend_compile_string: ::std::option::Option<
+        unsafe extern "C" fn(
+            source_string: *mut zend_string,
+            filename: *const ::std::os::raw::c_char,
+            position: zend_compile_position,
+        ) -> *mut zend_op_array,
+    >;
+}
+unsafe extern "C" {
+    pub fn destroy_op_array(op_array: *mut zend_op_array);
+}
+unsafe extern "C" {
+    pub fn zend_destroy_static_vars(op_array: *mut zend_op_array);
+}
 unsafe extern "C" {
     pub fn zend_is_auto_global(name: *mut zend_string) -> bool;
 }
@@ -2380,6 +2400,9 @@ unsafe extern "C" {
     ) -> *mut zend_constant;
 }
 unsafe extern "C" {
+    pub fn zend_execute(op_array: *mut zend_op_array, return_value: *mut zval);
+}
+unsafe extern "C" {
     pub fn zend_lookup_class_ex(
         name: *mut zend_string,
         lcname: *mut zend_string,
@@ -2399,6 +2422,9 @@ pub struct _zend_vm_stack {
     pub top: *mut zval,
     pub end: *mut zval,
     pub prev: zend_vm_stack,
+}
+unsafe extern "C" {
+    pub fn zend_get_executed_scope() -> *mut zend_class_entry;
 }
 unsafe extern "C" {
     pub fn zend_fetch_function_str(

--- a/src/describe/stub.rs
+++ b/src/describe/stub.rs
@@ -91,6 +91,10 @@ impl ToStub for Module {
             insert(ns, r#enum.to_stub()?);
         }
 
+        for bucket in entries.values_mut() {
+            bucket.sort();
+        }
+
         let mut entries: StdVec<_> = entries.iter().collect();
         entries.sort_by(|(l, _), (r, _)| match (l, r) {
             (None, _) => Ordering::Greater,
@@ -282,11 +286,19 @@ impl ToStub for Class {
 
         writeln!(buf, "{{")?;
 
+        let mut constants: StdVec<_> = stub(&self.constants).collect::<Result<_, FmtError>>()?;
+        let mut properties: StdVec<_> = stub(&self.properties).collect::<Result<_, FmtError>>()?;
+        let mut methods: StdVec<_> = stub(&self.methods).collect::<Result<_, FmtError>>()?;
+        constants.sort();
+        properties.sort();
+        methods.sort();
+
         buf.push_str(
-            &stub(&self.constants)
-                .chain(stub(&self.properties))
-                .chain(stub(&self.methods))
-                .collect::<Result<StdVec<_>, FmtError>>()?
+            &constants
+                .into_iter()
+                .chain(properties)
+                .chain(methods)
+                .collect::<StdVec<_>>()
                 .join(NEW_LINE_SEPARATOR),
         );
 

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -130,12 +130,12 @@ void ext_php_rs_zend_execute(zend_op_array *op_array) {
     zend_execute(op_array, &local_retval);
   } zend_catch {
     destroy_op_array(op_array);
-    efree_size(op_array, sizeof(zend_op_array));
+    efree(op_array);
     zend_bailout();
   } zend_end_try();
 
   zval_ptr_dtor(&local_retval);
   zend_destroy_static_vars(op_array);
   destroy_op_array(op_array);
-  efree_size(op_array, sizeof(zend_op_array));
+  efree(op_array);
 }


### PR DESCRIPTION
## Description

`cargo-php` lacks tests, and we're using snapshot testing to ensure that it's running and the output doesn't change without related code modification