### PR TITLE
fix: use raw-dylib for Windows symbol imports

### DIFF
--- a/windows_build.rs
+++ b/windows_build.rs
@@ -65,16 +65,25 @@ impl<'a> PHPProvider<'a> for Provider<'a> {
     }
 
     fn write_bindings(&self, bindings: String, writer: &mut impl Write) -> Result<()> {
-        // Symbols don't link without a `#[link(name = "php8")]` attribute on
-        // each extern block. Bindgen doesn't give us the option to add this so
-        // we need to add it manually.
+        // Symbols don't link without a `#[link]` attribute on each extern
+        // block. Bindgen doesn't give us the option to add this so we need
+        // to add it manually.
         //
-        // We use substring matching rather than exact line comparison because
-        // bindgen's output format varies depending on whether rustfmt is
-        // available. When rustfmt is missing, bindgen emits minimally-formatted
-        // output where extern blocks may not appear on their own line.
+        // We use `kind = "raw-dylib"` so the Rust compiler generates its
+        // own import stubs instead of relying on the pre-built import
+        // library. This ensures that data symbol imports (statics like
+        // `zend_ce_exception`, `std_object_handlers`) get proper
+        // `__imp_`-prefixed dllimport references. With `kind = "dylib"`,
+        // the compiler may emit direct references that neither rust-lld
+        // nor MSVC link.exe can resolve from the import library.
+        //
+        // We use substring matching rather than exact line comparison
+        // because bindgen's output format varies depending on whether
+        // rustfmt is available.
         let php_lib_name = self.get_php_lib_name()?;
-        let link_attr = format!("#[link(name = \"{php_lib_name}\")]");
+        let link_attr = format!(
+            "#[link(name = \"{php_lib_name}\", kind = \"raw-dylib\")]"
+        );
         let extern_patterns = [
             "extern \"C\" {",
             "extern \"fastcall\" {",


### PR DESCRIPTION
## Description

Switch from `kind = "dylib"` (the default) to `kind = "raw-dylib"` in the `#[link]` attributes injected into bindgen extern blocks.

With `raw-dylib`, the Rust compiler generates its own import stubs instead of relying on the pre-built import library (`php8.lib`). This ensures that data symbol imports (statics like `zend_ce_exception`, `std_object_handlers`) get proper `__imp_`-prefixed dllimport references. With `kind = "dylib"`, the compiler may emit direct references that neither `rust-lld` nor MSVC `link.exe` can resolve from the import library. Every Zend engine data symbol shows up as an unresolved external.

`raw-dylib` has been stable since Rust 1.65.

<!--
Describes the changes made in the pull request. This should include:
- A summary of the changes made.
- Relevant or closing issues (e.g. `Fixes #123`).
- Any additional context or information that might be helpful for reviewers.
- If this is a breaking change, please ensure to include a migration guide.

If your PR is related to an issue you can keep this section short and just link the issue.
If you are unsure about something, please ask in the issue or PR. We are always happy to help.
-->

## Checklist

<!--
Check the boxes that apply (put an `x` in the brackets, like `[x]`). You can also check boxes after the PR is created.
-->

- [x] I have read the [contribution guidelines](CONTRIBUTING.md) and the [code of conduct](CODE_OF_CONDUCT.md).
- [ ] I have added tests that prove my code works as expected.
- [ ] I have added documentation if applicable.
- [ ] I have added a [migration guide](CONTRIBUTING.md#breaking-changes) if applicable.

<!-- :heart: Thank you for your contribution! -->
