### PR TITLE
fix(types)!: make raw Zend resource assignment unsafe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Validate commit messages
         run: |
           git show-ref
-          curl -sSfL https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip | zcat > convco
+          curl -sSfL https://github.com/convco/convco/releases/latest/download/convco-x86_64-unknown-linux-musl.tar.gz | tar -xz --strip-components=1 convco-x86_64-unknown-linux-musl/convco
           chmod +x convco
           ./convco check refs/remotes/origin/master..HEAD
           rm convco

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776654897,
-        "narHash": "sha256-Vqi4AiJVCcBGn/RmBtRCgyH5rCxqm/w0xV9diJWF1Ic=",
+        "lastModified": 1783834461,
+        "narHash": "sha256-FCmrs1StAghJDKfqy56KM96KZtxpYzgeq6zM3QO8wjA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "25d75be8139815a53560745fa060909777495105",
+        "rev": "a286e5b998e852297a403786f063fb2c9fe7f57a",
         "type": "github"
       },
       "original": {

--- a/guide/src/migration-guides/v0.16.md
+++ b/guide/src/migration-guides/v0.16.md
@@ -1,5 +1,30 @@
 # Migrating to `v0.16`
 
+## `Zval::set_resource` Requires an Unsafe Block
+
+`Zval::set_resource` accepts a raw `zend_resource` pointer and transfers one
+owned Zend reference into the zval, so callers must now uphold its safety
+contract explicitly.
+
+### Before (v0.15)
+
+```rust,ignore
+zval.set_resource(resource);
+```
+
+### After (v0.16)
+
+```rust,ignore
+// SAFETY: `resource` is a valid Zend-managed resource whose owned reference is
+// transferred into `zval`.
+unsafe { zval.set_resource(resource) };
+```
+
+The pointer must be non-null and valid until Zend releases the transferred
+reference. `set_resource` does not increment the resource refcount, so the
+caller must relinquish that reference after the call. Replacing a zval with the
+same resource requires a separate incoming reference.
+
 ## Void Return Type for Functions Without Explicit Return
 
 Functions and methods without an explicit Rust return type now declare `void` as their PHP return type.

--- a/src/php_eval.rs
+++ b/src/php_eval.rs
@@ -130,10 +130,8 @@ fn strip_bom(code: &[u8]) -> &[u8] {
 }
 
 fn strip_php_open_tag(code: &[u8]) -> Option<&[u8]> {
-    let trimmed = match code.iter().position(|b| !b.is_ascii_whitespace()) {
-        Some(pos) => &code[pos..],
-        None => return None,
-    };
+    let pos = code.iter().position(|b| !b.is_ascii_whitespace())?;
+    let trimmed = &code[pos..];
 
     if trimmed.len() >= 5 && trimmed[..5].eq_ignore_ascii_case(b"<?php") {
         Some(trimmed[5..].trim_ascii_start())

--- a/src/types/zval.rs
+++ b/src/types/zval.rs
@@ -1009,7 +1009,43 @@ impl Zval {
     /// # Parameters
     ///
     /// * `val` - The value to set the zval as.
-    pub fn set_resource(&mut self, val: *mut zend_resource) {
+    ///
+    /// # Safety
+    ///
+    /// `val` must be non-null and point to a valid Zend-managed resource with
+    /// one independent reference that can be transferred into this zval. This
+    /// function does not increment the resource refcount: the caller
+    /// relinquishes the transferred reference, which the zval releases when it
+    /// is overwritten or dropped. The resource must remain valid until Zend
+    /// releases that reference.
+    ///
+    /// Replacing a zval with the same resource also requires an independent
+    /// incoming reference because the old reference is released before `val`
+    /// is stored.
+    ///
+    /// Calling this method requires an unsafe block:
+    ///
+    /// ```compile_fail,E0133
+    /// use ext_php_rs::{ffi::zend_resource, types::Zval};
+    ///
+    /// fn assign_resource(zval: &mut Zval, resource: *mut zend_resource) {
+    ///     zval.set_resource(resource);
+    /// }
+    /// ```
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use ext_php_rs::{ffi::zend_resource, types::Zval};
+    /// # fn acquire_resource_from_zend() -> *mut zend_resource { unimplemented!() }
+    /// let resource = acquire_resource_from_zend();
+    /// let mut zval = Zval::new();
+    ///
+    /// // SAFETY: `resource` is a valid Zend resource whose owned reference is
+    /// // transferred into `zval`.
+    /// unsafe { zval.set_resource(resource) };
+    /// ```
+    pub unsafe fn set_resource(&mut self, val: *mut zend_resource) {
         self.change_type(ZvalTypeFlags::ResourceEx);
         self.value.res = val;
     }


### PR DESCRIPTION
## Description

`Zval::set_resource` now requires `unsafe` because callers must guarantee pointer validity and transfer an owned Zend reference. I documented that contract, added compile-fail coverage, refreshed the Nix lock for Rust 1.97, and fixed its new Clippy diagnostic. Existing callers can follow the [v0.16 migration guide](guide/src/migration-guides/v0.16.md). I also updated CI to extract Convco's current Linux tarball after upstream removed the old zip asset.

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have added tests that prove my code works as expected.
- [x] I have added documentation if applicable.
- [x] I have added a [migration guide](CONTRIBUTING.md#breaking-changes) if applicable.
