### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## [0.15.15](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.14...ext-php-rs-v0.15.15) - 2026-06-02
+
+### Added
+- Support using ZendStr as ZendHashTable keys ([#743](https://github.com/extphprs/ext-php-rs/pull/743)) (by @hwawshy) [[#743](https://github.com/extphprs/ext-php-rs/issues/743)] 
+
+### Other
+- Add mago for PHP formatting and linting ([#745](https://github.com/extphprs/ext-php-rs/pull/745)) (by @ptondereau) [[#745](https://github.com/extphprs/ext-php-rs/issues/745)] 
 ## [0.15.14](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.13...ext-php-rs-v0.15.14) - 2026-05-23
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
 keywords = ["php", "ffi", "zend"]
-version = "0.15.14"
+version = "0.15.15"
 authors = [
     "Pierre Tondereau <pierre.tondereau@protonmail.com>",
     "Xenira <xenira@php.rs>",
@@ -25,7 +25,7 @@ anyhow = { version = "1", optional = true }
 smartstring = { version = "1", optional = true }
 indexmap = { version = "2", optional = true }
 inventory = "0.3"
-ext-php-rs-derive = { version = "=0.11.13", path = "./crates/macros" }
+ext-php-rs-derive = { version = "=0.11.14", path = "./crates/macros" }
 
 [dev-dependencies]
 skeptic = "0.13"

--- a/crates/macros/CHANGELOG.md
+++ b/crates/macros/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.11.14](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.13...ext-php-rs-derive-v0.11.14) - 2026-06-02
+
+### Added
+- Support using ZendStr as ZendHashTable keys ([#743](https://github.com/extphprs/ext-php-rs/pull/743)) (by @hwawshy) [[#743](https://github.com/extphprs/ext-php-rs/issues/743)] 
 ## [0.11.13](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.12...ext-php-rs-derive-v0.11.13) - 2026-05-23
 
 ### Other

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -4,7 +4,7 @@ description = "Derive macros for ext-php-rs."
 repository = "https://github.com/extphprs/ext-php-rs"
 homepage = "https://ext-php.rs"
 license = "MIT OR Apache-2.0"
-version = "0.11.13"
+version = "0.11.14"
 authors = [
     "Xenira <xenira@php.rs>",
     "David Cole <david.cole1340@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `ext-php-rs-derive`: 0.11.13 -> 0.11.14
* `ext-php-rs`: 0.15.14 -> 0.15.15 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `ext-php-rs-derive`

<blockquote>

## [0.11.14](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-derive-v0.11.13...ext-php-rs-derive-v0.11.14) - 2026-06-02

### Added
- Support using ZendStr as ZendHashTable keys ([#743](https://github.com/extphprs/ext-php-rs/pull/743)) (by @hwawshy) [[#743](https://github.com/extphprs/ext-php-rs/issues/743)]
</blockquote>

## `ext-php-rs`

<blockquote>

## [0.15.15](https://github.com/extphprs/ext-php-rs/compare/ext-php-rs-v0.15.14...ext-php-rs-v0.15.15) - 2026-06-02

### Added
- Support using ZendStr as ZendHashTable keys ([#743](https://github.com/extphprs/ext-php-rs/pull/743)) (by @hwawshy) [[#743](https://github.com/extphprs/ext-php-rs/issues/743)] 

### Other
- Add mago for PHP formatting and linting ([#745](https://github.com/extphprs/ext-php-rs/pull/745)) (by @ptondereau) [[#745](https://github.com/extphprs/ext-php-rs/issues/745)]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).