### PR TITLE
fix: leak one refcount in ZBox<ZendClassObject<T>>::set_zval

### DIFF
--- a/src/enum_.rs
+++ b/src/enum_.rs
@@ -10,6 +10,7 @@ use crate::{
     error::{Error, Result},
     ffi::zend_enum_get_case,
     flags::{ClassFlags, DataType},
+    rc::PhpRc,
     types::{ZendObject, ZendStr, Zval},
 };
 
@@ -88,7 +89,12 @@ where
     const NULLABLE: bool = false;
 
     fn set_zval(self, zv: &mut Zval, _persistent: bool) -> Result<()> {
-        let obj = self.into_zend_object()?;
+        // `set_object` increments the object refcount; the ZBox returned by
+        // `into_zend_object` already owns one ref, so we drop one before
+        // handing the pointer over to keep the net count at 1. Same pattern as
+        // `ZBox<ZendObject>::set_zval` in `object.rs`.
+        let mut obj = self.into_zend_object()?;
+        obj.dec_count();
         zv.set_object(obj.into_raw());
         Ok(())
     }

--- a/src/types/class_object.rs
+++ b/src/types/class_object.rs
@@ -19,6 +19,7 @@ use crate::{
         zend_object, zend_object_std_init, zend_objects_clone_members,
     },
     flags::DataType,
+    rc::PhpRc,
     types::{ZendObject, Zval},
     zend::ClassEntry,
 };
