### PR TITLE
fix(ci): enable ondrej main/debug component for libphp embed dbgsym

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,9 +227,11 @@ jobs:
 
       - name: Install libphp-embed
         if: matrix.phpts == 'nts'
-        # libphp*-embed-dbgsym is published in the ondrej PPA "main/debug" component,
-        # which setup-php does not always enable. Add it before installing.
+        # The GitHub runner image no longer ships the ondrej PPA, and setup-php
+        # uses its cached PHP build. Add the PPA and its "main/debug" component
+        # (where libphp*-embed-dbgsym lives) so the embed library resolves.
         run: |
+          sudo add-apt-repository -y ppa:ondrej/php
           src=$(grep -rlE 'ondrej' /etc/apt/sources.list.d/ | head -n1)
           if [ -n "$src" ] && ! grep -q 'main/debug' "$src"; then
             if [ "${src##*.}" = "sources" ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,7 +227,19 @@ jobs:
 
       - name: Install libphp-embed
         if: matrix.phpts == 'nts'
-        run: sudo apt update -y && sudo apt install -y libphp${{ env.php_version }}-embed-dbgsym
+        # libphp*-embed-dbgsym is published in the ondrej PPA "main/debug" component,
+        # which setup-php does not always enable. Add it before installing.
+        run: |
+          src=$(grep -rlE 'ondrej' /etc/apt/sources.list.d/ | head -n1)
+          if [ -n "$src" ] && ! grep -q 'main/debug' "$src"; then
+            if [ "${src##*.}" = "sources" ]; then
+              sudo sed -i -E '/^Components:/ s#$# main/debug#' "$src"
+            else
+              sudo sed -i -E 's#(^deb .* )main([[:space:]]*$)#\1main main/debug\2#' "$src"
+            fi
+          fi
+          sudo apt-get update -y
+          sudo apt-get install -y libphp${{ env.php_version }}-embed-dbgsym
 
       - name: Install cargo-expand
         uses: dtolnay/install@cargo-expand


### PR DESCRIPTION
## Description

The `test-embed (NTS)` job failed at the install step with `E: Unable to locate package libphp8.5-embed-dbgsym`.

That package still exists in the ondrej PPA, but it lives only in the `main/debug` component (the ddebs sub-archive). setup-php enables that component only when its debug build path runs, and it does so silently (`>/dev/null 2>&1`), so a miss leaves the package unreachable with no clear cause.

The NTS install step now adds the `main/debug` component to the ondrej source before installing. It covers both the deb822 (`.sources`) and legacy one-line (`.list`) formats, and it skips the edit when the component is already there.

This keeps the debug symbols package instead of dropping it.

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md) and the [code of conduct](CODE_OF_CONDUCT.md).
- [ ] I have added tests that prove my code works as expected.
- [ ] I have added documentation if applicable.
- [ ] I have added a [migration guide](CONTRIBUTING.md#breaking-changes) if applicable.
