### PR TITLE
build: add mago for PHP formatting and linting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,14 @@ jobs:
           fetch-depth: 0
       - name: Check typos
         uses: crate-ci/typos@master
+      - name: Setup Mago
+        uses: nhedger/setup-mago@v1
+        with:
+          version: 1.29.0
+      - name: Check PHP formatting
+        run: mago format --check
+      - name: Lint PHP
+        run: mago lint --reporting-format=github --minimum-fail-level=warning
       - name: Validate commit messages
         run: |
           git show-ref

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -22,3 +22,7 @@ pre-commit:
         - "guide/src/macros/*.md"
         - "crates/macros/src/lib.rs"
       stage_fixed: true
+    - name: mago
+      run: mago format {staged_files} && mago lint --fix {staged_files}
+      glob: "*.php"
+      stage_fixed: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,31 @@ lefthook install
 - When updating the macro guides (`guide/src/macros`), you need to have the `nightly` toolchain installed. This is required
   to have the proper formatting in the documentation.
 
+## Code Style
+
+Rust code is formatted with `rustfmt` and linted with `clippy`, both run by the git hooks above.
+
+The repository's PHP files (integration-test fixtures, benchmarks, and embed scripts) are formatted and
+linted with [mago](https://mago.carthage.software). The nix dev shell provides the pinned version, so
+`nix develop` gives you a ready-to-use `mago` with no extra setup. If you do not use nix, install the same
+version from the [mago installation guide](https://mago.carthage.software). The `lefthook` pre-commit hook
+formats and applies safe lint fixes to any staged `*.php` file, and CI runs the same checks.
+
+To run them manually:
+
+```bash
+mago format         # format every PHP file
+mago format --check # verify formatting without writing (what CI runs)
+mago lint           # lint every PHP file
+mago lint --fix     # apply safe lint fixes
+```
+
+The configuration lives in `mago.toml`. Several lint rules are disabled there because these PHP files are
+fixtures for a PHP extension, not application code: they deliberately use patterns an application linter
+would reject (for example calling `debug_zval_dump` for refcount testing, passing literal arguments
+positionally, or omitting `declare(strict_types=1)` to keep weak-mode coercion behaviour). Each disabled
+rule is annotated with the reason it does not apply.
+
 ## Testing
 
 We have both unit and integration tests. When contributing, please ensure that your changes are at least

--- a/benches/benches/array_interned_keys.php
+++ b/benches/benches/array_interned_keys.php
@@ -1,5 +1,5 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 $a = bench_array_with_interned_keys((int) $argv[1]);

--- a/benches/benches/array_str_ref_keys.php
+++ b/benches/benches/array_str_ref_keys.php
@@ -1,5 +1,5 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 $a = bench_array_with_str_ref_keys((int) $argv[1]);

--- a/benches/benches/callback_call.php
+++ b/benches/benches/callback_call.php
@@ -1,5 +1,5 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-bench_callback_function(fn ($i) => $i * 2, (int) $argv[1]);
+bench_callback_function(fn($i) => $i * 2, (int) $argv[1]);

--- a/benches/benches/function_call.php
+++ b/benches/benches/function_call.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 foreach (range(1, $argv[1]) as $i) {
     bench_function($i);

--- a/benches/benches/method_call.php
+++ b/benches/benches/method_call.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 $obj = new BenchClass();
 

--- a/benches/benches/property_dump.php
+++ b/benches/benches/property_dump.php
@@ -1,8 +1,8 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-$obj = new BenchProps(42, "hello");
+$obj = new BenchProps(42, 'hello');
 
 foreach (range(1, $argv[1]) as $i) {
     ob_start();

--- a/benches/benches/property_read.php
+++ b/benches/benches/property_read.php
@@ -1,8 +1,8 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-$obj = new BenchProps(42, "hello");
+$obj = new BenchProps(42, 'hello');
 
 foreach (range(1, $argv[1]) as $i) {
     $_ = $obj->fieldA;

--- a/benches/benches/property_write.php
+++ b/benches/benches/property_write.php
@@ -1,12 +1,12 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-$obj = new BenchProps(0, "");
+$obj = new BenchProps(0, '');
 
 foreach (range(1, $argv[1]) as $i) {
     $obj->fieldA = $i;
     $obj->fieldB = "value_{$i}";
-    $obj->fieldC = ($i % 2 === 0);
+    $obj->fieldC = ( $i % 2 ) === 0;
     $obj->computed = $i * 2;
 }

--- a/benches/benches/static_method_call.php
+++ b/benches/benches/static_method_call.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 foreach (range(1, $argv[1]) as $i) {
     BenchClass::staticMethod($i);

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,21 @@
       php-dev = php.unwrapped.dev;
       php-zts = (pkgs.php.override { ztsSupport = true; }).buildEnv { embedSupport = true; };
       php-zts-dev = php-zts.unwrapped.dev;
+      # mago is not packaged in nixpkgs; pin the upstream static musl binary so
+      # local dev and CI (nhedger/setup-mago) run the exact same version.
+      mago = pkgs.stdenvNoCC.mkDerivation rec {
+        pname = "mago";
+        version = "1.29.0";
+        src = pkgs.fetchurl {
+          url = "https://github.com/carthage-software/mago/releases/download/${version}/mago-${version}-x86_64-unknown-linux-musl.tar.gz";
+          hash = "sha256-XpnRIy+pPmrcb+qt2vK0bBSLKZAXPNzxhAC0dGRr8EY=";
+        };
+        installPhase = ''
+          runHook preInstall
+          install -Dm755 mago "$out/bin/mago"
+          runHook postInstall
+        '';
+      };
       mkShellFor = phpPkg: phpDevPkg: pkgs.mkShell {
         buildInputs = with pkgs; [
           phpPkg
@@ -28,6 +43,7 @@
           libclang.lib
           clang
           valgrind
+          mago
         ];
 
         nativeBuildInputs = [ pkgs.rust-bin.stable.latest.default ];

--- a/mago.toml
+++ b/mago.toml
@@ -1,0 +1,32 @@
+# mago — PHP formatter + linter for this repo's PHP files.
+# https://mago.carthage.software
+#
+# Scope: the PHP files here are test fixtures, benchmarks, and embed scripts for
+# a PHP *extension* written in Rust. They are not application code. `analyze`
+# (type checking) and `guard` (architecture) are intentionally not used: the
+# fixtures call extension-registered symbols that only exist at PHP runtime.
+
+php-version = "8.1" # support floor; also flags 8.2+ syntax that would not run on the oldest supported PHP
+
+[source]
+paths = ["tests", "benches", "src"] # mago only processes *.php; this captures every PHP file plus any added later
+extensions = ["php"]
+
+[formatter]
+preset = "psr-12"
+
+# Every rule below is disabled because it conflicts with the deliberate shape of
+# the fixtures, not for convenience. Keep this list honest: if a disable is no
+# longer justified by fixture intent, re-enable it.
+[linter.rules]
+literal-named-argument = { enabled = false }    # fixtures pass literals positionally to assert()/test fns by design
+assert-description = { enabled = false }         # bare assert() is the fixture idiom
+strict-types = { enabled = false }               # declare(strict_types=1) would change coercion across behavior-sensitive fixtures
+strict-behavior = { enabled = false }            # forcing in_array() strict comparison can change what is asserted
+no-debug-symbols = { enabled = false }           # debug_zval_dump is a documented refcount-testing tool (see CONTEXT.md)
+no-empty-catch-clause = { enabled = false }      # empty catch blocks are intentional in exception-throwing tests
+file-name = { enabled = false }                  # fixtures are named by what they test, not by their class name
+no-isset = { enabled = false }                   # isset is the subject under test (e.g. the __isset magic method)
+single-class-per-file = { enabled = false }      # fixtures define several test classes in one file
+no-error-control-operator = { enabled = false }  # the @ operator is intentional in the error-observer test
+no-shorthand-ternary = { enabled = false }       # getenv(...) ?: 'default' is the deliberate runtime env-or-default pattern (a full ternary would double-evaluate getenv())

--- a/src/embed/test-script.php
+++ b/src/embed/test-script.php
@@ -1,7 +1,10 @@
 <?php
 
-class Test {
-    public function __construct() {}
+class Test
+{
+    public function __construct()
+    {
+    }
 }
 
 $foo = new Test();

--- a/src/types/iterator.test.php
+++ b/src/types/iterator.test.php
@@ -1,13 +1,15 @@
 <?php
 
-function create_generator() {
+function create_generator()
+{
     yield 1;
     yield 2;
     yield 3;
     yield new class {} => new class {};
 }
 
-class TestIterator implements \Iterator {
+class TestIterator implements \Iterator
+{
     private $count = 0;
 
     public function current(): mixed
@@ -17,7 +19,7 @@ class TestIterator implements \Iterator {
             1 => 'bar',
             2 => 'baz',
             3 => new class {},
-            default => null,
+            default => null
         };
     }
 
@@ -33,7 +35,7 @@ class TestIterator implements \Iterator {
             1 => 10,
             2 => 2,
             3 => new class {},
-            default => null,
+            default => null
         };
     }
 

--- a/tests/src/integration/_utils.php
+++ b/tests/src/integration/_utils.php
@@ -7,5 +7,5 @@ function assert_exception_thrown(callable $callback): void
     } catch (\Throwable $th) {
         return;
     }
-    throw new Exception("Exception was not thrown", 255);
+    throw new Exception('Exception was not thrown', 255);
 }

--- a/tests/src/integration/array/array.php
+++ b/tests/src/integration/array/array.php
@@ -25,50 +25,58 @@ assert(in_array('2', $assoc));
 assert(in_array('3', $assoc));
 
 $arrayKeys = test_array_keys();
-assert($arrayKeys[-42] === "foo");
-assert($arrayKeys[0] === "bar");
-assert($arrayKeys[5] === "baz");
-assert($arrayKeys[10] === "qux");
-assert($arrayKeys["10"] === "qux");
-assert($arrayKeys["quux"] === "quuux");
+assert($arrayKeys[-42] === 'foo');
+assert($arrayKeys[0] === 'bar');
+assert($arrayKeys[5] === 'baz');
+assert($arrayKeys[10] === 'qux');
+assert($arrayKeys['10'] === 'qux');
+assert($arrayKeys['quux'] === 'quuux');
 
 $assoc_keys = test_array_assoc_array_keys([
     'a' => '1',
     2 => '2',
-    '3' => '3',
+    '3' => '3'
 ]);
-assert($assoc_keys === [
-    'a' => '1',
-    2 => '2',
-    '3' => '3',
-]);
+assert(
+    $assoc_keys === [
+        'a' => '1',
+        2 => '2',
+        '3' => '3'
+    ]
+);
 $assoc_keys = test_btree_map([
     'a' => '1',
     2 => '2',
-    '3' => '3',
+    '3' => '3'
 ]);
-assert($assoc_keys === [
-    2 => '2',
-    '3' => '3',
-    'a' => '1',
-]);
+assert(
+    $assoc_keys === [
+        2 => '2',
+        '3' => '3',
+        'a' => '1'
+    ]
+);
 
 $assoc_keys = test_array_assoc_array_keys(['foo', 'bar', 'baz']);
-assert($assoc_keys === [
-    0 => 'foo',
-    1 => 'bar',
-    2 => 'baz',
-]);
-assert(test_btree_map(['foo', 'bar', 'baz']) === [
-    0 => 'foo',
-    1 => 'bar',
-    2 => 'baz',
-]);
+assert(
+    $assoc_keys === [
+        0 => 'foo',
+        1 => 'bar',
+        2 => 'baz'
+    ]
+);
+assert(
+    test_btree_map(['foo', 'bar', 'baz']) === [
+        0 => 'foo',
+        1 => 'bar',
+        2 => 'baz'
+    ]
+);
 
 $leading_zeros = test_array_assoc_array_keys([
-  '0' => 'zero',
-  '00' => 'zerozero',
-  '007' => 'bond',
+    '0' => 'zero',
+    '00' => 'zerozero',
+    '007' => 'bond'
 ]);
 
 assert(array_key_exists(0, $leading_zeros), '"0" should become integer key 0');
@@ -89,7 +97,10 @@ assert(test_optional_array_ref($arr) === 4, 'Option<&ZendHashTable> should accep
 
 // Test Option<&mut ZendHashTable> (anti-regression for issue #515)
 $mut_arr = ['x', 'y'];
-assert(test_optional_array_mut_ref($mut_arr) === 3, 'Option<&mut ZendHashTable> should accept variable array and add element');
+assert(
+    test_optional_array_mut_ref($mut_arr) === 3,
+    'Option<&mut ZendHashTable> should accept variable array and add element'
+);
 assert(array_key_exists('added_by_rust', $mut_arr), 'Rust should have added a key to the array');
 assert($mut_arr['added_by_rust'] === 'value', 'Added value should be correct');
 $null_arr = null;

--- a/tests/src/integration/bailout/bailout_control.php
+++ b/tests/src/integration/bailout/bailout_control.php
@@ -1,4 +1,5 @@
 <?php
+
 // Control test - verify destructors work without bailout
 
 bailout_test_reset();
@@ -8,4 +9,4 @@ bailout_test_without_exit();
 
 // The destructors should have been called
 $counter = bailout_test_get_counter();
-assert($counter === 2, "Expected 2 destructors to be called, got $counter");
+assert($counter === 2, "Expected 2 destructors to be called, got {$counter}");

--- a/tests/src/integration/bailout/bailout_deep_nested.php
+++ b/tests/src/integration/bailout/bailout_deep_nested.php
@@ -1,4 +1,5 @@
 <?php
+
 // Test deeply nested BailoutGuard cleanup - 3 levels of nesting
 
 bailout_test_reset();
@@ -9,10 +10,10 @@ bailout_test_reset();
 // - Level 3 (nested closure): 1 guard
 // Then triggers exit() at the deepest level.
 // All 3 guards should be cleaned up.
-bailout_test_deep_nested(function() {
+bailout_test_deep_nested(function () {
     exit(0);
 });
 
 // After the function returns, check that all 3 destructors were called
 $counter = bailout_test_get_counter();
-assert($counter === 3, "Expected 3 destructors for deep nested test, got $counter");
+assert($counter === 3, "Expected 3 destructors for deep nested test, got {$counter}");

--- a/tests/src/integration/bailout/bailout_exit.php
+++ b/tests/src/integration/bailout/bailout_exit.php
@@ -1,4 +1,5 @@
 <?php
+
 // Test that Rust destructors are called when bailout occurs (issue #537)
 
 bailout_test_reset();
@@ -7,10 +8,10 @@ bailout_test_reset();
 // The callback triggers exit(), which causes a bailout.
 // Thanks to the try_catch wrapper, the Rust destructors should run
 // when the function returns, incrementing the counter to 3.
-bailout_test_with_callback(function() {
+bailout_test_with_callback(function () {
     exit(0);
 });
 
 // After the function returns, check that all 3 destructors were called
 $counter = bailout_test_get_counter();
-assert($counter === 3, "Expected 3 destructors to be called after bailout, got $counter");
+assert($counter === 3, "Expected 3 destructors to be called after bailout, got {$counter}");

--- a/tests/src/integration/bailout/bailout_guard.php
+++ b/tests/src/integration/bailout/bailout_guard.php
@@ -1,4 +1,5 @@
 <?php
+
 // Test BailoutGuard - ensures values wrapped in BailoutGuard are cleaned up on bailout
 
 bailout_test_reset();
@@ -6,10 +7,10 @@ bailout_test_reset();
 // This function creates 2 guarded trackers and 1 unguarded tracker,
 // then calls a callback that triggers exit().
 // All 3 should be cleaned up (guarded ones via BailoutGuard, unguarded via try_call).
-bailout_test_with_guard(function() {
+bailout_test_with_guard(function () {
     exit(0);
 });
 
 // After the function returns, check that all 3 destructors were called
 $counter = bailout_test_get_counter();
-assert($counter === 3, "Expected 3 destructors to be called with BailoutGuard, got $counter");
+assert($counter === 3, "Expected 3 destructors to be called with BailoutGuard, got {$counter}");

--- a/tests/src/integration/bailout/bailout_nested.php
+++ b/tests/src/integration/bailout/bailout_nested.php
@@ -1,4 +1,5 @@
 <?php
+
 // Test nested BailoutGuard cleanup - guards at multiple call stack levels
 
 bailout_test_reset();
@@ -6,11 +7,11 @@ bailout_test_reset();
 // This function creates 2 outer guards (id 1, 2) and calls an inner function
 // that creates 2 inner guards (id 10, 11), then triggers exit().
 // All 4 guards should be cleaned up.
-bailout_test_nested(function() {
+bailout_test_nested(function () {
     exit(0);
 });
 
 // After the function returns, check that all 4 destructors were called
 // (2 outer + 2 inner = 4 total, contributing 1+2+10+11 = 24 to counter)
 $counter = bailout_test_get_counter();
-assert($counter === 4, "Expected 4 destructors for nested test, got $counter");
+assert($counter === 4, "Expected 4 destructors for nested test, got {$counter}");

--- a/tests/src/integration/callable/callable.php
+++ b/tests/src/integration/callable/callable.php
@@ -1,32 +1,41 @@
 <?php
 
 // Basic callable test
-assert(test_callable(fn (string $a) => $a, 'test') === 'test');
+assert(test_callable(fn(string $a) => $a, 'test') === 'test');
 
 // Named arguments test - order should not matter, args matched by name
-$namedResult = test_callable_named(fn (string $a, string $b) => "$a-$b");
-assert($namedResult === 'first-second', "Named args failed: expected 'first-second', got '$namedResult'");
+$namedResult = test_callable_named(fn(string $a, string $b) => "{$a}-{$b}");
+assert($namedResult === 'first-second', "Named args failed: expected 'first-second', got '{$namedResult}'");
 
 // Mixed positional + named arguments test
-$mixedResult = test_callable_mixed(fn (string $pos, string $named) => "$pos|$named");
-assert($mixedResult === 'positional|named_value', "Mixed args failed: expected 'positional|named_value', got '$mixedResult'");
+$mixedResult = test_callable_mixed(fn(string $pos, string $named) => "{$pos}|{$named}");
+assert(
+    $mixedResult === 'positional|named_value',
+    "Mixed args failed: expected 'positional|named_value', got '{$mixedResult}'"
+);
 
 // Macro test with named arguments only
-$macroNamedResult = test_callable_macro_named(fn (string $x, string $y) => "$x $y");
-assert($macroNamedResult === 'hello world', "Macro named args failed: expected 'hello world', got '$macroNamedResult'");
+$macroNamedResult = test_callable_macro_named(fn(string $x, string $y) => "{$x} {$y}");
+assert(
+    $macroNamedResult === 'hello world',
+    "Macro named args failed: expected 'hello world', got '{$macroNamedResult}'"
+);
 
 // Macro test with positional + named arguments
-$macroMixedResult = test_callable_macro_mixed(fn (string $first, string $second) => "$first,$second");
-assert($macroMixedResult === 'first,second_val', "Macro mixed args failed: expected 'first,second_val', got '$macroMixedResult'");
+$macroMixedResult = test_callable_macro_mixed(fn(string $first, string $second) => "{$first},{$second}");
+assert(
+    $macroMixedResult === 'first,second_val',
+    "Macro mixed args failed: expected 'first,second_val', got '{$macroMixedResult}'"
+);
 
 // Empty named params (should behave like try_call)
-$emptyNamedResult = test_callable_empty_named(fn (string $a) => "got:$a");
-assert($emptyNamedResult === 'got:hello', "Empty named args failed: expected 'got:hello', got '$emptyNamedResult'");
+$emptyNamedResult = test_callable_empty_named(fn(string $a) => "got:{$a}");
+assert($emptyNamedResult === 'got:hello', "Empty named args failed: expected 'got:hello', got '{$emptyNamedResult}'");
 
 // Built-in PHP function with named args (str_replace with args in non-standard order)
 $builtinResult = test_callable_builtin_named();
-assert($builtinResult === 'Hello PHP', "Builtin named args failed: expected 'Hello PHP', got '$builtinResult'");
+assert($builtinResult === 'Hello PHP', "Builtin named args failed: expected 'Hello PHP', got '{$builtinResult}'");
 
 // Duplicate named params - last value wins
-$dupResult = test_callable_duplicate_named(fn (string $a) => "val:$a");
-assert($dupResult === 'val:overwritten', "Duplicate named args failed: expected 'val:overwritten', got '$dupResult'");
+$dupResult = test_callable_duplicate_named(fn(string $a) => "val:{$a}");
+assert($dupResult === 'val:overwritten', "Duplicate named args failed: expected 'val:overwritten', got '{$dupResult}'");

--- a/tests/src/integration/class/class.php
+++ b/tests/src/integration/class/class.php
@@ -1,6 +1,6 @@
 <?php
 
-require(__DIR__ . '/../_utils.php');
+require __DIR__ . '/../_utils.php';
 
 // Tests constructor
 $class = test_class('lorem ipsum', 2022);
@@ -10,9 +10,9 @@ assert($class instanceof TestClass);
 assert($class->string === 'lorem ipsum');
 $class->string = 'dolor et';
 assert($class->string === 'dolor et');
-$class->selfRef("foo");
+$class->selfRef('foo');
 assert($class->string === 'Changed to foo');
-$class->selfMultiRef("bar");
+$class->selfMultiRef('bar');
 assert($class->string === 'Changed to bar');
 
 // Test method returning Self (new instance)
@@ -37,8 +37,14 @@ assert($class->booleanProp === false);
 $testClassReflection = new ReflectionClass(TestClass::class);
 $methodNames = array_map(fn($m) => $m->getName(), $testClassReflection->getMethods());
 $propertyNames = array_map(fn($p) => $p->getName(), $testClassReflection->getProperties());
-assert(!in_array('get_string', $methodNames) && !in_array('getString', $methodNames), 'Getter methods should NOT appear in reflection');
-assert(!in_array('set_string', $methodNames) && !in_array('setString', $methodNames), 'Setter methods should NOT appear in reflection');
+assert(
+    !in_array('get_string', $methodNames) && !in_array('getString', $methodNames),
+    'Getter methods should NOT appear in reflection'
+);
+assert(
+    !in_array('set_string', $methodNames) && !in_array('setString', $methodNames),
+    'Setter methods should NOT appear in reflection'
+);
 assert(in_array('string', $propertyNames), 'Property "string" from getter/setter SHOULD appear in reflection');
 assert(in_array('number', $propertyNames), 'Property "number" from getter/setter SHOULD appear in reflection');
 assert(in_array('booleanProp', $propertyNames), 'Property "booleanProp" from #[php(prop)] SHOULD appear in reflection');
@@ -80,9 +86,9 @@ try {
 }
 assert(
     $reported_refcount === 2,
-    "Caught exception refcount should be 2 (\$e + debug_zval_dump's copy); a " .
-        "regression in ZBox<ZendClassObject<T>>::set_zval pushes it to 3. Got: " .
-        var_export($reported_refcount, true)
+    "Caught exception refcount should be 2 (\$e + debug_zval_dump's copy); a "
+        . 'regression in ZBox<ZendClassObject<T>>::set_zval pushes it to 3. Got: '
+        . var_export($reported_refcount, true)
 );
 
 $arrayAccess = new TestClassArrayAccess();
@@ -164,7 +170,7 @@ $selfRef = $builder2->getSelf();
 assert($selfRef === $builder2, 'getSelf should return $this');
 
 // Test readonly class (PHP 8.2+)
-if (PHP_VERSION_ID >= 80200) {
+if (PHP_VERSION_ID >= 80_200) {
     $readonlyObj = new TestReadonlyClass('hello', 42);
     assert($readonlyObj->getName() === 'hello', 'Readonly class getter should work');
     assert($readonlyObj->getValue() === 42, 'Readonly class getter should work');
@@ -205,10 +211,11 @@ assert_exception_thrown(fn() => $visibilityObj->protectedStr = 'test', 'Writing 
 // Casting to array exposes these mangled keys directly.
 $arr = (array) $visibilityObj;
 assert(array_key_exists('publicNum', $arr), 'Public property should appear unmangled');
-assert(array_key_exists("\0TestPropertyVisibility\0privateStr", $arr),
-    'Private property should appear with \0ClassName\0prop mangling');
-assert(array_key_exists("\0*\0protectedStr", $arr),
-    'Protected property should appear with \0*\0prop mangling');
+assert(
+    array_key_exists("\0TestPropertyVisibility\0privateStr", $arr),
+    'Private property should appear with \0ClassName\0prop mangling'
+);
+assert(array_key_exists("\0*\0protectedStr", $arr), 'Protected property should appear with \0*\0prop mangling');
 
 // Test reserved keyword method names
 $keywordObj = new TestReservedKeywordMethods();
@@ -261,25 +268,34 @@ assert($abstractReflection->isAbstract(), 'TestAbstractClass should be marked as
 
 // Verify abstract methods are marked as abstract in reflection
 assert($abstractReflection->getMethod('abstractMethod')->isAbstract(), 'abstractMethod should be marked as abstract');
-assert(!$abstractReflection->getMethod('concreteMethod')->isAbstract(), 'concreteMethod should NOT be marked as abstract');
+assert(
+    !$abstractReflection->getMethod('concreteMethod')->isAbstract(),
+    'concreteMethod should NOT be marked as abstract'
+);
 
 // Test extending the abstract class in PHP
-class ConcreteTestClass extends TestAbstractClass {
-    public function __construct() {
+class ConcreteTestClass extends TestAbstractClass
+{
+    public function __construct()
+    {
         parent::__construct();
     }
 
-    public function abstractMethod(): string {
+    public function abstractMethod(): string
+    {
         return 'implemented abstract method';
     }
 }
 
 $concreteObj = new ConcreteTestClass();
 assert($concreteObj->abstractMethod() === 'implemented abstract method', 'Implemented abstract method should work');
-assert($concreteObj->concreteMethod() === 'concrete method in abstract class', 'Concrete method from abstract class should work');
+assert(
+    $concreteObj->concreteMethod() === 'concrete method in abstract class',
+    'Concrete method from abstract class should work'
+);
 
 // Test lazy objects (PHP 8.4+)
-if (PHP_VERSION_ID >= 80400) {
+if (PHP_VERSION_ID >= 80_400) {
     // Test with a regular (non-lazy) Rust object first
     $regularObj = new TestLazyClass('regular');
     assert(test_is_lazy($regularObj) === false, 'Regular Rust object should not be lazy');
@@ -288,11 +304,13 @@ if (PHP_VERSION_ID >= 80400) {
     assert(test_is_lazy_initialized($regularObj) === false, 'Regular Rust object lazy_initialized should be false');
     // PHP 8.4 lazy objects only work with user-defined PHP classes, not internal classes.
     // Rust-defined classes are internal classes, so we test with a pure PHP class.
-    class PhpLazyTestClass {
+    class PhpLazyTestClass
+    {
         public string $data = '';
         public bool $initialized = false;
 
-        public function __construct(string $data) {
+        public function __construct(string $data)
+        {
             $this->data = $data;
             $this->initialized = true;
         }
@@ -357,7 +375,10 @@ assert($childObj->getBaseInfo() === 'I am the base class', 'Child should have ba
 
 // Verify inheritance through reflection
 $childReflection = new ReflectionClass(TestChildClass::class);
-assert($childReflection->getParentClass()->getName() === TestBaseClass::class, 'TestChildClass should extend TestBaseClass');
+assert(
+    $childReflection->getParentClass()->getName() === TestBaseClass::class,
+    'TestChildClass should extend TestBaseClass'
+);
 assert($childObj instanceof TestBaseClass, 'TestChildClass instance should be instanceof TestBaseClass');
 
 $original = new TestCloneableClass(42, 'original');
@@ -384,15 +405,15 @@ assert_exception_thrown(fn() => clone $uncloneable, 'Cloning uncloneable class s
 // hit the cache_slot fast path and return the same correct value.
 $cacheObj = test_class('cached', 999);
 for ($i = 0; $i < 1000; $i++) {
-    assert($cacheObj->string === 'cached', "Cached read failed at iteration $i");
-    assert($cacheObj->number === 999, "Cached read (number) failed at iteration $i");
+    assert($cacheObj->string === 'cached', "Cached read failed at iteration {$i}");
+    assert($cacheObj->number === 999, "Cached read (number) failed at iteration {$i}");
 }
 
 // Test cache_slot: write then read in the same loop iteration.
 // Validates the cache returns the updated descriptor (same descriptor, new value).
 for ($i = 0; $i < 100; $i++) {
     $cacheObj->number = $i;
-    assert($cacheObj->number === $i, "Write-then-read failed at iteration $i");
+    assert($cacheObj->number === $i, "Write-then-read failed at iteration {$i}");
 }
 
 // Test cache_slot: isset() followed by read on the same property.

--- a/tests/src/integration/class/prop_string_leak.php
+++ b/tests/src/integration/class/prop_string_leak.php
@@ -41,13 +41,14 @@ try {
 }
 assert(
     $first_call_returned === 'leak-bait message contents',
-    "Sanity check: one getMessage() call should return the stored message " .
-        "verbatim. Got: " . var_export($first_call_returned, true)
+    'Sanity check: one getMessage() call should return the stored message verbatim. Got: '
+        . var_export($first_call_returned, true)
 );
 assert(
     $leak_observed !== null && $leak_observed < 8192,
-    "getMessage() on a #[php(prop)] String field leaks zend_strings: 500 " .
-        "calls grew the emalloc heap by " . var_export($leak_observed, true) .
-        " bytes. Each call orphans one zend_string refcount (~150 bytes); " .
-        "with the fix this delta should be near zero."
+    'getMessage() on a #[php(prop)] String field leaks zend_strings: 500 '
+    . 'calls grew the emalloc heap by '
+    . var_export($leak_observed, true)
+    . ' bytes. Each call orphans one zend_string refcount (~150 bytes); '
+    . 'with the fix this delta should be near zero.'
 );

--- a/tests/src/integration/closure/closure.php
+++ b/tests/src/integration/closure/closure.php
@@ -1,6 +1,6 @@
 <?php
 
-require(__DIR__ . '/../_utils.php');
+require __DIR__ . '/../_utils.php';
 
 $v = test_closure();
 
@@ -13,10 +13,15 @@ $closure = test_closure_once('test');
 assert(call_user_func($closure) === 'test');
 assert_exception_thrown($closure);
 
-function take(\stdClass $rs): void { }
+function take(\stdClass $rs): void
+{
+}
 
 try {
     take($closure);
 } catch (\TypeError $e) {
-    assert(str_starts_with($e->getMessage(), 'take(): Argument #1 ($rs) must be of type stdClass, RustClosure given, called in '));
+    assert(str_starts_with(
+        $e->getMessage(),
+        'take(): Argument #1 ($rs) must be of type stdClass, RustClosure given, called in '
+    ));
 }

--- a/tests/src/integration/defaults/defaults.php
+++ b/tests/src/integration/defaults/defaults.php
@@ -22,6 +22,9 @@ assert($threw, 'Expected TypeError when passing null to non-nullable parameter w
 assert(test_defaults_nullable_string(null) === null);
 
 // Test nullable parameter with Some() default value
-assert(test_defaults_nullable_with_some_default() === 'fallback', 'Should return fallback when called without arguments');
+assert(
+    test_defaults_nullable_with_some_default() === 'fallback',
+    'Should return fallback when called without arguments'
+);
 assert(test_defaults_nullable_with_some_default(null) === null, 'Should return null when null is passed');
 assert(test_defaults_nullable_with_some_default('custom') === 'custom', 'Should return custom value when provided');

--- a/tests/src/integration/enum_/enum.php
+++ b/tests/src/integration/enum_/enum.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 $enum_variant = TestEnum::Variant1;
 assert($enum_variant === TestEnum::Variant1);

--- a/tests/src/integration/exception/exception.php
+++ b/tests/src/integration/exception/exception.php
@@ -1,6 +1,6 @@
 <?php
 
-require(__DIR__ . '/../_utils.php');
+require __DIR__ . '/../_utils.php';
 
 assert_exception_thrown(fn() => throw_default_exception(), \Exception::class);
 
@@ -9,5 +9,5 @@ try {
 } catch (\Throwable $e) {
     // Check if object is initiated
     assert($e instanceof \Test\TestException);
-    assert("Not good custom!" === $e->getMessage());
+    assert('Not good custom!' === $e->getMessage());
 }

--- a/tests/src/integration/globals/globals.php
+++ b/tests/src/integration/globals/globals.php
@@ -3,6 +3,6 @@
 assert(test_globals_http_get() === []);
 assert(test_globals_http_post() === []);
 assert(test_globals_http_cookie() === []);
-assert(!empty(test_globals_http_server()));
+assert(test_globals_http_server() !== []);
 assert(test_globals_http_request() === []);
 assert(test_globals_http_files() === []);

--- a/tests/src/integration/interface/interface.php
+++ b/tests/src/integration/interface/interface.php
@@ -1,34 +1,34 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 // Test existing functionality: Interface existence and explicit extends
 assert(interface_exists('ExtPhpRs\Interface\EmptyObjectInterface'), 'Interface not exist');
 assert(is_a('ExtPhpRs\Interface\EmptyObjectInterface', Throwable::class, true), 'Interface could extend Throwable');
 
-
 final class Test extends Exception implements ExtPhpRs\Interface\EmptyObjectInterface
 {
-	public static function void(): void
-	{
-	}
+    public static function void(): void
+    {
+    }
 
-	public function nonStatic(string $data): string
-	{
-		return sprintf('%s - TEST', $data);
-	}
+    public function nonStatic(string $data): string
+    {
+        return sprintf('%s - TEST', $data);
+    }
 
-	public function refToLikeThisClass(
-		string $data,
-		ExtPhpRs\Interface\EmptyObjectInterface $other,
-	): string {
-		return sprintf('%s | %s', $this->nonStatic($data), $other->nonStatic($data));
-	}
+    public function refToLikeThisClass(
+        string $data,
+        ExtPhpRs\Interface\EmptyObjectInterface $other
+    ): string {
+        return sprintf('%s | %s', $this->nonStatic($data), $other->nonStatic($data));
+    }
 
-    public function setValue(int $value = 0): void {
-
+    public function setValue(int $value = 0): void
+    {
     }
 }
+
 $f = new Test();
 
 assert(is_a($f, Throwable::class));
@@ -97,8 +97,10 @@ $mapCollected = [];
 foreach ($map as $key => $value) {
     $mapCollected[$key] = $value;
 }
-assert($mapCollected === ['first' => 'one', 'second' => 'two', 'third' => 'three'],
-    'MapIterator should iterate with string keys and values');
+assert(
+    $mapCollected === ['first' => 'one', 'second' => 'two', 'third' => 'three'],
+    'MapIterator should iterate with string keys and values'
+);
 
 // Test VecIterator - dynamic content iterator
 assert(class_exists('ExtPhpRs\Interface\VecIterator'), 'VecIterator class should exist');
@@ -148,18 +150,20 @@ assert(class_exists('ExtPhpRs\Interface\Greeter'), 'Greeter class should exist')
 $greeter = new ExtPhpRs\Interface\Greeter('World');
 
 // Test that Greeter implements ParentInterface via #[php_impl_interface]
-assert($greeter instanceof ExtPhpRs\Interface\ParentInterface,
-    'Greeter should implement ParentInterface via #[php_impl_interface]');
+assert(
+    $greeter instanceof ExtPhpRs\Interface\ParentInterface,
+    'Greeter should implement ParentInterface via #[php_impl_interface]'
+);
 
 // Test is_a() works for interface checking
-assert(is_a($greeter, 'ExtPhpRs\Interface\ParentInterface'),
-    'is_a() should recognize Greeter as ParentInterface');
+assert(is_a($greeter, 'ExtPhpRs\Interface\ParentInterface'), 'is_a() should recognize Greeter as ParentInterface');
 
 // Test the class method
 assert($greeter->getName() === 'World', 'Greeter should return correct name');
 
 // Test type hinting with the interface
-function greetWithInterface(ExtPhpRs\Interface\ParentInterface $obj): string {
+function greetWithInterface(ExtPhpRs\Interface\ParentInterface $obj): string
+{
     // The parentMethod is defined on the interface
     return $obj->parentMethod();
 }

--- a/tests/src/integration/iterator/iterator.php
+++ b/tests/src/integration/iterator/iterator.php
@@ -6,6 +6,6 @@ assert(iter_back([]) === []);
 assert(iter_back([1, 2, 3]) === [2, 3, 1, 2, 0, 1]);
 
 assert(iter_next_back([], 2) === [null, null]);
-assert(iter_next_back([1, 2 ,3], 2) === [2, 3, 0, 1, 1, 2, null, null]);
+assert(iter_next_back([1, 2, 3], 2) === [2, 3, 0, 1, 1, 2, null, null]);
 var_dump(iter_next_back([1, 2, 3, 4, 5], 3));
 assert(iter_next_back([1, 2, 3, 4, 5], 3) === [4, 5, 0, 1, 1, 2, 3, 4, 2, 3, null, null, null]);

--- a/tests/src/integration/magic_method/magic_method.php
+++ b/tests/src/integration/magic_method/magic_method.php
@@ -17,8 +17,8 @@ unset($magicMethod->count);
 assert(0 === $magicMethod->count);
 
 // __toString
-assert("0" === $magicMethod->__toString());
-assert("0" === (string) $magicMethod);
+assert('0' === $magicMethod->__toString());
+assert('0' === (string) $magicMethod);
 
 // __invoke
 assert(34 === $magicMethod(34));
@@ -29,9 +29,9 @@ $expectedDebug = "MagicMethod Object\n(\n    [count] => 0\n)\n";
 assert($expectedDebug === $debug);
 
 // __call
-assert("Hello" === $magicMethod->callMagicMethod(1, 2, 3));
+assert('Hello' === $magicMethod->callMagicMethod(1, 2, 3));
 assert(null === $magicMethod->callUndefinedMagicMethod());
 
 // __call_static
-assert("Hello from static call 1, 2, 3" === MagicMethod::callStaticSomeMagic(1, 2, 3));
+assert('Hello from static call 1, 2, 3' === MagicMethod::callStaticSomeMagic(1, 2, 3));
 assert(null === MagicMethod::callUndefinedStaticSomeMagic());

--- a/tests/src/integration/number/number.php
+++ b/tests/src/integration/number/number.php
@@ -1,6 +1,6 @@
 <?php
 
-require(__DIR__ . '/../_utils.php');
+require __DIR__ . '/../_utils.php';
 
 // Signed
 assert(test_number_signed(-12) === -12);
@@ -10,7 +10,7 @@ assert(test_number_signed(12) === 12);
 // Unsigned
 assert(test_number_unsigned(0) === 0);
 assert(test_number_unsigned(12) === 12);
-assert_exception_thrown(fn () => test_number_unsigned(-12));
+assert_exception_thrown(fn() => test_number_unsigned(-12));
 
 // Float
 assert(round(test_number_float(-1.2), 2) === round(-1.2, 2));

--- a/tests/src/integration/object/object.php
+++ b/tests/src/integration/object/object.php
@@ -1,11 +1,13 @@
 <?php
 
-$obj = new stdClass;
+$obj = new stdClass();
 $obj->string = 'string';
 $obj->bool = true;
 $obj->number = 2022;
 $obj->array = [
-    1, 2, 3
+    1,
+    2,
+    3
 ];
 
 $test = test_object($obj);

--- a/tests/src/integration/observer/error_observer.php
+++ b/tests/src/integration/observer/error_observer.php
@@ -5,38 +5,41 @@ error_observer_test_reset();
 $initial_error_count = error_observer_test_get_error_count();
 $initial_warning_count = error_observer_test_get_warning_count();
 
-assert($initial_error_count === 0, "Initial error count should be 0, got: " . $initial_error_count);
-assert($initial_warning_count === 0, "Initial warning count should be 0, got: " . $initial_warning_count);
+assert($initial_error_count === 0, 'Initial error count should be 0, got: ' . $initial_error_count);
+assert($initial_warning_count === 0, 'Initial warning count should be 0, got: ' . $initial_warning_count);
 
-trigger_error("Test warning message", E_USER_WARNING);
+trigger_error('Test warning message', E_USER_WARNING);
 
 $warning_count = error_observer_test_get_warning_count();
-assert($warning_count === 1, "Expected 1 warning, got: " . $warning_count);
+assert($warning_count === 1, 'Expected 1 warning, got: ' . $warning_count);
 
 $last_message = error_observer_test_get_last_message();
-assert(str_contains($last_message, "Test warning message"), "Message should contain 'Test warning message', got: " . $last_message);
+assert(
+    str_contains($last_message, 'Test warning message'),
+    "Message should contain 'Test warning message', got: " . $last_message
+);
 
 $last_line = error_observer_test_get_last_line();
-assert($last_line === 11, "Line should be 11, got: " . $last_line);
+assert($last_line === 11, 'Line should be 11, got: ' . $last_line);
 
 error_observer_test_reset();
 
-trigger_error("Warning 1", E_USER_WARNING);
-trigger_error("Warning 2", E_USER_WARNING);
-trigger_error("Warning 3", E_USER_WARNING);
+trigger_error('Warning 1', E_USER_WARNING);
+trigger_error('Warning 2', E_USER_WARNING);
+trigger_error('Warning 3', E_USER_WARNING);
 
 $warning_count = error_observer_test_get_warning_count();
-assert($warning_count === 3, "Expected 3 warnings after multiple triggers, got: " . $warning_count);
+assert($warning_count === 3, 'Expected 3 warnings after multiple triggers, got: ' . $warning_count);
 
 $last_message = error_observer_test_get_last_message();
-assert(str_contains($last_message, "Warning 3"), "Last message should be 'Warning 3', got: " . $last_message);
+assert(str_contains($last_message, 'Warning 3'), "Last message should be 'Warning 3', got: " . $last_message);
 
 error_observer_test_reset();
 $old_level = error_reporting(E_ALL);
-@trigger_error("This notice should not be observed", E_USER_NOTICE);
+@trigger_error('This notice should not be observed', E_USER_NOTICE);
 error_reporting($old_level);
 
 $warning_count = error_observer_test_get_warning_count();
 $error_count = error_observer_test_get_error_count();
-assert($warning_count === 0, "Notice should not be counted as warning, got: " . $warning_count);
-assert($error_count === 0, "Notice should not be counted as error, got: " . $error_count);
+assert($warning_count === 0, 'Notice should not be counted as warning, got: ' . $warning_count);
+assert($error_count === 0, 'Notice should not be counted as error, got: ' . $error_count);

--- a/tests/src/integration/observer/exception_observer.php
+++ b/tests/src/integration/observer/exception_observer.php
@@ -4,96 +4,110 @@ exception_observer_test_reset();
 
 // Test 1: Initial state
 $initial_count = exception_observer_test_get_count();
-assert($initial_count === 0, "Initial exception count should be 0, got: " . $initial_count);
+assert($initial_count === 0, 'Initial exception count should be 0, got: ' . $initial_count);
 
 // Test 2: Throw and catch an exception
 try {
-    throw new RuntimeException("Test exception message", 42);
+    throw new RuntimeException('Test exception message', 42);
 } catch (RuntimeException $e) {
     // Exception was caught
 }
 
 $count = exception_observer_test_get_count();
-assert($count === 1, "Expected 1 exception, got: " . $count);
+assert($count === 1, 'Expected 1 exception, got: ' . $count);
 
 $last_class = exception_observer_test_get_last_class();
-assert($last_class === "RuntimeException", "Expected class 'RuntimeException', got: " . $last_class);
+assert($last_class === 'RuntimeException', "Expected class 'RuntimeException', got: " . $last_class);
 
 $last_message = exception_observer_test_get_last_message();
-assert($last_message === "Test exception message", "Expected message 'Test exception message', got: " . $last_message);
+assert($last_message === 'Test exception message', "Expected message 'Test exception message', got: " . $last_message);
 
 $last_code = exception_observer_test_get_last_code();
-assert($last_code === 42, "Expected code 42, got: " . $last_code);
+assert($last_code === 42, 'Expected code 42, got: ' . $last_code);
 
 $last_line = exception_observer_test_get_last_line();
-assert($last_line === 11, "Expected line 11, got: " . $last_line);
+assert($last_line === 11, 'Expected line 11, got: ' . $last_line);
 
 // Test 3: Reset and verify
 exception_observer_test_reset();
 
 $count = exception_observer_test_get_count();
-assert($count === 0, "After reset, count should be 0, got: " . $count);
+assert($count === 0, 'After reset, count should be 0, got: ' . $count);
 
 // Test 4: Multiple exceptions
 try {
-    throw new InvalidArgumentException("First");
-} catch (Exception $e) {}
+    throw new InvalidArgumentException('First');
+} catch (Exception $e) {
+}
 
 try {
-    throw new LogicException("Second");
-} catch (Exception $e) {}
+    throw new LogicException('Second');
+} catch (Exception $e) {
+}
 
 try {
-    throw new Exception("Third", 100);
-} catch (Exception $e) {}
+    throw new Exception('Third', 100);
+} catch (Exception $e) {
+}
 
 $count = exception_observer_test_get_count();
-assert($count === 3, "Expected 3 exceptions, got: " . $count);
+assert($count === 3, 'Expected 3 exceptions, got: ' . $count);
 
 $last_class = exception_observer_test_get_last_class();
-assert($last_class === "Exception", "Last class should be 'Exception', got: " . $last_class);
+assert($last_class === 'Exception', "Last class should be 'Exception', got: " . $last_class);
 
 $last_message = exception_observer_test_get_last_message();
-assert($last_message === "Third", "Last message should be 'Third', got: " . $last_message);
+assert($last_message === 'Third', "Last message should be 'Third', got: " . $last_message);
 
 $last_code = exception_observer_test_get_last_code();
-assert($last_code === 100, "Last code should be 100, got: " . $last_code);
+assert($last_code === 100, 'Last code should be 100, got: ' . $last_code);
 
 // Test 5: Nested exceptions
 exception_observer_test_reset();
 
-function throwNested() {
-    throw new RuntimeException("Nested exception");
+function throwNested()
+{
+    throw new RuntimeException('Nested exception');
 }
 
 try {
     throwNested();
-} catch (Exception $e) {}
+} catch (Exception $e) {
+}
 
 $count = exception_observer_test_get_count();
-assert($count === 1, "Expected 1 nested exception, got: " . $count);
+assert($count === 1, 'Expected 1 nested exception, got: ' . $count);
 
 $last_class = exception_observer_test_get_last_class();
-assert($last_class === "RuntimeException", "Expected 'RuntimeException', got: " . $last_class);
+assert($last_class === 'RuntimeException', "Expected 'RuntimeException', got: " . $last_class);
 
 // Test 6: Backtrace capture
 exception_observer_test_reset();
 
-function innerThrow() {
-    throw new RuntimeException("From inner");
+function innerThrow()
+{
+    throw new RuntimeException('From inner');
 }
 
-function outerCall() {
+function outerCall()
+{
     innerThrow();
 }
 
 try {
     outerCall();
-} catch (Exception $e) {}
+} catch (Exception $e) {
+}
 
 $backtrace_depth = exception_observer_test_get_backtrace_depth();
-assert($backtrace_depth >= 2, "Expected backtrace depth >= 2, got: " . $backtrace_depth);
+assert($backtrace_depth >= 2, 'Expected backtrace depth >= 2, got: ' . $backtrace_depth);
 
 $backtrace_functions = exception_observer_test_get_backtrace_functions();
-assert(strpos($backtrace_functions, "innerThrow") !== false, "Expected 'innerThrow' in backtrace, got: " . $backtrace_functions);
-assert(strpos($backtrace_functions, "outerCall") !== false, "Expected 'outerCall' in backtrace, got: " . $backtrace_functions);
+assert(
+    str_contains($backtrace_functions, 'innerThrow'),
+    "Expected 'innerThrow' in backtrace, got: " . $backtrace_functions
+);
+assert(
+    str_contains($backtrace_functions, 'outerCall'),
+    "Expected 'outerCall' in backtrace, got: " . $backtrace_functions
+);

--- a/tests/src/integration/observer/observer.php
+++ b/tests/src/integration/observer/observer.php
@@ -4,7 +4,7 @@
 observer_test_reset();
 
 // Define a user function to observe
-function my_test_function(string $suffix = ""): string
+function my_test_function(string $suffix = ''): string
 {
     return "hello{$suffix}";
 }
@@ -26,7 +26,7 @@ $initial_end_count = observer_test_get_end_count();
 $user_calls = [
     [getenv('EXT_PHP_RS_OBSERVER_FN1') ?: 'my_test_function', ['']],
     [getenv('EXT_PHP_RS_OBSERVER_FN2') ?: 'another_function', [5]],
-    [getenv('EXT_PHP_RS_OBSERVER_FN3') ?: 'my_test_function', [' again']],
+    [getenv('EXT_PHP_RS_OBSERVER_FN3') ?: 'my_test_function', [' again']]
 ];
 
 $results = [];
@@ -34,10 +34,7 @@ foreach ($user_calls as [$function, $args]) {
     $results[] = $function(...$args);
 }
 
-assert(
-    $results === ['hello', 10, 'hello again'],
-    'Unexpected results from observed user function calls',
-);
+assert($results === ['hello', 10, 'hello again'], 'Unexpected results from observed user function calls');
 
 // Get counts after calling user functions
 $call_count = observer_test_get_call_count();
@@ -46,9 +43,9 @@ $end_count = observer_test_get_end_count();
 // We called 3 user functions, so we expect:
 // - call_count should have increased by 3
 // - end_count should have increased by 3
-assert($call_count >= 3, "Expected at least 3 calls, got: " . $call_count);
-assert($end_count >= 3, "Expected at least 3 ends, got: " . $end_count);
-assert($call_count === $end_count, "Call count and end count should match");
+assert($call_count >= 3, 'Expected at least 3 calls, got: ' . $call_count);
+assert($end_count >= 3, 'Expected at least 3 ends, got: ' . $end_count);
+assert($call_count === $end_count, 'Call count and end count should match');
 
 // Test nested function calls
 function outer(callable $callback): int
@@ -65,17 +62,11 @@ observer_test_reset();
 $outer = getenv('EXT_PHP_RS_OUTER_FN') ?: 'outer';
 $inner = getenv('EXT_PHP_RS_INNER_FN') ?: 'inner';
 $result = $outer($inner);
-assert($result === 42, "Nested call should return 42");
+assert($result === 42, 'Nested call should return 42');
 
 $nested_call_count = observer_test_get_call_count();
 $nested_end_count = observer_test_get_end_count();
 
 // outer() calls inner(), so we expect 2 calls
-assert(
-    $nested_call_count >= 2,
-    "Expected at least 2 nested calls, got: " . $nested_call_count,
-);
-assert(
-    $nested_end_count >= 2,
-    "Expected at least 2 nested ends, got: " . $nested_end_count,
-);
+assert($nested_call_count >= 2, 'Expected at least 2 nested calls, got: ' . $nested_call_count);
+assert($nested_end_count >= 2, 'Expected at least 2 nested ends, got: ' . $nested_end_count);

--- a/tests/src/integration/observer/zend_extension.php
+++ b/tests/src/integration/observer/zend_extension.php
@@ -5,7 +5,7 @@
 // ============================================================================
 
 $activate_count = zend_ext_test_get_activate_count();
-assert($activate_count >= 1, "Expected activate() to be called at least once, got: " . $activate_count);
+assert($activate_count >= 1, 'Expected activate() to be called at least once, got: ' . $activate_count);
 
 // ============================================================================
 // Test 2: op_array_handler() fires after compilation
@@ -14,7 +14,7 @@ assert($activate_count >= 1, "Expected activate() to be called at least once, go
 // has already been called for the main script and any functions defined above.
 
 $op_count = zend_ext_test_get_op_array_handler_count();
-assert($op_count > 0, "Expected op_array_handler to be called at least once, got: " . $op_count);
+assert($op_count > 0, 'Expected op_array_handler to be called at least once, got: ' . $op_count);
 
 // ============================================================================
 // Test 3: statement_handler() fires for executed statements
@@ -27,7 +27,7 @@ $c = $a + $b;
 $stmt_count = zend_ext_test_get_statement_count();
 // The reset call, three assignments, and the get call each produce
 // ZEND_EXT_STMT opcodes, so the count must be greater than zero.
-assert($stmt_count > 0, "Expected statement_handler to be called, got: " . $stmt_count);
+assert($stmt_count > 0, 'Expected statement_handler to be called, got: ' . $stmt_count);
 
 // ============================================================================
 // Test 4: fcall_begin_handler() / fcall_end_handler() fire around calls
@@ -48,8 +48,8 @@ zend_ext_test_user_fn();
 zend_ext_test_user_fn();
 $begin_count = zend_ext_test_get_fcall_begin_count();
 $end_count = zend_ext_test_get_fcall_end_count();
-assert($begin_count >= 3, "Expected at least 3 fcall_begin, got: " . $begin_count);
-assert($end_count >= 3, "Expected at least 3 fcall_end, got: " . $end_count);
+assert($begin_count >= 3, 'Expected at least 3 fcall_begin, got: ' . $begin_count);
+assert($end_count >= 3, 'Expected at least 3 fcall_end, got: ' . $end_count);
 
 // ============================================================================
 // Test 5: Nested user function calls are tracked
@@ -67,15 +67,15 @@ function zend_ext_inner(): int
 
 zend_ext_test_reset_fcall_counts();
 $result = zend_ext_outer();
-assert($result === 99, "Nested call should return 99, got: " . $result);
+assert($result === 99, 'Nested call should return 99, got: ' . $result);
 
 $nested_begin = zend_ext_test_get_fcall_begin_count();
 $nested_end = zend_ext_test_get_fcall_end_count();
 // outer() calls inner(), each with EXT_FCALL_BEGIN/END at the call-site.
 // The call to outer() in the main script also generates EXT_FCALL, and
 // inner()'s call-site inside outer() generates another pair.
-assert($nested_begin >= 2, "Expected at least 2 nested fcall_begin, got: " . $nested_begin);
-assert($nested_end >= 2, "Expected at least 2 nested fcall_end, got: " . $nested_end);
+assert($nested_begin >= 2, 'Expected at least 2 nested fcall_begin, got: ' . $nested_begin);
+assert($nested_end >= 2, 'Expected at least 2 nested fcall_end, got: ' . $nested_end);
 
 // ============================================================================
 // Test 6: statement_handler counts increase with more statements
@@ -95,5 +95,5 @@ $second_batch = zend_ext_test_get_statement_count();
 
 assert(
     $second_batch > $first_batch,
-    "More statements should produce a higher count: first=$first_batch, second=$second_batch",
+    "More statements should produce a higher count: first={$first_batch}, second={$second_batch}"
 );

--- a/tests/src/integration/persistent_string/persistent_string.php
+++ b/tests/src/integration/persistent_string/persistent_string.php
@@ -1,18 +1,19 @@
 <?php
+
 $result = test_persistent_string();
-assert($result === "persistent string test passed", "Persistent string test failed: $result");
+assert($result === 'persistent string test passed', "Persistent string test failed: {$result}");
 
 $result = test_non_persistent_string();
-assert($result === "non-persistent string test passed", "Non-persistent string test failed: $result");
+assert($result === 'non-persistent string test passed', "Non-persistent string test failed: {$result}");
 
 $result = test_persistent_string_read();
-assert($result === "read: READ_BEFORE_DROP", "Persistent string read test failed: $result");
+assert($result === 'read: READ_BEFORE_DROP', "Persistent string read test failed: {$result}");
 
 $result = test_persistent_string_loop(100);
-assert($result === "completed 100 iterations", "Persistent string loop test failed: $result");
+assert($result === 'completed 100 iterations', "Persistent string loop test failed: {$result}");
 
 $result = test_interned_string_persistent();
-assert($result === "interned persistent test passed", "Interned persistent string test failed: $result");
+assert($result === 'interned persistent test passed', "Interned persistent string test failed: {$result}");
 
 $result = test_interned_string_non_persistent();
-assert($result === "interned non-persistent test passed", "Interned non-persistent string test failed: $result");
+assert($result === 'interned non-persistent test passed', "Interned non-persistent string test failed: {$result}");

--- a/tests/src/integration/reference/reference.php
+++ b/tests/src/integration/reference/reference.php
@@ -3,42 +3,42 @@
 // Test passing references to Rust functions (issue #102)
 
 // Test string reference
-$val = "hello";
+$val = 'hello';
 $ref = &$val;
-assert(test_ref_string($ref) === "hello", "String reference should work");
+assert(test_ref_string($ref) === 'hello', 'String reference should work');
 
 // Test modifying through reference
-$val = "world";
-assert(test_ref_string($ref) === "world", "Modified string reference should work");
+$val = 'world';
+assert(test_ref_string($ref) === 'world', 'Modified string reference should work');
 
 // Test long reference
 $num = 42;
 $refNum = &$num;
-assert(test_ref_long($refNum) === 42, "Long reference should work");
+assert(test_ref_long($refNum) === 42, 'Long reference should work');
 
 // Test modifying long through reference
 $num = 100;
-assert(test_ref_long($refNum) === 100, "Modified long reference should work");
+assert(test_ref_long($refNum) === 100, 'Modified long reference should work');
 
 // Test double reference
 $dbl = 3.14;
 $refDbl = &$dbl;
-assert(test_ref_double($refDbl) === 3.14, "Double reference should work");
+assert(test_ref_double($refDbl) === 3.14, 'Double reference should work');
 
 // Test modifying double through reference
 $dbl = 2.71;
-assert(test_ref_double($refDbl) === 2.71, "Modified double reference should work");
+assert(test_ref_double($refDbl) === 2.71, 'Modified double reference should work');
 
 // Test &mut Zval - read
-$str = "test";
-assert(test_mut_zval($str) === "string: test", "&mut Zval should read string");
+$str = 'test';
+assert(test_mut_zval($str) === 'string: test', '&mut Zval should read string');
 
 // Test &mut Zval - modify string in place
-$str = "original";
+$str = 'original';
 test_mut_zval_set_string($str);
-assert($str === "modified by rust", "&mut Zval should modify string in place");
+assert($str === 'modified by rust', '&mut Zval should modify string in place');
 
 // Test &mut Zval - modify to long in place
-$str = "not a long";
+$str = 'not a long';
 test_mut_zval_set_long($str);
-assert($str === 999, "&mut Zval should modify to long in place");
+assert($str === 999, '&mut Zval should modify to long in place');

--- a/tests/src/integration/separated/separated.php
+++ b/tests/src/integration/separated/separated.php
@@ -22,7 +22,7 @@ assert(test_separated_array_len([10, 20, 30]) === 3, 'Separated read should repo
 assert(test_separated_array_len([]) === 0, 'Separated should handle empty array');
 
 // Works with different PHP types
-assert(test_separated_string("hello") === "hello", 'Separated should read strings');
+assert(test_separated_string('hello') === 'hello', 'Separated should read strings');
 assert(test_separated_long(42) === 42, 'Separated should read integers');
 
 // Passthrough returns a copy of the value
@@ -31,12 +31,12 @@ $copy = test_separated_passthrough($original);
 assert($copy === [1, 2, 3], 'Passthrough should return equivalent value');
 
 // Type reporting
-assert(test_separated_type(42) === "Long", 'Separated should report Long type');
-assert(test_separated_type("str") === "String", 'Separated should report String type');
-assert(test_separated_type([1]) === "Array", 'Separated should report Array type');
-assert(test_separated_type(null) === "Null", 'Separated should report Null type');
-assert(test_separated_type(true) === "True", 'Separated should report True type');
-assert(test_separated_type(3.14) === "Double", 'Separated should report Double type');
+assert(test_separated_type(42) === 'Long', 'Separated should report Long type');
+assert(test_separated_type('str') === 'String', 'Separated should report String type');
+assert(test_separated_type([1]) === 'Array', 'Separated should report Array type');
+assert(test_separated_type(null) === 'Null', 'Separated should report Null type');
+assert(test_separated_type(true) === 'True', 'Separated should report True type');
+assert(test_separated_type(3.14) === 'Double', 'Separated should report Double type');
 
 // ============================================================
 // PhpRef: requires &$var, DOES modify caller's value
@@ -64,7 +64,7 @@ assert(test_phpref_read($val) === 99, 'PhpRef read should return the value');
 // Replace value through PhpRef
 $val = 42;
 test_phpref_set_string($val);
-assert($val === "replaced_by_rust", 'PhpRef should replace the value entirely');
+assert($val === 'replaced_by_rust', 'PhpRef should replace the value entirely');
 assert(is_string($val), 'Replaced value should be a string');
 
 // PhpRef rejects literals (this should fail — uncomment to verify manually)

--- a/tests/src/integration/types/types.php
+++ b/tests/src/integration/types/types.php
@@ -18,23 +18,26 @@ const TYPES = [
     'test_callable' => [['callable', 'string'], 'mixed']
 ];
 
-function toStr(ReflectionNamedType|ReflectionUnionType|ReflectionIntersectionType|null $v): string {
+function toStr(ReflectionNamedType|ReflectionUnionType|ReflectionIntersectionType|null $v): string
+{
     if ($v === null) {
         return '<null>';
     }
     return match (true) {
-        $v instanceof ReflectionNamedType => $v->allowsNull() && $v->getName() !== 'mixed' ? '?'.$v->getName() : $v->getName(),
+        $v instanceof ReflectionNamedType => $v->allowsNull() && $v->getName() !== 'mixed'
+            ? '?' . $v->getName()
+            : $v->getName(),
         $v instanceof ReflectionUnionType => $v->getName(),
-        $v instanceof ReflectionIntersectionType => $v->getName(),
+        $v instanceof ReflectionIntersectionType => $v->getName()
     };
 }
 
 foreach (TYPES as $func => [$args, $return]) {
     $f = new ReflectionFunction($func);
     $tReturn = toStr($f->getReturnType());
-    assert($tReturn === $return, "Wrong return type of $func, expected $return, got $tReturn");
+    assert($tReturn === $return, "Wrong return type of {$func}, expected {$return}, got {$tReturn}");
     foreach ($f->getParameters() as $idx => $param) {
         $tParam = toStr($param->getType());
-        assert($tParam === $args[$idx], "Wrong arg type $idx of $func, expected {$args[$idx]}, got $tParam");
+        assert($tParam === $args[$idx], "Wrong arg type {$idx} of {$func}, expected {$args[$idx]}, got {$tParam}");
     }
 }

--- a/tests/src/integration/variadic_args/variadic_args.php
+++ b/tests/src/integration/variadic_args/variadic_args.php
@@ -1,12 +1,12 @@
 <?php
 
-require __DIR__ . "/../_utils.php";
+require __DIR__ . '/../_utils.php';
 
 $a = 'a';
 $b = 'b';
 $c = 'c';
 
-$array = [$b, 'a','c'];
+$array = [$b, 'a', 'c'];
 
 // Passing arguments as references
 $args = test_variadic_args();
@@ -30,7 +30,7 @@ assert($sum === 6, 'Expected to return 6');
 $count = test_variadic_add_required(11); // 11
 assert($count === 11, 'Allow only one argument');
 
-$types = test_variadic_args('a', 1, ['abc', 'def', 0.01], true, new stdClass);
+$types = test_variadic_args('a', 1, ['abc', 'def', 0.01], true, new stdClass());
 assert(gettype(end($types[2])) === 'double', 'Type of argument 2 and its last element should be a float of 0.01');
 assert($types[3], 'Arg 4 should be boolean true');
 assert($types[4] instanceof stdClass, 'Last argument is an instance of an StdClass');
@@ -42,20 +42,23 @@ assert(test_variadic_count(1, 2, 3, 4, 5) === 5, 'Five args should return 5');
 assert(test_variadic_count(...range(1, 100)) === 100, 'Spread of 100 items should return 100');
 
 // Test variadic types detection
-$type_result = test_variadic_types(42, "hello", 3.14, true, [1, 2], new stdClass, null);
-assert($type_result === ['long', 'string', 'double', 'bool', 'array', 'object', 'null'], 'Should detect all types correctly');
+$type_result = test_variadic_types(42, 'hello', 3.14, true, [1, 2], new stdClass(), null);
+assert(
+    $type_result === ['long', 'string', 'double', 'bool', 'array', 'object', 'null'],
+    'Should detect all types correctly'
+);
 
 $type_result = test_variadic_types();
 assert($type_result === [], 'Empty variadic should return empty array');
 
 // Test variadic with string operations
-$prefixed = test_variadic_strings("pre_", "a", "b", "c");
+$prefixed = test_variadic_strings('pre_', 'a', 'b', 'c');
 assert($prefixed === ['pre_a', 'pre_b', 'pre_c'], 'Should prefix all strings');
 
-$prefixed = test_variadic_strings("x_");
+$prefixed = test_variadic_strings('x_');
 assert($prefixed === [], 'No suffixes should return empty');
 
-$prefixed = test_variadic_strings("test_", "one", 123, "two");
+$prefixed = test_variadic_strings('test_', 'one', 123, 'two');
 assert(count($prefixed) === 2, 'Should only process strings, filtering out non-strings');
 
 // Test variadic sum
@@ -63,13 +66,13 @@ assert(test_variadic_sum_all() === 0, 'Empty sum should be 0');
 assert(test_variadic_sum_all(1, 2, 3, 4, 5) === 15, 'Sum 1-5 should be 15');
 assert(test_variadic_sum_all(10, 20, 30) === 60, 'Sum should be 60');
 assert(test_variadic_sum_all(-5, 5) === 0, 'Negative and positive should cancel');
-assert(test_variadic_sum_all(100, "not a number", 200) === 300, 'Should skip non-numeric values');
+assert(test_variadic_sum_all(100, 'not a number', 200) === 300, 'Should skip non-numeric values');
 
 // Test variadic with optional parameter
-assert(test_variadic_optional("req", null) === "req-none-0", 'Optional null, no extras');
-assert(test_variadic_optional("req", 42) === "req-42-0", 'Optional provided, no extras');
-assert(test_variadic_optional("req", 42, "a", "b") === "req-42-2", 'Optional and extras provided');
-assert(test_variadic_optional("req", null, "x") === "req-none-1", 'Null optional, one extra');
+assert(test_variadic_optional('req', null) === 'req-none-0', 'Optional null, no extras');
+assert(test_variadic_optional('req', 42) === 'req-42-0', 'Optional provided, no extras');
+assert(test_variadic_optional('req', 42, 'a', 'b') === 'req-42-2', 'Optional and extras provided');
+assert(test_variadic_optional('req', null, 'x') === 'req-none-1', 'Null optional, one extra');
 
 // Test variadic empty check
 assert(test_variadic_empty_check() === true, 'No args should be empty');
@@ -89,5 +92,5 @@ assert($fl === [1, 2], 'Two items should return first and last');
 $fl = test_variadic_first_last(1, 2, 3, 4, 5);
 assert($fl === [1, 5], 'Multiple items should return first and last');
 
-$fl = test_variadic_first_last("start", true, 3.14, ["middle"], "end");
-assert($fl[0] === "start" && $fl[1] === "end", 'Should preserve types for first and last');
+$fl = test_variadic_first_last('start', true, 3.14, ['middle'], 'end');
+assert($fl[0] === 'start' && $fl[1] === 'end', 'Should preserve types for first and last');


### PR DESCRIPTION
## Description

Set up [mago](https://mago.carthage.software) as the formatter and linter for every PHP file in the repo (integration-test fixtures, benchmarks, and embed scripts). These files are fixtures for a PHP extension, not application code, so the scope is formatting and linting only. `analyze` and `guard` are intentionally excluded because the fixtures call extension-registered symbols that only exist at PHP runtime.

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md) and the [code of conduct](CODE_OF_CONDUCT.md).
- [ ] I have added tests that prove my code works as expected. <!-- N/A: tooling change; the existing integration suite (32 passed, 0 failed) verifies the reformatted fixtures still behave identically. -->
- [x] I have added documentation if applicable.
- [ ] I have added a [migration guide](CONTRIBUTING.md#breaking-changes) if applicable. <!-- N/A: not a breaking change. -->