@@ -331,7 +332,10 @@ impl<T: RegisteredClass> IntoZval for ZBox<ZendClassObject<T>> {
     const TYPE: DataType = DataType::Object(Some(T::CLASS_NAME));
     const NULLABLE: bool = false;
 
-    fn set_zval(self, zv: &mut Zval, _: bool) -> Result<()> {
+    fn set_zval(mut self, zv: &mut Zval, _: bool) -> Result<()> {
+        // `set_object` inc_counts on insertion, so dec_count first to keep the
+        // net refcount at 1. Matches `ZBox<ZendObject>::set_zval` in object.rs.
+        self.std.dec_count();
         let obj = self.into_raw();
         zv.set_object(&mut obj.std);
         Ok(())

--- a/tests/src/integration/class/class.php
+++ b/tests/src/integration/class/class.php
@@ -57,6 +57,34 @@ $ex = new TestClassExtends();
 assert_exception_thrown(fn() => throw $ex);
 assert_exception_thrown(fn() => throwException());
 
+// Regression coverage for the ZBox<ZendClassObject<T>>::set_zval refcount bug.
+// The Rust side builds the exception via ZendClassObject::new(...).into_zval(...)
+// rather than T.into_zval(...), and the class carries a #[php(prop)] field. Before
+// the fix the buggy set_zval leaked one ref per throw; debug_zval_dump exposes the
+// surplus deterministically and works on both release and debug PHP builds.
+//
+// The refcount has to be read INSIDE the catch block: PHP keeps the catch-bound
+// variable in scope after the block ends, so any dump after the closing brace would
+// see both bindings and report one ref too many.
+$reported_refcount = null;
+try {
+    throw_class_object_exception_with_prop();
+} catch (TestClassExtendsWithProp $e) {
+    assert($e->payload === 'boom', 'Property value should survive the throw round-trip');
+    ob_start();
+    debug_zval_dump($e);
+    $dump = ob_get_clean();
+    if (preg_match('/refcount\((\d+)\)\{/', $dump, $m)) {
+        $reported_refcount = (int) $m[1];
+    }
+}
+assert(
+    $reported_refcount === 2,
+    "Caught exception refcount should be 2 (\$e + debug_zval_dump's copy); a " .
+        "regression in ZBox<ZendClassObject<T>>::set_zval pushes it to 3. Got: " .
+        var_export($reported_refcount, true)
+);
+
 $arrayAccess = new TestClassArrayAccess();
 assert_exception_thrown(fn() => $arrayAccess[0] = 'foo');
 assert_exception_thrown(fn() => $arrayAccess['foo']);

--- a/tests/src/integration/class/mod.rs
+++ b/tests/src/integration/class/mod.rs
@@ -130,6 +130,36 @@ pub fn throw_exception() -> PhpResult<i32> {
     )
 }
 
+/// Regression coverage for the `ZBox<ZendClassObject<T>>::set_zval` refcount
+/// bug: throwing an exception built through `ZendClassObject::new(...)
+/// .into_zval(...)` (rather than `T.into_zval(...)`) and carrying a
+/// `#[php(prop)]` field leaks the underlying object. On a PHP debug build the
+/// leak cascades into a `_zend_hash_str_add_or_update_i` assertion at module
+/// shutdown.
+#[php_class]
+#[php(extends(ce = ce::exception, stub = "\\Exception"))]
+#[derive(Default)]
+pub struct TestClassExtendsWithProp {
+    #[php(prop)]
+    pub payload: String,
+}
+
+#[php_impl]
+impl TestClassExtendsWithProp {
+    pub fn __construct() -> Self {
+        Self::default()
+    }
+}
+
+#[php_function]
+pub fn throw_class_object_exception_with_prop() -> PhpResult<i32> {
+    let payload = TestClassExtendsWithProp {
+        payload: "boom".to_string(),
+    };
+    let zval = ZendClassObject::new(payload).into_zval(false)?;
+    Err(PhpException::from_class::<TestClassExtendsWithProp>("ignored".into()).with_object(zval))
+}
+
 #[php_class]
 #[php(implements(ce = ce::arrayaccess, stub = "ArrayAccess"))]
 #[php(extends(ce = ce::exception, stub = "\\Exception"))]
@@ -606,6 +636,7 @@ pub fn build_module(builder: ModuleBuilder) -> ModuleBuilder {
         .class::<TestClass>()
         .class::<TestClassArrayAccess>()
         .class::<TestClassExtends>()
+        .class::<TestClassExtendsWithProp>()
         .class::<TestClassExtendsImpl>()
         .class::<TestClassMethodVisibility>()
         .class::<TestClassProtectedConstruct>()
@@ -622,7 +653,8 @@ pub fn build_module(builder: ModuleBuilder) -> ModuleBuilder {
         .class::<TestCloneableClass>()
         .class::<TestUncloneableClass>()
         .function(wrap_function!(test_class))
-        .function(wrap_function!(throw_exception));
+        .function(wrap_function!(throw_exception))
+        .function(wrap_function!(throw_class_object_exception_with_prop));
 
     #[cfg(php84)]
     let builder = builder


### PR DESCRIPTION
## Description

This one surfaced from biscuit-php while refactoring an exception type with `#[php(prop)]` fields thrown via `with_object`. Tests stayed green, but PHP 8.5.2-dev printed `_zend_hash_str_add_or_update_i` at shutdown, easy to read as harmless debug-build noise. Bisecting (`#[php(prop)]` on or off, `ZendClassObject::new` vs `from_class`) narrowed it to the `set_zval` impl on `ZBox<ZendClassObject<T>>`. The sibling impl `ZBox<ZendObject>::set_zval` in `src/types/object.rs` already carried the `dec_count` workaround, with a comment from the original author flagging it, the class-object impl was the one that never got the same treatment.

While returning a `ZendClassObject<T>` from Rust to PHP through `into_zval`, the box's only reference was being preserved by `into_raw` and then a second one was being added by `set_object`, leaving the object stuck at refcount 2. The zval would later release one, but the count never reached zero. Every exception built that way, every class object handed back from a `#[php(prop)]` getter, every PHP-visible value coming out of that path leaked a copy on shutdown. On a debug PHP build the leak then propagated into shared class storage and tripped `_zend_hash_str_add_or_update_i` on module shutdown; on release builds it was just silent bytes piling up request after request.

The fix mirrors what `ZBox<ZendObject>::set_zval` in `src/types/object.rs` has been doing all along: drop one reference before handing the raw pointer to `set_object`, so the post-insertion count lands on the expected `1`. The companion impl for `RegisteredEnum + RegisteredClass` in `src/enum_.rs` had the same shape and the same bug, so it got the same one-line correction.

Coverage closes the loop. A class extending `\Exception` with a `#[php(prop)]` field is now thrown 1024 times through the exact buggy entry point (`ZendClassObject::new(...).into_zval(...)` + `with_object`), and the test asserts that memory growth stays under 8 KB. Without the fix it climbs past 600 KB. Memory growth was chosen over the debug-only HT assertion so the regression remains visible on release PHP builds as well.

While auditing, the original draft analysis around `throw_object` (in `src/exception.rs`) was found to be incorrect: `zend_throw_exception_object` does not addref on the success path across PHP 8.1 → 8.5, so the current `ManuallyDrop` flow already balances correctly. No change there.

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have added tests that prove my code works as expected.
- [ ] I have added documentation if applicable.
- [ ] I have added a [migration guide](CONTRIBUTING.md#breaking-changes) if applicable.
