### PR TITLE
doc(showcase): Add grpc-php-rs to usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Check out one of the example projects:
   scrypt password hashing algorithm.
 - [fluent-php](https://github.com/Ennexa/fluent-php) - PHP wrapper for Mozilla's Project Fluent i18n library.
 - [php-rocksdb-rc](https://github.com/s00d/php-rocksdb-rc) - PHP wrapper for rocksdb library.
+- [grpc-php-rs](https://github.com/BSN4/grpc-php-rs) - Rust-based gRPC extension for PHP, drop-in replacement for ext-grpc.
 
 ## Contributions
 


### PR DESCRIPTION
## Summary

- Adds [grpc-php-rs](https://github.com/BSN4/grpc-php-rs) to the usage examples list

Rust-based gRPC extension for PHP — drop-in replacement for ext-grpc. Solves ZTS/TSRM crashes and OpenSSL/BoringSSL conflicts by using tonic + rustls. Published on PIE with pre-packaged binaries for PHP 8.2–8.5.