### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## [0.15.14](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.13...ext-php-rs-v0.15.14) - 2026-05-23
+
+### Fixed
+- *(bindgen)* Bump ext-php-rs-bindgen to drop the clang-sys fork ([#741](https://github.com/extphprs/ext-php-rs/pull/741)) (by @ptondereau) [[#741](https://github.com/extphprs/ext-php-rs/issues/741)] [[#740](https://github.com/extphprs/ext-php-rs/issues/740)] 
 ## [0.15.13](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.12...ext-php-rs-v0.15.13) - 2026-05-11
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.15.13"
+version = "0.15.14"
 authors = [
     "Pierre Tondereau <pierre.tondereau@protonmail.com>",
     "Xenira <xenira@php.rs>",
@@ -25,7 +25,7 @@ anyhow = { version = "1", optional = true }
 smartstring = { version = "1", optional = true }
 indexmap = { version = "2", optional = true }
 inventory = "0.3"
-ext-php-rs-derive = { version = "=0.11.12", path = "./crates/macros" }
+ext-php-rs-derive = { version = "=0.11.13", path = "./crates/macros" }
 
 [dev-dependencies]
 skeptic = "0.13"

--- a/crates/macros/CHANGELOG.md
+++ b/crates/macros/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.11.13](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.12...ext-php-rs-derive-v0.11.13) - 2026-05-23
+
+### Other
+- *(prop)* Document the Exception::getMessage refcount leak ([#737](https://github.com/extphprs/ext-php-rs/pull/737)) (by @ptondereau) [[#737](https://github.com/extphprs/ext-php-rs/issues/737)] 
 ## [0.11.12](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.11...ext-php-rs-derive-v0.11.12) - 2026-04-20
 
 ### Other

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -4,7 +4,7 @@ description = "Derive macros for ext-php-rs."
 repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
-version = "0.11.12"
+version = "0.11.13"
 authors = [
     "Xenira <xenira@php.rs>",
     "David Cole <david.cole1340@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `ext-php-rs-derive`: 0.11.12 -> 0.11.13
* `ext-php-rs`: 0.15.13 -> 0.15.14 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `ext-php-rs-derive`

<blockquote>

## [0.11.13](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.12...ext-php-rs-derive-v0.11.13) - 2026-05-23

### Other
- *(prop)* Document the Exception::getMessage refcount leak ([#737](https://github.com/extphprs/ext-php-rs/pull/737)) (by @ptondereau) [[#737](https://github.com/extphprs/ext-php-rs/issues/737)]
</blockquote>

## `ext-php-rs`

<blockquote>

## [0.15.14](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.13...ext-php-rs-v0.15.14) - 2026-05-23

### Fixed
- *(bindgen)* Bump ext-php-rs-bindgen to drop the clang-sys fork ([#741](https://github.com/extphprs/ext-php-rs/pull/741)) (by @ptondereau) [[#741](https://github.com/extphprs/ext-php-rs/issues/741)] [[#740](https://github.com/extphprs/ext-php-rs/issues/740)]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).