### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## [0.15.11](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.10...ext-php-rs-v0.15.11) - 2026-04-20
+
+### Added
+- *(observer)* Allow zend_extension registration for low level function ([#678](https://github.com/extphprs/ext-php-rs/pull/678)) (by @ptondereau) [[#678](https://github.com/extphprs/ext-php-rs/issues/678)] 
+
+### Fixed
+- Address clippy 1.95.0 lint errors ([#728](https://github.com/extphprs/ext-php-rs/pull/728)) (by @ptondereau) [[#728](https://github.com/extphprs/ext-php-rs/issues/728)] 
+
+### Other
+- Cache property lookups across repeated accesses ([#726](https://github.com/extphprs/ext-php-rs/pull/726)) (by @ptondereau) [[#726](https://github.com/extphprs/ext-php-rs/issues/726)] 
+- Pre-compute mangled property names in get_properties ([#724](https://github.com/extphprs/ext-php-rs/pull/724)) (by @ptondereau) [[#724](https://github.com/extphprs/ext-php-rs/issues/724)] 
 ## [0.15.10](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.9...ext-php-rs-v0.15.10) - 2026-04-14
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.15.10"
+version = "0.15.11"
 authors = [
     "Pierre Tondereau <pierre.tondereau@protonmail.com>",
     "Xenira <xenira@php.rs>",
@@ -25,7 +25,7 @@ anyhow = { version = "1", optional = true }
 smartstring = { version = "1", optional = true }
 indexmap = { version = "2", optional = true }
 inventory = "0.3"
-ext-php-rs-derive = { version = "=0.11.11", path = "./crates/macros" }
+ext-php-rs-derive = { version = "=0.11.12", path = "./crates/macros" }
 
 [dev-dependencies]
 skeptic = "0.13"

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.21](https://github.com/extphprs/ext-php-rs/compare/cargo-php-v0.1.20...cargo-php-v0.1.21) - 2026-04-20
+
+### Fixed
+- Address clippy 1.95.0 lint errors ([#728](https://github.com/extphprs/ext-php-rs/pull/728)) (by @ptondereau) [[#728](https://github.com/extphprs/ext-php-rs/issues/728)] 
 ## [0.1.20](https://github.com/extphprs/ext-php-rs/compare/cargo-php-v0.1.19...cargo-php-v0.1.20) - 2026-04-14
 
 ### Added

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.1.20"
+version = "0.1.21"
 authors = [
     "Xenira <xenira@php.rs>",
     "David Cole <david.cole1340@gmail.com>",

--- a/crates/macros/CHANGELOG.md
+++ b/crates/macros/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.11.12](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.11...ext-php-rs-derive-v0.11.12) - 2026-04-20
+
+### Other
+- Pre-compute mangled property names in get_properties ([#724](https://github.com/extphprs/ext-php-rs/pull/724)) (by @ptondereau) [[#724](https://github.com/extphprs/ext-php-rs/issues/724)] 
 ## [0.11.11](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.10...ext-php-rs-derive-v0.11.11) - 2026-04-14
 
 ### Added

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -4,7 +4,7 @@ description = "Derive macros for ext-php-rs."
 repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
-version = "0.11.11"
+version = "0.11.12"
 authors = [
     "Xenira <xenira@php.rs>",
     "David Cole <david.cole1340@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `ext-php-rs-derive`: 0.11.11 -> 0.11.12
* `ext-php-rs`: 0.15.10 -> 0.15.11 (✓ API compatible changes)
* `cargo-php`: 0.1.20 -> 0.1.21 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `ext-php-rs-derive`

<blockquote>

## [0.11.12](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.11...ext-php-rs-derive-v0.11.12) - 2026-04-20

### Other
- Pre-compute mangled property names in get_properties ([#724](https://github.com/extphprs/ext-php-rs/pull/724)) (by @ptondereau) [[#724](https://github.com/extphprs/ext-php-rs/issues/724)]
</blockquote>

## `ext-php-rs`

<blockquote>

## [0.15.11](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.10...ext-php-rs-v0.15.11) - 2026-04-20

### Added
- *(observer)* Allow zend_extension registration for low level function ([#678](https://github.com/extphprs/ext-php-rs/pull/678)) (by @ptondereau) [[#678](https://github.com/extphprs/ext-php-rs/issues/678)] 

### Fixed
- Address clippy 1.95.0 lint errors ([#728](https://github.com/extphprs/ext-php-rs/pull/728)) (by @ptondereau) [[#728](https://github.com/extphprs/ext-php-rs/issues/728)] 

### Other
- Cache property lookups across repeated accesses ([#726](https://github.com/extphprs/ext-php-rs/pull/726)) (by @ptondereau) [[#726](https://github.com/extphprs/ext-php-rs/issues/726)] 
- Pre-compute mangled property names in get_properties ([#724](https://github.com/extphprs/ext-php-rs/pull/724)) (by @ptondereau) [[#724](https://github.com/extphprs/ext-php-rs/issues/724)]
</blockquote>

## `cargo-php`

<blockquote>

## [0.1.21](https://github.com/extphprs/ext-php-rs/compare/cargo-php-v0.1.20...cargo-php-v0.1.21) - 2026-04-20

### Fixed
- Address clippy 1.95.0 lint errors ([#728](https://github.com/extphprs/ext-php-rs/pull/728)) (by @ptondereau) [[#728](https://github.com/extphprs/ext-php-rs/issues/728)]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).