### PR TITLE
fix: inject #[link] attributes correctly when rustfmt is unavailable

### DIFF
--- a/windows_build.rs
+++ b/windows_build.rs
@@ -69,27 +69,26 @@ impl<'a> PHPProvider<'a> for Provider<'a> {
         // each extern block. Bindgen doesn't give us the option to add this so
         // we need to add it manually.
         //
-        // We use substring matching rather than exact line comparison because
-        // bindgen's output format varies depending on whether rustfmt is
-        // available. When rustfmt is missing, bindgen emits minimally-formatted
-        // output where extern blocks may not appear on their own line.
+        // We use direct string replacement rather than line-by-line matching.
+        // When rustfmt is missing, bindgen emits the entire file on a single
+        // line, which breaks any line-based approach.
+        //
+        // Because "extern \"C\" {" is a substring of "unsafe extern \"C\" {",
+        // we first mark all `extern` blocks with a placeholder, then move the
+        // marker before any preceding `unsafe` keyword, and finally expand the
+        // markers into the real `#[link]` attribute.
         let php_lib_name = self.get_php_lib_name()?;
         let link_attr = format!("#[link(name = \"{php_lib_name}\")]");
-        let extern_patterns = [
-            "extern \"C\" {",
-            "extern \"fastcall\" {",
-            "unsafe extern \"C\" {",
-            "unsafe extern \"fastcall\" {",
-        ];
-        for line in bindings.lines() {
-            for pattern in &extern_patterns {
-                if line.contains(pattern) {
-                    writeln!(writer, "{link_attr}")?;
-                    break;
-                }
-            }
-            writeln!(writer, "{}", line)?;
+
+        const MARKER: &str = "__EXT_PHP_RS_LINK__";
+
+        let mut result = bindings;
+        for pattern in ["extern \"C\" {", "extern \"fastcall\" {"] {
+            result = result.replace(pattern, &format!("{MARKER} {pattern}"));
         }
+        result = result.replace(&format!("unsafe {MARKER} "), &format!("{MARKER} unsafe "));
+        result = result.replace(&format!("{MARKER} "), &format!("{link_attr}\n"));
+        writer.write_all(result.as_bytes())?;
         Ok(())
     }
 


### PR DESCRIPTION
## Description

Fix Windows link failures when `rustfmt` is not installed for the active Rust toolchain.

**The problem:** When `rustfmt` is unavailable, bindgen generates the entire bindings file as a single line (~120K characters). The previous `write_bindings()` implementation iterated line-by-line, looking for `extern "C" {` patterns to inject `#[link(name = "php8")]` before them. With a single-line output, the `#[link]` attribute ended up before the mega-line's first item (a struct definition) instead of the extern blocks. This left all PHP/Zend data symbols (`std_object_handlers`, `zend_ce_exception`, `zend_string_init_interned`, etc.) without a link directive, causing `rust-lld` to report "undefined symbol" for every one of them.

**How it surfaces in practice:** CI workflows that install `rustfmt` only for a `stable` toolchain while the project uses `nightly` (via `rust-toolchain.toml`). The nightly toolchain lacks `rustfmt`, triggering the bug. This is exactly what happens in [paragonie/ext-pqcrypto](https://github.com/paragonie/ext-pqcrypto/actions/runs/24397394186/job/71258583161).

**The fix:** Replace line-by-line iteration with direct string replacement using a three-phase marker approach:

1. Mark all `extern "C/fastcall" {` occurrences with a placeholder
2. Swap `unsafe <marker>` to `<marker> unsafe` to handle the substring overlap (`extern "C" {` is a substring of `unsafe extern "C" {`)
3. Expand markers into the real `#[link(name = "...")]` attribute

This produces correct output regardless of whether bindgen's output is formatted or not.

**Tested on Windows 11** with nightly `1.97.0-nightly`, `rust-lld`, PHP 8.2 NTS, and `rustfmt` deliberately removed to reproduce CI conditions. Verified that 110 extern blocks all receive the correct `#[link]` attribute placement.

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md) and the [code of conduct](CODE_OF_CONDUCT.md).
- [ ] I have added tests that prove my code works as expected.
- [x] I have added documentation if applicable.
- [ ] I have added a [migration guide](CONTRIBUTING.md#breaking-changes) if applicable.
