### PR TITLE
feat(observer): allow zend_extension registration for low level function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,11 @@ name = "observer"
 crate-type = ["cdylib"]
 required-features = ["observer"]
 
+[[example]]
+name = "zend_extension"
+crate-type = ["cdylib"]
+required-features = ["observer"]
+
 [[test]]
 name = "guide_tests"
 path = "tests/guide.rs"

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN rustup component add rustfmt
 RUN --mount=type=bind,target=/src,rw <<EOF
 set -e
 cargo clean
-cargo build
+cargo build --features observer
 cp target/debug/build/ext-php-rs-*/out/bindings.rs /docsrs_bindings.rs
 rustfmt /docsrs_bindings.rs
 EOF

--- a/allowed_bindings.rs
+++ b/allowed_bindings.rs
@@ -387,5 +387,11 @@ bind! {
     zend_execute,
     zend_get_executed_scope,
     zend_destroy_static_vars,
-    destroy_op_array
+    destroy_op_array,
+    zend_extension,
+    zend_extension_version_info,
+    zend_register_extension,
+    zend_get_resource_handle,
+    zend_get_op_array_extension_handle,
+    zend_get_op_array_extension_handles
 }

--- a/build.rs
+++ b/build.rs
@@ -252,6 +252,9 @@ fn main() -> Result<()> {
     let mut defines = provider.get_defines()?;
     add_php_version_defines(&mut defines, &info)?;
 
+    #[cfg(feature = "observer")]
+    defines.push(("EXT_PHP_RS_OBSERVER", "1"));
+
     check_php_version(&info)?;
     build_wrapper(&defines, &includes)?;
 

--- a/docsrs_bindings.rs
+++ b/docsrs_bindings.rs
@@ -3889,3 +3889,94 @@ pub type zend_observer_error_cb = ::std::option::Option<
 unsafe extern "C" {
     pub fn zend_observer_error_register(callback: zend_observer_error_cb);
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _zend_extension_version_info {
+    pub zend_extension_api_no: ::std::os::raw::c_int,
+    pub build_id: *const ::std::os::raw::c_char,
+}
+pub type zend_extension_version_info = _zend_extension_version_info;
+pub type zend_extension = _zend_extension;
+pub type startup_func_t = ::std::option::Option<
+    unsafe extern "C" fn(extension: *mut zend_extension) -> ::std::os::raw::c_int,
+>;
+pub type shutdown_func_t =
+    ::std::option::Option<unsafe extern "C" fn(extension: *mut zend_extension)>;
+pub type activate_func_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type deactivate_func_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type message_handler_func_t = ::std::option::Option<
+    unsafe extern "C" fn(message: ::std::os::raw::c_int, arg: *mut ::std::os::raw::c_void),
+>;
+pub type op_array_handler_func_t =
+    ::std::option::Option<unsafe extern "C" fn(op_array: *mut zend_op_array)>;
+pub type statement_handler_func_t =
+    ::std::option::Option<unsafe extern "C" fn(frame: *mut zend_execute_data)>;
+pub type fcall_begin_handler_func_t =
+    ::std::option::Option<unsafe extern "C" fn(frame: *mut zend_execute_data)>;
+pub type fcall_end_handler_func_t =
+    ::std::option::Option<unsafe extern "C" fn(frame: *mut zend_execute_data)>;
+pub type op_array_ctor_func_t =
+    ::std::option::Option<unsafe extern "C" fn(op_array: *mut zend_op_array)>;
+pub type op_array_dtor_func_t =
+    ::std::option::Option<unsafe extern "C" fn(op_array: *mut zend_op_array)>;
+pub type op_array_persist_calc_func_t =
+    ::std::option::Option<unsafe extern "C" fn(op_array: *mut zend_op_array) -> usize>;
+pub type op_array_persist_func_t = ::std::option::Option<
+    unsafe extern "C" fn(op_array: *mut zend_op_array, mem: *mut ::std::os::raw::c_void) -> usize,
+>;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _zend_extension {
+    pub name: *const ::std::os::raw::c_char,
+    pub version: *const ::std::os::raw::c_char,
+    pub author: *const ::std::os::raw::c_char,
+    pub URL: *const ::std::os::raw::c_char,
+    pub copyright: *const ::std::os::raw::c_char,
+    pub startup: startup_func_t,
+    pub shutdown: shutdown_func_t,
+    pub activate: activate_func_t,
+    pub deactivate: deactivate_func_t,
+    pub message_handler: message_handler_func_t,
+    pub op_array_handler: op_array_handler_func_t,
+    pub statement_handler: statement_handler_func_t,
+    pub fcall_begin_handler: fcall_begin_handler_func_t,
+    pub fcall_end_handler: fcall_end_handler_func_t,
+    pub op_array_ctor: op_array_ctor_func_t,
+    pub op_array_dtor: op_array_dtor_func_t,
+    pub api_no_check: ::std::option::Option<
+        unsafe extern "C" fn(api_no: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
+    >,
+    pub build_id_check: ::std::option::Option<
+        unsafe extern "C" fn(build_id: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int,
+    >,
+    pub op_array_persist_calc: op_array_persist_calc_func_t,
+    pub op_array_persist: op_array_persist_func_t,
+    pub reserved5: *mut ::std::os::raw::c_void,
+    pub reserved6: *mut ::std::os::raw::c_void,
+    pub reserved7: *mut ::std::os::raw::c_void,
+    pub reserved8: *mut ::std::os::raw::c_void,
+    pub handle: *mut ::std::os::raw::c_void,
+    pub resource_number: ::std::os::raw::c_int,
+}
+unsafe extern "C" {
+    pub fn zend_get_resource_handle(
+        module_name: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn zend_get_op_array_extension_handle(
+        module_name: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn zend_get_op_array_extension_handles(
+        module_name: *const ::std::os::raw::c_char,
+        handles: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn zend_register_extension(
+        new_extension: *mut zend_extension,
+        handle: *mut ::std::os::raw::c_void,
+    );
+}

--- a/examples/zend_extension.rs
+++ b/examples/zend_extension.rs
@@ -1,0 +1,54 @@
+//! Example: Zend Extension hooks for low-level profiling.
+//!
+//! Build: `cargo build --example zend_extension --features observer`
+
+#![allow(missing_docs, clippy::must_use_candidate)]
+#![cfg_attr(windows, feature(abi_vectorcall))]
+
+use ext_php_rs::ffi::zend_op_array;
+use ext_php_rs::prelude::*;
+use ext_php_rs::zend::ExecuteData;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+pub struct StatementProfiler {
+    compiled_functions: AtomicU64,
+    executed_statements: AtomicU64,
+}
+
+impl StatementProfiler {
+    fn new() -> Self {
+        Self {
+            compiled_functions: AtomicU64::new(0),
+            executed_statements: AtomicU64::new(0),
+        }
+    }
+}
+
+impl ZendExtensionHandler for StatementProfiler {
+    fn on_op_array_compiled(&self, _op_array: &mut zend_op_array) {
+        self.compiled_functions.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn on_statement(&self, _execute_data: &ExecuteData) {
+        self.executed_statements.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn on_activate(&self) {
+        self.executed_statements.store(0, Ordering::Relaxed);
+    }
+}
+
+#[php_function]
+pub fn zend_ext_compiled_count() -> u64 {
+    0
+}
+
+#[php_module]
+pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
+    module
+        .zend_extension(StatementProfiler::new)
+        .hook_statements()
+        .hook_op_array_compile()
+        .finish()
+        .function(wrap_function!(zend_ext_compiled_count))
+}

--- a/guide/src/advanced/observer.md
+++ b/guide/src/advanced/observer.md
@@ -279,6 +279,84 @@ The backtrace is lazy - only captured when called, so there's zero cost if unuse
 | `file` | `Option<String>` | Source file |
 | `line` | `u32` | Line number |
 
+## Zend Extension Handler
+
+For low-level engine hooks beyond the Observer API -- per-statement profiling,
+bytecode instrumentation, or `op_array` lifecycle tracking -- register a
+`ZendExtensionHandler`. This registers your extension as a `zend_extension`
+alongside the regular PHP extension, the same mechanism used by OPcache,
+Xdebug, and dd-trace-php.
+
+```rust,ignore
+use ext_php_rs::prelude::*;
+use ext_php_rs::ffi::zend_op_array;
+use ext_php_rs::zend::ExecuteData;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+struct StatementProfiler { count: AtomicU64 }
+
+impl ZendExtensionHandler for StatementProfiler {
+    fn on_statement(&self, _execute_data: &ExecuteData) {
+        self.count.fetch_add(1, Ordering::Relaxed);
+    }
+    fn on_activate(&self) {
+        self.count.store(0, Ordering::Relaxed);
+    }
+}
+
+#[php_module]
+pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
+    module
+        .zend_extension(|| StatementProfiler { count: AtomicU64::new(0) })
+        .hook_statements()
+        .finish()
+}
+```
+
+### Opt-in hooks
+
+| Method | Enables | Cost when enabled |
+|--------|---------|-------------------|
+| `hook_op_array_compile()` | `on_op_array_compiled` | One callback per compiled function |
+| `hook_statements()` | `on_statement` | Extra `ZEND_EXT_STMT` opcode on every statement of every compiled script |
+| `hook_fcalls()` | `on_fcall_begin` / `on_fcall_end` | Extra `ZEND_EXT_FCALL_BEGIN`/`END` opcodes around every call site |
+
+### Why opt in?
+
+`hook_statements()` and `hook_fcalls()` tell the PHP engine to emit extra
+opcodes in every compiled script. Paying that tax by default would slow every
+PHP script, even when your profiler doesn't need the data. The builder makes
+the trade-off explicit.
+
+`hook_op_array_compile()` has no compile-time cost: PHP's default
+`CG(compiler_options)` already includes `ZEND_COMPILE_HANDLE_OP_ARRAY`. Opting
+in only registers the dispatcher, so enabling it just adds one callback per
+compiled function.
+
+The other hooks -- `on_activate`, `on_deactivate`, `on_message`,
+`on_op_array_ctor`, `on_op_array_dtor` -- are always wired when you register
+an extension; they don't need opt-in because they're cold-path.
+
+### ZTS note
+
+Flags are re-asserted in `on_activate` so worker threads created after MINIT
+get them on their first request. Scripts pre-compiled by opcache before a
+thread's first activation may miss hooks -- for full coverage in ZTS with
+opcache, load the extension via `zend_extension=...` in `php.ini`.
+
+### Zend Extension vs Observer API
+
+| Feature | Observer API (`FcallObserver`) | Zend Extension (`ZendExtensionHandler`) |
+|---------|------|------|
+| Function call hooks | `begin` / `end` with return value | `on_fcall_begin` / `on_fcall_end` (legacy) |
+| Filtering | `should_observe` (cached per function) | No built-in filtering |
+| Statement-level hooks | Not available | `on_statement` |
+| Bytecode access | Not available | `on_op_array_compiled`, `on_op_array_ctor`, `on_op_array_dtor` |
+| Request lifecycle | Not available | `on_activate` / `on_deactivate` |
+| Best for | Function-level profiling, tracing | Statement-level profiling, code coverage, bytecode instrumentation |
+
+Both can be registered on the same module simultaneously.
+
 ## Using All Observers
 
 You can register all observers on the same module:
@@ -290,6 +368,9 @@ pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
         .fcall_observer(MyProfiler::new)
         .error_observer(MyErrorTracker::new)
         .exception_observer(MyExceptionTracker::new)
+        .zend_extension(MyStatementProfiler::new)
+        .hook_statements()
+        .finish()
 }
 ```
 
@@ -324,4 +405,5 @@ Use thread-safe primitives like `AtomicU64`, `Mutex`, or `RwLock` for mutable st
 - Only one fcall observer can be registered per extension
 - Only one error observer can be registered per extension
 - Only one exception observer can be registered per extension
-- Observers are registered globally for the entire PHP process
+- Only one zend extension handler can be registered per extension
+- Observers and handlers are registered globally for the entire PHP process

--- a/src/builders/module.rs
+++ b/src/builders/module.rs
@@ -575,9 +575,50 @@ impl ModuleBuilder<'_> {
     }
 }
 
+#[cfg(feature = "observer")]
+impl<'a> ModuleBuilder<'a> {
+    /// Register a [`ZendExtensionHandler`] and configure which hooks PHP should
+    /// call.
+    ///
+    /// Returns a [`ZendExtensionBuilder`] that exposes three opt-in methods
+    /// (`hook_statements`, `hook_fcalls`, `hook_op_array_compile`). Call
+    /// [`ZendExtensionBuilder::finish`] to return to `ModuleBuilder`.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// module
+    ///     .zend_extension(|| MyProfiler::new())
+    ///     .hook_statements()
+    ///     .finish()
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if called more than once on the same module.
+    ///
+    /// [`ZendExtensionHandler`]: crate::zend::ZendExtensionHandler
+    /// [`ZendExtensionBuilder`]: crate::zend::ZendExtensionBuilder
+    /// [`ZendExtensionBuilder::finish`]: crate::zend::ZendExtensionBuilder::finish
+    pub fn zend_extension<F, H>(
+        self,
+        factory: F,
+    ) -> crate::zend::zend_extension::ZendExtensionBuilder<'a>
+    where
+        F: Fn() -> H + Send + Sync + 'static,
+        H: crate::zend::ZendExtensionHandler,
+    {
+        crate::zend::zend_extension::ZendExtensionBuilder::new(self, factory)
+    }
+}
+
 /// Artifacts from the [`ModuleBuilder`] that should be revisited inside the
 /// extension startup function.
 pub struct ModuleStartup {
+    #[cfg(feature = "observer")]
+    name: String,
+    #[cfg(feature = "observer")]
+    version: String,
     constants: Vec<(String, Box<dyn IntoConst + Send>)>,
     classes: Vec<fn() -> ClassBuilder>,
     interfaces: Vec<fn() -> ClassBuilder>,
@@ -625,6 +666,7 @@ impl ModuleStartup {
             crate::zend::observer::observer_startup();
             crate::zend::error_observer::error_observer_startup();
             crate::zend::exception_observer::exception_observer_startup();
+            crate::zend::zend_extension::zend_extension_startup(&self.name, &self.version);
         }
 
         Ok(())
@@ -651,10 +693,19 @@ impl TryFrom<ModuleBuilder<'_>> for (ModuleEntry, ModuleStartup) {
         functions.push(FunctionEntry::end());
         let functions = Box::into_raw(functions.into_boxed_slice()) as *const FunctionEntry;
 
+        #[cfg(feature = "observer")]
+        let ext_name = builder.name.clone();
+        #[cfg(feature = "observer")]
+        let ext_version = builder.version.clone();
+
         let name = CString::new(builder.name)?.into_raw();
         let version = CString::new(builder.version)?.into_raw();
 
         let startup = ModuleStartup {
+            #[cfg(feature = "observer")]
+            name: ext_name,
+            #[cfg(feature = "observer")]
+            version: ext_version,
             constants: builder
                 .constants
                 .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod observer {
     pub use crate::zend::error_observer::{BacktraceFrame, ErrorInfo, ErrorObserver, ErrorType};
     pub use crate::zend::exception_observer::{ExceptionInfo, ExceptionObserver};
     pub use crate::zend::observer::{FcallInfo, FcallObserver};
+    pub use crate::zend::zend_extension::{ZendExtensionBuilder, ZendExtensionHandler};
 }
 #[doc(hidden)]
 pub mod internal;
@@ -71,7 +72,7 @@ pub mod prelude {
     #[cfg(feature = "observer")]
     pub use crate::zend::{
         BacktraceFrame, ErrorInfo, ErrorObserver, ErrorType, ExceptionInfo, ExceptionObserver,
-        FcallInfo, FcallObserver,
+        FcallInfo, FcallObserver, ZendExtensionHandler,
     };
     pub use crate::zend::{BailoutGuard, ModuleGlobal, ModuleGlobals};
     pub use crate::{

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -38,7 +38,10 @@
 #include "zend_interfaces.h"
 #include "php_variables.h"
 #include "zend_ini.h"
+#ifdef EXT_PHP_RS_OBSERVER
 #include "zend_observer.h"
+#include "zend_extensions.h"
+#endif
 #include "main/SAPI.h"
 
 zend_string *ext_php_rs_zend_string_init(const char *str, size_t len, bool persistent);
@@ -50,6 +53,7 @@ const char *ext_php_rs_php_build_id();
 void *ext_php_rs_zend_object_alloc(size_t obj_size, zend_class_entry *ce);
 void ext_php_rs_zend_object_release(zend_object *obj);
 zend_executor_globals *ext_php_rs_executor_globals();
+zend_compiler_globals *ext_php_rs_compiler_globals();
 php_core_globals *ext_php_rs_process_globals();
 sapi_globals_struct *ext_php_rs_sapi_globals();
 php_file_globals *ext_php_rs_file_globals();

--- a/src/zend/mod.rs
+++ b/src/zend/mod.rs
@@ -20,6 +20,8 @@ pub(crate) mod module_globals;
 pub(crate) mod observer;
 mod streams;
 mod try_catch;
+#[cfg(feature = "observer")]
+pub(crate) mod zend_extension;
 
 use crate::{
     error::Result,
@@ -57,6 +59,23 @@ pub use streams::*;
 #[cfg(feature = "embed")]
 pub(crate) use try_catch::panic_wrapper;
 pub use try_catch::{CatchError, bailout, try_catch, try_catch_first};
+#[cfg(feature = "observer")]
+pub use zend_extension::{ZendExtensionBuilder, ZendExtensionHandler};
+
+/// Register a `zend_extension` with the PHP engine.
+///
+/// # Safety
+///
+/// * Must be called during `MINIT`.
+/// * The struct's string fields (`name`, `version`, ...) must point at memory
+///   that lives for the process lifetime. PHP copies the struct into its
+///   internal list but keeps those `*const c_char` pointers.
+#[cfg(feature = "observer")]
+pub(crate) unsafe fn register_extension(ext: *mut crate::ffi::zend_extension) {
+    unsafe {
+        crate::ffi::zend_register_extension(ext, std::ptr::null_mut());
+    }
+}
 
 // Used as the format string for `php_printf`.
 const FORMAT_STR: &[u8] = b"%s\0";

--- a/src/zend/zend_extension.rs
+++ b/src/zend/zend_extension.rs
@@ -1,0 +1,499 @@
+//! Zend Extension API bindings for low-level engine hooks.
+//!
+//! Enables building profilers, APMs, and code coverage tools by registering
+//! as a `zend_extension` alongside the regular PHP extension.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use ext_php_rs::prelude::*;
+//! use ext_php_rs::ffi::zend_op_array;
+//!
+//! struct MyProfiler;
+//!
+//! impl ZendExtensionHandler for MyProfiler {
+//!     fn on_op_array_compiled(&self, _op_array: &mut zend_op_array) {}
+//!     fn on_statement(&self, _execute_data: &ExecuteData) {}
+//! }
+//! ```
+
+use std::ffi::{CString, c_void};
+use std::sync::OnceLock;
+
+use crate::ffi;
+use crate::zend::ExecuteData;
+
+/// Trait for handling low-level Zend Engine hooks via `zend_extension`.
+///
+/// All methods have default no-op implementations. Override only what you need.
+///
+/// # Thread Safety
+///
+/// Handler must be `Send + Sync`. Use thread-safe primitives for mutable state.
+pub trait ZendExtensionHandler: Send + Sync + 'static {
+    /// Called after compilation of each function/method `op_array`.
+    /// Enabled by [`ZendExtensionBuilder::hook_op_array_compile`].
+    fn on_op_array_compiled(&self, _op_array: &mut ffi::zend_op_array) {}
+
+    /// Called for each executed statement.
+    /// Enabled by [`ZendExtensionBuilder::hook_statements`].
+    fn on_statement(&self, _execute_data: &ExecuteData) {}
+
+    /// Called at the beginning of each function call (legacy hook).
+    /// Enabled by [`ZendExtensionBuilder::hook_fcalls`].
+    fn on_fcall_begin(&self, _execute_data: &ExecuteData) {}
+
+    /// Called at the end of each function call (legacy hook).
+    /// Enabled by [`ZendExtensionBuilder::hook_fcalls`].
+    fn on_fcall_end(&self, _execute_data: &ExecuteData) {}
+
+    /// Called when a new `op_array` is constructed.
+    fn on_op_array_ctor(&self, _op_array: &mut ffi::zend_op_array) {}
+
+    /// Called when an `op_array` is destroyed.
+    fn on_op_array_dtor(&self, _op_array: &mut ffi::zend_op_array) {}
+
+    /// Called when another `zend_extension` sends a message.
+    fn on_message(&self, _message: i32, _arg: *mut c_void) {}
+
+    /// Per-request activation (distinct from RINIT).
+    fn on_activate(&self) {}
+
+    /// Per-request deactivation (distinct from RSHUTDOWN).
+    fn on_deactivate(&self) {}
+}
+
+// ============================================================================
+// Config + statics
+// ============================================================================
+
+pub(crate) struct ZendExtensionConfig {
+    pub(crate) factory: Box<dyn Fn() -> Box<dyn ZendExtensionHandler> + Send + Sync>,
+    pub(crate) hook_op_array: bool,
+    pub(crate) hook_statements: bool,
+    pub(crate) hook_fcalls: bool,
+}
+
+static ZEND_EXT_CONFIG: OnceLock<ZendExtensionConfig> = OnceLock::new();
+static ZEND_EXT_INSTANCE: OnceLock<Box<dyn ZendExtensionHandler>> = OnceLock::new();
+static EXT_NAME: OnceLock<CString> = OnceLock::new();
+static EXT_VERSION: OnceLock<CString> = OnceLock::new();
+
+fn get_handler() -> Option<&'static dyn ZendExtensionHandler> {
+    ZEND_EXT_INSTANCE.get().map(std::convert::AsRef::as_ref)
+}
+
+// PHP compiler flags (from zend_compile.h) that cause the compiler to emit
+// the special opcodes consumed by zend_extension hooks.
+const ZEND_COMPILE_EXTENDED_STMT: u32 = 1 << 0;
+const ZEND_COMPILE_EXTENDED_FCALL: u32 = 1 << 1;
+const ZEND_COMPILE_HANDLE_OP_ARRAY: u32 = 1 << 2;
+
+fn compile_flags_for(cfg: &ZendExtensionConfig) -> u32 {
+    let mut flags = 0u32;
+    if cfg.hook_op_array {
+        flags |= ZEND_COMPILE_HANDLE_OP_ARRAY;
+    }
+    if cfg.hook_statements {
+        flags |= ZEND_COMPILE_EXTENDED_STMT;
+    }
+    if cfg.hook_fcalls {
+        flags |= ZEND_COMPILE_EXTENDED_FCALL;
+    }
+    flags
+}
+
+// ============================================================================
+// Builder
+// ============================================================================
+
+/// Builder for a `zend_extension` registration.
+///
+/// Returned by [`crate::builders::ModuleBuilder::zend_extension`]. Call
+/// [`Self::finish`] to return to the outer
+/// [`ModuleBuilder`](crate::builders::ModuleBuilder) after selecting opt-in
+/// hooks.
+///
+/// Each opt-in method enables one family of [`ZendExtensionHandler`] hooks.
+/// [`Self::hook_statements`] and [`Self::hook_fcalls`] also flip the matching
+/// `ZEND_COMPILE_*` flag so PHP emits the extra opcodes the hook depends on,
+/// which costs every compiled script. [`Self::hook_op_array_compile`] has no
+/// compile-time cost because its flag is already set by PHP's defaults; it
+/// only controls whether the dispatcher callback runs.
+#[must_use = "call .finish() to return to ModuleBuilder"]
+pub struct ZendExtensionBuilder<'a> {
+    module: Option<crate::builders::ModuleBuilder<'a>>,
+    factory: Box<dyn Fn() -> Box<dyn ZendExtensionHandler> + Send + Sync>,
+    hook_op_array: bool,
+    hook_statements: bool,
+    hook_fcalls: bool,
+}
+
+impl<'a> ZendExtensionBuilder<'a> {
+    pub(crate) fn new<F, H>(module: crate::builders::ModuleBuilder<'a>, factory: F) -> Self
+    where
+        F: Fn() -> H + Send + Sync + 'static,
+        H: ZendExtensionHandler,
+    {
+        Self {
+            module: Some(module),
+            factory: Box::new(move || Box::new(factory())),
+            hook_op_array: false,
+            hook_statements: false,
+            hook_fcalls: false,
+        }
+    }
+
+    /// Enable `on_op_array_compiled`, called after PHP finishes compiling
+    /// each function or method.
+    ///
+    /// Unlike [`Self::hook_statements`] and [`Self::hook_fcalls`], this
+    /// opt-in does not change the bytecode PHP emits: the matching flag
+    /// (`ZEND_COMPILE_HANDLE_OP_ARRAY`) is already part of PHP's default
+    /// `CG(compiler_options)`. The opt-in only controls whether the
+    /// dispatcher is registered, so the cost scales with the number of
+    /// compiled functions, not with every opcode.
+    pub fn hook_op_array_compile(mut self) -> Self {
+        self.hook_op_array = true;
+        self
+    }
+
+    /// Enable `on_statement` -- called for every executed statement.
+    ///
+    /// Flips `ZEND_COMPILE_EXTENDED_STMT`, which causes PHP to emit extra
+    /// `ZEND_EXT_STMT` opcodes in every compiled script. Opt in only if your
+    /// profiler actually needs per-statement granularity.
+    pub fn hook_statements(mut self) -> Self {
+        self.hook_statements = true;
+        self
+    }
+
+    /// Enable `on_fcall_begin` / `on_fcall_end` -- legacy per-call-site hooks.
+    ///
+    /// Flips `ZEND_COMPILE_EXTENDED_FCALL`, which causes PHP to emit
+    /// `ZEND_EXT_FCALL_BEGIN`/`END` opcodes around every call site.
+    pub fn hook_fcalls(mut self) -> Self {
+        self.hook_fcalls = true;
+        self
+    }
+
+    /// Consume the builder, register the extension, and return the outer
+    /// [`ModuleBuilder`](crate::builders::ModuleBuilder) so further module
+    /// config can be chained.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a `ZendExtensionHandler` has already been registered on this
+    /// module. Each extension may register at most one handler.
+    pub fn finish(self) -> crate::builders::ModuleBuilder<'a> {
+        register_config(ZendExtensionConfig {
+            factory: self.factory,
+            hook_op_array: self.hook_op_array,
+            hook_statements: self.hook_statements,
+            hook_fcalls: self.hook_fcalls,
+        });
+        self.module
+            .expect("ZendExtensionBuilder::finish called on test instance")
+    }
+
+    #[cfg(test)]
+    pub(crate) fn __for_tests<F, H>(factory: F) -> Self
+    where
+        F: Fn() -> H + Send + Sync + 'static,
+        H: ZendExtensionHandler,
+    {
+        Self {
+            module: None,
+            factory: Box::new(move || Box::new(factory())),
+            hook_op_array: false,
+            hook_statements: false,
+            hook_fcalls: false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn opts(&self) -> (bool, bool, bool) {
+        (self.hook_op_array, self.hook_statements, self.hook_fcalls)
+    }
+}
+
+pub(crate) fn register_config(config: ZendExtensionConfig) {
+    assert!(
+        ZEND_EXT_CONFIG.set(config).is_ok(),
+        "zend_extension can only be registered once per module",
+    );
+}
+
+// ============================================================================
+// extern "C" dispatchers
+// ============================================================================
+
+/// # Safety
+///
+/// Called from PHP's C code.
+unsafe extern "C" fn ext_op_array_handler(op_array: *mut ffi::zend_op_array) {
+    if let Some(handler) = get_handler()
+        && let Some(op) = unsafe { op_array.as_mut() }
+    {
+        handler.on_op_array_compiled(op);
+    }
+}
+
+/// # Safety
+///
+/// Called from PHP's C code.
+unsafe extern "C" fn ext_statement_handler(execute_data: *mut ffi::zend_execute_data) {
+    if let Some(handler) = get_handler()
+        && let Some(ex) = unsafe { execute_data.as_ref() }
+    {
+        handler.on_statement(ex);
+    }
+}
+
+/// # Safety
+///
+/// Called from PHP's C code.
+unsafe extern "C" fn ext_fcall_begin_handler(execute_data: *mut ffi::zend_execute_data) {
+    if let Some(handler) = get_handler()
+        && let Some(ex) = unsafe { execute_data.as_ref() }
+    {
+        handler.on_fcall_begin(ex);
+    }
+}
+
+/// # Safety
+///
+/// Called from PHP's C code.
+unsafe extern "C" fn ext_fcall_end_handler(execute_data: *mut ffi::zend_execute_data) {
+    if let Some(handler) = get_handler()
+        && let Some(ex) = unsafe { execute_data.as_ref() }
+    {
+        handler.on_fcall_end(ex);
+    }
+}
+
+/// # Safety
+///
+/// Called from PHP's C code.
+unsafe extern "C" fn ext_op_array_ctor(op_array: *mut ffi::zend_op_array) {
+    if let Some(handler) = get_handler()
+        && let Some(op) = unsafe { op_array.as_mut() }
+    {
+        handler.on_op_array_ctor(op);
+    }
+}
+
+/// # Safety
+///
+/// Called from PHP's C code.
+unsafe extern "C" fn ext_op_array_dtor(op_array: *mut ffi::zend_op_array) {
+    if let Some(handler) = get_handler()
+        && let Some(op) = unsafe { op_array.as_mut() }
+    {
+        handler.on_op_array_dtor(op);
+    }
+}
+
+/// # Safety
+///
+/// Called from PHP's C code.
+unsafe extern "C" fn ext_message_handler(message: i32, arg: *mut c_void) {
+    if let Some(handler) = get_handler() {
+        handler.on_message(message, arg);
+    }
+}
+
+/// # Safety
+///
+/// Called from PHP's C code.
+unsafe extern "C" fn ext_activate() {
+    if let Some(cfg) = ZEND_EXT_CONFIG.get() {
+        apply_compiler_flags(cfg);
+    }
+    if let Some(handler) = get_handler() {
+        handler.on_activate();
+    }
+}
+
+/// # Safety
+///
+/// Called from PHP's C code.
+unsafe extern "C" fn ext_deactivate() {
+    if let Some(handler) = get_handler() {
+        handler.on_deactivate();
+    }
+}
+
+// ============================================================================
+// Registration
+// ============================================================================
+
+/// # Safety
+///
+/// Must be called during MINIT phase only.
+pub(crate) unsafe fn zend_extension_startup(name: &str, version: &str) {
+    let Some(cfg) = ZEND_EXT_CONFIG.get() else {
+        return;
+    };
+
+    let _ = ZEND_EXT_INSTANCE.set((cfg.factory)());
+
+    let c_name = CString::new(name).expect("zend extension name must not contain nul bytes");
+    let c_version =
+        CString::new(version).expect("zend extension version must not contain nul bytes");
+    let name_ptr = EXT_NAME.get_or_init(|| c_name).as_ptr();
+    let version_ptr = EXT_VERSION.get_or_init(|| c_version).as_ptr();
+
+    let mut ext: ffi::zend_extension = unsafe { std::mem::zeroed() };
+    ext.name = name_ptr;
+    ext.version = version_ptr;
+
+    // Always-on cold-path hooks.
+    ext.activate = Some(ext_activate);
+    ext.deactivate = Some(ext_deactivate);
+    ext.message_handler = Some(ext_message_handler);
+    ext.op_array_ctor = Some(ext_op_array_ctor);
+    ext.op_array_dtor = Some(ext_op_array_dtor);
+
+    // Opt-in hot-path hooks.
+    if cfg.hook_op_array {
+        ext.op_array_handler = Some(ext_op_array_handler);
+    }
+    if cfg.hook_statements {
+        ext.statement_handler = Some(ext_statement_handler);
+    }
+    if cfg.hook_fcalls {
+        ext.fcall_begin_handler = Some(ext_fcall_begin_handler);
+        ext.fcall_end_handler = Some(ext_fcall_end_handler);
+    }
+
+    unsafe {
+        crate::zend::register_extension(&raw mut ext);
+    }
+    apply_compiler_flags(cfg);
+}
+
+fn apply_compiler_flags(cfg: &ZendExtensionConfig) {
+    let flags = compile_flags_for(cfg);
+    if flags != 0 {
+        let mut cg = super::globals::CompilerGlobals::get_mut();
+        cg.compiler_options |= flags;
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(stmts: bool, fcalls: bool, op_array: bool) -> ZendExtensionConfig {
+        ZendExtensionConfig {
+            factory: Box::new(|| Box::new(NoopHandler)),
+            hook_statements: stmts,
+            hook_fcalls: fcalls,
+            hook_op_array: op_array,
+        }
+    }
+
+    struct NoopHandler;
+    impl ZendExtensionHandler for NoopHandler {}
+
+    // -- compile_flags_for tests --
+
+    #[test]
+    fn compile_flags_for_none_is_zero() {
+        assert_eq!(compile_flags_for(&cfg(false, false, false)), 0);
+    }
+
+    #[test]
+    fn compile_flags_for_statements_only() {
+        assert_eq!(
+            compile_flags_for(&cfg(true, false, false)),
+            ZEND_COMPILE_EXTENDED_STMT,
+        );
+    }
+
+    #[test]
+    fn compile_flags_for_fcalls_only() {
+        assert_eq!(
+            compile_flags_for(&cfg(false, true, false)),
+            ZEND_COMPILE_EXTENDED_FCALL,
+        );
+    }
+
+    #[test]
+    fn compile_flags_for_op_array_only() {
+        assert_eq!(
+            compile_flags_for(&cfg(false, false, true)),
+            ZEND_COMPILE_HANDLE_OP_ARRAY,
+        );
+    }
+
+    #[test]
+    fn compile_flags_for_all_is_or() {
+        assert_eq!(
+            compile_flags_for(&cfg(true, true, true)),
+            ZEND_COMPILE_EXTENDED_STMT | ZEND_COMPILE_EXTENDED_FCALL | ZEND_COMPILE_HANDLE_OP_ARRAY,
+        );
+    }
+
+    // -- builder state tests --
+
+    #[test]
+    fn builder_starts_with_no_hooks() {
+        let b = ZendExtensionBuilder::__for_tests(|| NoopHandler);
+        assert_eq!(b.opts(), (false, false, false));
+    }
+
+    #[test]
+    fn builder_hook_statements_flips_only_statements() {
+        let b = ZendExtensionBuilder::__for_tests(|| NoopHandler).hook_statements();
+        assert_eq!(b.opts(), (false, true, false));
+    }
+
+    #[test]
+    fn builder_hook_fcalls_flips_only_fcalls() {
+        let b = ZendExtensionBuilder::__for_tests(|| NoopHandler).hook_fcalls();
+        assert_eq!(b.opts(), (false, false, true));
+    }
+
+    #[test]
+    fn builder_hook_op_array_compile_flips_only_op_array() {
+        let b = ZendExtensionBuilder::__for_tests(|| NoopHandler).hook_op_array_compile();
+        assert_eq!(b.opts(), (true, false, false));
+    }
+
+    #[test]
+    fn builder_hooks_compose() {
+        let b = ZendExtensionBuilder::__for_tests(|| NoopHandler)
+            .hook_statements()
+            .hook_fcalls()
+            .hook_op_array_compile();
+        assert_eq!(b.opts(), (true, true, true));
+    }
+
+    #[test]
+    fn builder_hooks_idempotent() {
+        let b = ZendExtensionBuilder::__for_tests(|| NoopHandler)
+            .hook_statements()
+            .hook_statements();
+        assert_eq!(b.opts(), (false, true, false));
+    }
+
+    #[test]
+    fn trait_lifecycle_defaults_are_no_op() {
+        // The other six defaults (on_op_array_compiled, on_statement,
+        // on_fcall_begin/end, on_op_array_ctor/dtor) require a PHP runtime
+        // to construct their arguments; the integration test exercises
+        // them end-to-end.
+        struct Empty;
+        impl ZendExtensionHandler for Empty {}
+        let h = Empty;
+        h.on_activate();
+        h.on_deactivate();
+        h.on_message(0, std::ptr::null_mut());
+    }
+}

--- a/tests/src/integration/observer/mod.rs
+++ b/tests/src/integration/observer/mod.rs
@@ -1,5 +1,7 @@
-//! Integration tests for the Observer API (fcall, error, and exception observers).
+//! Integration tests for the Observer API (fcall, error, exception observers,
+//! and `zend_extension` handler).
 
+use ext_php_rs::ffi;
 use ext_php_rs::prelude::*;
 use ext_php_rs::types::Zval;
 use ext_php_rs::zend::ExecuteData;
@@ -397,6 +399,122 @@ impl ExceptionObserver for TestExceptionObserverWrapper {
 }
 
 // ============================================================================
+// Zend Extension Handler Tests
+// ============================================================================
+
+/// Shared state for the zend extension test handler.
+#[allow(clippy::struct_field_names)] // every field counts a different hook invocation
+struct ZendExtTestState {
+    activate_count: AtomicU64,
+    op_array_handler_count: AtomicU64,
+    statement_count: AtomicU64,
+    fcall_begin_count: AtomicU64,
+    fcall_end_count: AtomicU64,
+}
+
+impl ZendExtTestState {
+    fn new() -> Self {
+        Self {
+            activate_count: AtomicU64::new(0),
+            op_array_handler_count: AtomicU64::new(0),
+            statement_count: AtomicU64::new(0),
+            fcall_begin_count: AtomicU64::new(0),
+            fcall_end_count: AtomicU64::new(0),
+        }
+    }
+}
+
+static ZEND_EXT_STATE: std::sync::OnceLock<ZendExtTestState> = std::sync::OnceLock::new();
+
+fn get_or_init_zend_ext_state() -> &'static ZendExtTestState {
+    ZEND_EXT_STATE.get_or_init(ZendExtTestState::new)
+}
+
+/// Test handler that counts hook invocations via static state.
+struct TestZendExtHandler;
+
+impl ZendExtensionHandler for TestZendExtHandler {
+    fn on_activate(&self) {
+        get_or_init_zend_ext_state()
+            .activate_count
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn on_op_array_compiled(&self, _op_array: &mut ffi::zend_op_array) {
+        get_or_init_zend_ext_state()
+            .op_array_handler_count
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn on_statement(&self, _execute_data: &ExecuteData) {
+        get_or_init_zend_ext_state()
+            .statement_count
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn on_fcall_begin(&self, _execute_data: &ExecuteData) {
+        get_or_init_zend_ext_state()
+            .fcall_begin_count
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn on_fcall_end(&self, _execute_data: &ExecuteData) {
+        get_or_init_zend_ext_state()
+            .fcall_end_count
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[php_function]
+pub fn zend_ext_test_get_activate_count() -> u64 {
+    get_or_init_zend_ext_state()
+        .activate_count
+        .load(Ordering::Relaxed)
+}
+
+#[php_function]
+pub fn zend_ext_test_get_op_array_handler_count() -> u64 {
+    get_or_init_zend_ext_state()
+        .op_array_handler_count
+        .load(Ordering::Relaxed)
+}
+
+#[php_function]
+pub fn zend_ext_test_get_statement_count() -> u64 {
+    get_or_init_zend_ext_state()
+        .statement_count
+        .load(Ordering::Relaxed)
+}
+
+#[php_function]
+pub fn zend_ext_test_get_fcall_begin_count() -> u64 {
+    get_or_init_zend_ext_state()
+        .fcall_begin_count
+        .load(Ordering::Relaxed)
+}
+
+#[php_function]
+pub fn zend_ext_test_get_fcall_end_count() -> u64 {
+    get_or_init_zend_ext_state()
+        .fcall_end_count
+        .load(Ordering::Relaxed)
+}
+
+#[php_function]
+pub fn zend_ext_test_reset_statement_count() {
+    get_or_init_zend_ext_state()
+        .statement_count
+        .store(0, Ordering::Relaxed);
+}
+
+#[php_function]
+pub fn zend_ext_test_reset_fcall_counts() {
+    let state = get_or_init_zend_ext_state();
+    state.fcall_begin_count.store(0, Ordering::Relaxed);
+    state.fcall_end_count.store(0, Ordering::Relaxed);
+}
+
+// ============================================================================
 // Module Builder
 // ============================================================================
 
@@ -409,6 +527,14 @@ pub fn build_module(builder: ModuleBuilder) -> ModuleBuilder {
 
     // Register the exception observer factory
     let builder = builder.exception_observer(|| TestExceptionObserverWrapper);
+
+    // Register the zend extension handler via builder
+    let builder = builder
+        .zend_extension(|| TestZendExtHandler)
+        .hook_op_array_compile()
+        .hook_statements()
+        .hook_fcalls()
+        .finish();
 
     builder
         // Fcall observer functions
@@ -434,6 +560,14 @@ pub fn build_module(builder: ModuleBuilder) -> ModuleBuilder {
         .function(wrap_function!(
             exception_observer_test_get_backtrace_functions
         ))
+        // Zend extension handler functions
+        .function(wrap_function!(zend_ext_test_get_activate_count))
+        .function(wrap_function!(zend_ext_test_get_op_array_handler_count))
+        .function(wrap_function!(zend_ext_test_get_statement_count))
+        .function(wrap_function!(zend_ext_test_get_fcall_begin_count))
+        .function(wrap_function!(zend_ext_test_get_fcall_end_count))
+        .function(wrap_function!(zend_ext_test_reset_statement_count))
+        .function(wrap_function!(zend_ext_test_reset_fcall_counts))
 }
 
 #[cfg(test)]
@@ -454,6 +588,13 @@ mod tests {
     fn exception_observer_works() {
         assert!(crate::integration::test::run_php(
             "observer/exception_observer.php"
+        ));
+    }
+
+    #[test]
+    fn zend_extension_handler_works() {
+        assert!(crate::integration::test::run_php(
+            "observer/zend_extension.php"
         ));
     }
 }

--- a/tests/src/integration/observer/zend_extension.php
+++ b/tests/src/integration/observer/zend_extension.php
@@ -1,0 +1,99 @@
+<?php
+
+// ============================================================================
+// Test 1: activate() was called during request startup
+// ============================================================================
+
+$activate_count = zend_ext_test_get_activate_count();
+assert($activate_count >= 1, "Expected activate() to be called at least once, got: " . $activate_count);
+
+// ============================================================================
+// Test 2: op_array_handler() fires after compilation
+// ============================================================================
+// In CLI mode the entire file is compiled before execution, so op_array_handler
+// has already been called for the main script and any functions defined above.
+
+$op_count = zend_ext_test_get_op_array_handler_count();
+assert($op_count > 0, "Expected op_array_handler to be called at least once, got: " . $op_count);
+
+// ============================================================================
+// Test 3: statement_handler() fires for executed statements
+// ============================================================================
+
+zend_ext_test_reset_statement_count();
+$a = 1;
+$b = 2;
+$c = $a + $b;
+$stmt_count = zend_ext_test_get_statement_count();
+// The reset call, three assignments, and the get call each produce
+// ZEND_EXT_STMT opcodes, so the count must be greater than zero.
+assert($stmt_count > 0, "Expected statement_handler to be called, got: " . $stmt_count);
+
+// ============================================================================
+// Test 4: fcall_begin_handler() / fcall_end_handler() fire around calls
+// ============================================================================
+// ZEND_EXT_FCALL_BEGIN/END opcodes are emitted at call-sites in the calling
+// code.  The reset function's own EXT_FCALL_BEGIN fires *before* the reset
+// while its EXT_FCALL_END fires *after*, so begin and end may differ by one.
+// We therefore only assert a minimum count for each.
+
+function zend_ext_test_user_fn(): int
+{
+    return 42;
+}
+
+zend_ext_test_reset_fcall_counts();
+zend_ext_test_user_fn();
+zend_ext_test_user_fn();
+zend_ext_test_user_fn();
+$begin_count = zend_ext_test_get_fcall_begin_count();
+$end_count = zend_ext_test_get_fcall_end_count();
+assert($begin_count >= 3, "Expected at least 3 fcall_begin, got: " . $begin_count);
+assert($end_count >= 3, "Expected at least 3 fcall_end, got: " . $end_count);
+
+// ============================================================================
+// Test 5: Nested user function calls are tracked
+// ============================================================================
+
+function zend_ext_outer(): int
+{
+    return zend_ext_inner();
+}
+
+function zend_ext_inner(): int
+{
+    return 99;
+}
+
+zend_ext_test_reset_fcall_counts();
+$result = zend_ext_outer();
+assert($result === 99, "Nested call should return 99, got: " . $result);
+
+$nested_begin = zend_ext_test_get_fcall_begin_count();
+$nested_end = zend_ext_test_get_fcall_end_count();
+// outer() calls inner(), each with EXT_FCALL_BEGIN/END at the call-site.
+// The call to outer() in the main script also generates EXT_FCALL, and
+// inner()'s call-site inside outer() generates another pair.
+assert($nested_begin >= 2, "Expected at least 2 nested fcall_begin, got: " . $nested_begin);
+assert($nested_end >= 2, "Expected at least 2 nested fcall_end, got: " . $nested_end);
+
+// ============================================================================
+// Test 6: statement_handler counts increase with more statements
+// ============================================================================
+
+zend_ext_test_reset_statement_count();
+$x = 1;
+$y = 2;
+$first_batch = zend_ext_test_get_statement_count();
+
+zend_ext_test_reset_statement_count();
+$x = 1;
+$y = 2;
+$z = 3;
+$w = 4;
+$second_batch = zend_ext_test_get_statement_count();
+
+assert(
+    $second_batch > $first_batch,
+    "More statements should produce a higher count: first=$first_batch, second=$second_batch",
+);


### PR DESCRIPTION
## Description

Closes the API gap for building `zend_extension`-style profilers (APM, coverage tools, line-level timers) on top of ext-php-rs. Until now the crate only exposed the Observer API (function-call level). This PR adds dual registration so a single extension can also hook the engine's compile-time and per-statement callbacks.

### What you get

```rust
module
    .zend_extension(|| MyProfiler::new())
    .hook_statements()
    .hook_fcalls()
    .finish()
```

The handler trait carries all hooks with default no-op implementations; the builder decides which ones the engine will actually call. Enabling a hook also flips the matching PHP compiler flag so the right opcodes get emitted.

### Why the opt-in

`hook_statements()` and `hook_fcalls()` tell the PHP engine to emit extra opcodes in every compiled script (`ZEND_EXT_STMT`, `ZEND_EXT_FCALL_BEGIN`/`END`). Paying that tax by default would slow every PHP script, even when your profiler doesn't need the data. The builder makes the trade-off explicit. `hook_op_array_compile()` has no compile-time cost because its flag is already set by PHP's defaults; it only controls whether the dispatcher is registered.

### ZTS

Flags are re-asserted in `on_activate`, which is per-request-per-thread, so worker threads created after MINIT still get them. Scripts pre-compiled by opcache before a thread's first activation may miss hooks; load the extension via `zend_extension=...` in `php.ini` if you need 100% coverage there.

### Docs

Guide section at `guide/src/advanced/observer.md#zend-extension-handler` rewritten. Example at `examples/zend_extension.rs` updated. All trait methods renamed to `on_*` prefix for consistency with sibling observers.

## Checklist

- [x] I have read the contribution guidelines and the code of conduct.
- [x] I have added tests that prove my code works as expected.
- [x] I have added documentation if applicable.
- [x] I have added a migration guide if applicable. (N/A: the earlier `zend_extension_handler(factory)` API shipped only on this unmerged branch, no release notes or published docs referenced it.)
