### PR TITLE
fix(embed)!: own SAPI header callback data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ ext-php-rs-derive = { version = "=0.11.14", path = "./crates/macros" }
 
 [dev-dependencies]
 skeptic = "0.13"
+serde_json = "1"
 
 [build-dependencies]
 anyhow = "1"
@@ -95,3 +96,8 @@ path = "tests/module.rs"
 [[test]]
 name = "sapi_tests"
 path = "tests/sapi.rs"
+
+[[test]]
+name = "sapi_header_safety"
+path = "tests/sapi_header_safety.rs"
+required-features = ["embed"]

--- a/guide/src/migration-guides/v0.16.md
+++ b/guide/src/migration-guides/v0.16.md
@@ -25,6 +25,44 @@ reference. `set_resource` does not increment the resource refcount, so the
 caller must relinquish that reference after the call. Replacing a zval with the
 same resource requires a separate incoming reference.
 
+## SAPI Header Raw Constructors Removed
+
+`SapiHeader::from_raw` and `SapiHeaders::from_raw` have been removed. These
+constructors accepted unchecked Zend pointers through safe Rust.
+
+ext-php-rs now copies the header data into owned snapshots before invoking the
+`Sapi::send_header` and `Sapi::send_headers` callbacks.
+
+### Before (v0.15)
+
+```rust,ignore
+let header = SapiHeader::from_raw(raw_header);
+let headers = SapiHeaders::from_raw(raw_headers);
+```
+
+### After (v0.16)
+
+Read header data from the snapshots supplied to your `Sapi` implementation:
+
+```rust,ignore
+fn send_header(_ctx: &mut MyContext, header: &SapiHeader) {
+    if let Some((name, value)) = header.as_name_value() {
+        // Send the header to the client.
+    }
+}
+
+fn send_headers(
+    _ctx: &mut MyContext,
+    headers: &SapiHeaders,
+) -> SendHeadersResult {
+    let response_code = headers.http_response_code();
+    SendHeadersResult::DoSend
+}
+```
+
+Code that needs direct access to `sapi_header_struct` must use the raw FFI API
+and uphold Zend's pointer validity and lifetime requirements itself.
+
 ## Void Return Type for Functions Without Explicit Return
 
 Functions and methods without an explicit Rust return type now declare `void` as their PHP return type.

--- a/src/embed/sapi_trait.rs
+++ b/src/embed/sapi_trait.rs
@@ -6,14 +6,16 @@ use crate::error::Result;
 use crate::ffi::{ext_php_rs_sapi_globals, sapi_header_struct, sapi_headers_struct};
 use crate::types::Zval;
 use std::ffi::{c_char, c_int, c_void};
+use std::ptr::NonNull;
 
 /// Safe wrapper around `sapi_headers_struct` providing access to the HTTP
 /// response code set by PHP.
 ///
-/// This type is only valid for the duration of the [`Sapi::send_headers`]
-/// callback. Do not store it.
+/// ext-php-rs creates this snapshot and passes it to
+/// [`Sapi::send_headers`]. The response code is copied before user code runs,
+/// so the safe API does not borrow the Zend structure.
 pub struct SapiHeaders {
-    raw: *mut sapi_headers_struct,
+    http_response_code: i32,
 }
 
 impl std::fmt::Debug for SapiHeaders {
@@ -25,31 +27,33 @@ impl std::fmt::Debug for SapiHeaders {
 }
 
 impl SapiHeaders {
-    /// Creates a `SapiHeaders` from a raw pointer.
+    /// Copies a `sapi_headers_struct` into an owned snapshot.
     ///
     /// # Safety
     ///
-    /// `raw` must be a valid, non-null pointer to a `sapi_headers_struct`
-    /// that remains valid for the lifetime of the returned `SapiHeaders`.
-    #[must_use]
-    pub fn from_raw(raw: *mut sapi_headers_struct) -> Self {
-        Self { raw }
+    /// `raw` must be valid and readable for the duration of the callback.
+    unsafe fn snapshot(raw: NonNull<sapi_headers_struct>) -> Self {
+        // SAFETY: The caller guarantees that `raw` is readable for this copy.
+        let http_response_code = unsafe { raw.as_ref().http_response_code };
+        Self { http_response_code }
     }
 
     /// Returns the HTTP response code set by PHP (e.g. 200, 404, 500).
     #[must_use]
     pub fn http_response_code(&self) -> i32 {
-        unsafe { (*self.raw).http_response_code }
+        self.http_response_code
     }
 }
 
 /// Safe wrapper around `sapi_header_struct` providing access to a single
 /// HTTP response header sent by PHP.
 ///
-/// This type is only valid for the duration of the [`Sapi::send_header`]
-/// callback. Do not store it.
+/// ext-php-rs creates this snapshot and passes it to [`Sapi::send_header`].
+/// The header bytes are copied before user code runs, so the safe API does not
+/// borrow the Zend structure or its buffer.
 pub struct SapiHeader {
-    raw: *mut sapi_header_struct,
+    header: Option<Box<[u8]>>,
+    header_len: usize,
 }
 
 impl std::fmt::Debug for SapiHeader {
@@ -61,15 +65,28 @@ impl std::fmt::Debug for SapiHeader {
 }
 
 impl SapiHeader {
-    /// Creates a `SapiHeader` from a raw pointer.
+    /// Copies a `sapi_header_struct` into an owned snapshot.
     ///
     /// # Safety
     ///
-    /// `raw` must be a valid, non-null pointer to a `sapi_header_struct`
-    /// that remains valid for the lifetime of the returned `SapiHeader`.
-    #[must_use]
-    pub fn from_raw(raw: *mut sapi_header_struct) -> Self {
-        Self { raw }
+    /// `raw` must be valid and readable for the duration of the callback. If
+    /// its nested header pointer is non-null, it must be readable for exactly
+    /// `header_len` bytes during the copy.
+    unsafe fn snapshot(raw: NonNull<sapi_header_struct>) -> Self {
+        // SAFETY: The caller guarantees that `raw` is readable for this copy.
+        let raw = unsafe { raw.as_ref() };
+        let header_len = raw.header_len;
+        let header = NonNull::new(raw.header.cast::<u8>()).map(|header| {
+            if header_len == 0 {
+                Box::default()
+            } else {
+                // SAFETY: The caller guarantees that a non-null nested header
+                // pointer is readable for `header_len` bytes during this copy.
+                unsafe { std::slice::from_raw_parts(header.as_ptr(), header_len) }.into()
+            }
+        });
+
+        Self { header, header_len }
     }
 
     /// Returns the raw header string (e.g. `"Content-Type: text/html"`).
@@ -77,12 +94,10 @@ impl SapiHeader {
     /// Returns `None` if the header data is not valid UTF-8.
     #[must_use]
     pub fn as_str(&self) -> Option<&str> {
-        let raw = unsafe { &*self.raw };
-        if raw.header.is_null() || raw.header_len == 0 {
+        if self.header_len == 0 {
             return None;
         }
-        let bytes = unsafe { std::slice::from_raw_parts(raw.header.cast::<u8>(), raw.header_len) };
-        std::str::from_utf8(bytes).ok()
+        std::str::from_utf8(self.header.as_deref()?).ok()
     }
 
     /// Returns the header parsed as a `(name, value)` pair, splitting on the
@@ -100,7 +115,7 @@ impl SapiHeader {
     /// Returns the length of the header string in bytes.
     #[must_use]
     pub fn len(&self) -> usize {
-        unsafe { (*self.raw).header_len }
+        self.header_len
     }
 
     /// Returns `true` if the header is empty.
@@ -260,13 +275,14 @@ extern "C" fn trampoline_flush<S: Sapi>(server_context: *mut c_void) {
 }
 
 extern "C" fn trampoline_send_headers<S: Sapi>(sapi_headers: *mut sapi_headers_struct) -> c_int {
-    if sapi_headers.is_null() {
+    let Some(sapi_headers) = NonNull::new(sapi_headers) else {
         return SendHeadersResult::Failed.into_c_int();
-    }
+    };
     let Some(ctx) = get_server_context::<S>() else {
         return SendHeadersResult::Failed.into_c_int();
     };
-    let headers = SapiHeaders::from_raw(sapi_headers);
+    // SAFETY: PHP provides a readable SAPI headers struct for this callback.
+    let headers = unsafe { SapiHeaders::snapshot(sapi_headers) };
     S::send_headers(ctx, &headers).into_c_int()
 }
 
@@ -274,11 +290,13 @@ extern "C" fn trampoline_send_header<S: Sapi>(
     header: *mut sapi_header_struct,
     _server_context: *mut c_void,
 ) {
-    if header.is_null() {
+    let Some(header) = NonNull::new(header) else {
         return;
-    }
+    };
     if let Some(ctx) = get_server_context::<S>() {
-        let header = SapiHeader::from_raw(header);
+        // SAFETY: PHP provides a readable header struct and nested header
+        // buffer for the declared length during this callback.
+        let header = unsafe { SapiHeader::snapshot(header) };
         S::send_header(ctx, &header);
     }
 }
@@ -316,4 +334,240 @@ extern "C" fn trampoline_register_server_variables<S: Sapi>(vars: *mut Zval) {
     };
     let mut registrar = unsafe { ServerVarRegistrar::from_raw(vars) };
     S::register_server_variables(ctx, &mut registrar);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::embed::RequestInfo;
+
+    struct PanicContext;
+
+    impl ServerContext for PanicContext {
+        fn init_request_info(&self, _info: &mut RequestInfo) {
+            panic!("init_request_info callback must not be invoked");
+        }
+
+        fn read_post(&mut self, _buf: &mut [u8]) -> usize {
+            panic!("read_post callback must not be invoked");
+        }
+
+        fn read_cookies(&self) -> Option<&str> {
+            panic!("read_cookies callback must not be invoked");
+        }
+
+        fn finish_request(&mut self) -> bool {
+            panic!("finish_request callback must not be invoked");
+        }
+
+        fn is_request_finished(&self) -> bool {
+            panic!("is_request_finished callback must not be invoked");
+        }
+    }
+
+    struct PanicSapi;
+
+    impl Sapi for PanicSapi {
+        type Context = PanicContext;
+
+        fn name() -> &'static str {
+            "panic-sapi"
+        }
+
+        fn pretty_name() -> &'static str {
+            "Panic SAPI"
+        }
+
+        fn ub_write(_ctx: &mut Self::Context, _buf: &[u8]) -> usize {
+            panic!("ub_write callback must not be invoked");
+        }
+
+        fn log_message(_message: &str, _syslog_type: i32) {
+            panic!("log_message callback must not be invoked");
+        }
+
+        fn send_headers(_ctx: &mut Self::Context, _headers: &SapiHeaders) -> SendHeadersResult {
+            panic!("send_headers callback must not be invoked");
+        }
+
+        fn send_header(_ctx: &mut Self::Context, _header: &SapiHeader) {
+            panic!("send_header callback must not be invoked");
+        }
+    }
+
+    #[test]
+    fn test_sapi_header_valid() {
+        let header_bytes = b"Content-Type: text/html";
+        let mut raw = sapi_header_struct {
+            header: header_bytes.as_ptr().cast_mut().cast::<c_char>(),
+            header_len: header_bytes.len(),
+        };
+        // SAFETY: `raw` and its header buffer are readable for the copy.
+        let wrapper = unsafe { SapiHeader::snapshot(NonNull::from(&mut raw)) };
+
+        assert_eq!(wrapper.as_str(), Some("Content-Type: text/html"));
+        assert_eq!(wrapper.as_name_value(), Some(("Content-Type", "text/html")));
+        assert_eq!(wrapper.len(), 23);
+        assert!(!wrapper.is_empty());
+    }
+
+    #[test]
+    fn test_sapi_header_null_pointer() {
+        let mut raw = sapi_header_struct {
+            header: std::ptr::null_mut(),
+            header_len: 0,
+        };
+        // SAFETY: `raw` is readable and its nested header pointer is null.
+        let wrapper = unsafe { SapiHeader::snapshot(NonNull::from(&mut raw)) };
+
+        assert_eq!(wrapper.as_str(), None);
+        assert_eq!(wrapper.as_name_value(), None);
+        assert!(wrapper.is_empty());
+    }
+
+    #[test]
+    fn test_sapi_header_no_colon() {
+        let header_bytes = b"InvalidHeader";
+        let mut raw = sapi_header_struct {
+            header: header_bytes.as_ptr().cast_mut().cast::<c_char>(),
+            header_len: header_bytes.len(),
+        };
+        // SAFETY: `raw` and its header buffer are readable for the copy.
+        let wrapper = unsafe { SapiHeader::snapshot(NonNull::from(&mut raw)) };
+
+        assert_eq!(wrapper.as_str(), Some("InvalidHeader"));
+        assert_eq!(wrapper.as_name_value(), None);
+    }
+
+    #[test]
+    fn test_sapi_header_debug_format() {
+        let header_bytes = b"X-Custom: value";
+        let mut raw = sapi_header_struct {
+            header: header_bytes.as_ptr().cast_mut().cast::<c_char>(),
+            header_len: header_bytes.len(),
+        };
+        // SAFETY: `raw` and its header buffer are readable for the copy.
+        let wrapper = unsafe { SapiHeader::snapshot(NonNull::from(&mut raw)) };
+        let debug = format!("{wrapper:?}");
+        assert!(debug.contains("X-Custom: value"));
+    }
+
+    #[test]
+    fn test_sapi_headers_response_code() {
+        // SAFETY: A zeroed C SAPI headers struct has valid null/zero fields.
+        let mut raw: sapi_headers_struct = unsafe { std::mem::zeroed() };
+        raw.http_response_code = 404;
+        // SAFETY: `raw` is readable for the copy.
+        let wrapper = unsafe { SapiHeaders::snapshot(NonNull::from(&mut raw)) };
+
+        assert_eq!(wrapper.http_response_code(), 404);
+    }
+
+    #[test]
+    fn test_sapi_headers_debug_format() {
+        // SAFETY: A zeroed C SAPI headers struct has valid null/zero fields.
+        let mut raw: sapi_headers_struct = unsafe { std::mem::zeroed() };
+        raw.http_response_code = 200;
+        // SAFETY: `raw` is readable for the copy.
+        let wrapper = unsafe { SapiHeaders::snapshot(NonNull::from(&mut raw)) };
+        let debug = format!("{wrapper:?}");
+        assert!(debug.contains("200"));
+    }
+
+    #[test]
+    fn null_header_buffer_preserves_declared_nonzero_length() {
+        let mut raw = sapi_header_struct {
+            header: std::ptr::null_mut(),
+            header_len: 12,
+        };
+        // SAFETY: `raw` is readable and its nested header pointer is null.
+        let wrapper = unsafe { SapiHeader::snapshot(NonNull::from(&mut raw)) };
+
+        assert_eq!(wrapper.as_str(), None);
+        assert_eq!(wrapper.as_name_value(), None);
+        assert_eq!(wrapper.len(), 12);
+        assert!(!wrapper.is_empty());
+    }
+
+    #[test]
+    fn nonnull_zero_length_header_is_not_dereferenced() {
+        let mut raw = sapi_header_struct {
+            header: NonNull::<u8>::dangling().as_ptr().cast::<c_char>(),
+            header_len: 0,
+        };
+        // SAFETY: `raw` is readable; a non-null pointer is readable for zero bytes.
+        let wrapper = unsafe { SapiHeader::snapshot(NonNull::from(&mut raw)) };
+
+        assert_eq!(wrapper.as_str(), None);
+        assert_eq!(wrapper.len(), 0);
+        assert!(wrapper.is_empty());
+    }
+
+    #[test]
+    fn invalid_utf8_header_has_no_string_view() {
+        let header_bytes = [0xff, 0xfe];
+        let mut raw = sapi_header_struct {
+            header: header_bytes.as_ptr().cast_mut().cast::<c_char>(),
+            header_len: header_bytes.len(),
+        };
+        // SAFETY: `raw` and its header buffer are readable for the copy.
+        let wrapper = unsafe { SapiHeader::snapshot(NonNull::from(&mut raw)) };
+
+        assert_eq!(wrapper.as_str(), None);
+        assert_eq!(wrapper.as_name_value(), None);
+        assert_eq!(wrapper.len(), 2);
+    }
+
+    #[test]
+    fn snapshots_own_copied_source_data() {
+        let header = {
+            let mut header_bytes = b"X-Owned: original".to_vec();
+            let mut raw_header = sapi_header_struct {
+                header: header_bytes.as_mut_ptr().cast::<c_char>(),
+                header_len: header_bytes.len(),
+            };
+            // SAFETY: `raw_header` and its header buffer are readable for the copy.
+            let header = unsafe { SapiHeader::snapshot(NonNull::from(&mut raw_header)) };
+
+            header_bytes.fill(b'X');
+            raw_header.header = std::ptr::null_mut();
+            raw_header.header_len = 0;
+            assert!(raw_header.header.is_null());
+            assert_eq!(raw_header.header_len, 0);
+            drop(header_bytes);
+            header
+        };
+
+        assert_eq!(header.as_str(), Some("X-Owned: original"));
+        assert_eq!(header.as_name_value(), Some(("X-Owned", "original")));
+
+        let headers = {
+            // SAFETY: A zeroed C SAPI headers struct has valid null/zero fields.
+            let mut raw_headers: sapi_headers_struct = unsafe { std::mem::zeroed() };
+            raw_headers.http_response_code = 201;
+            // SAFETY: `raw_headers` is readable for the copy.
+            let headers = unsafe { SapiHeaders::snapshot(NonNull::from(&mut raw_headers)) };
+            raw_headers.http_response_code = 500;
+            assert_eq!(raw_headers.http_response_code, 500);
+            headers
+        };
+
+        assert_eq!(headers.http_response_code(), 201);
+    }
+
+    #[test]
+    fn null_trampoline_inputs_take_fast_paths() {
+        assert_eq!(
+            trampoline_send_headers::<PanicSapi>(std::ptr::null_mut()),
+            SendHeadersResult::Failed.into_c_int()
+        );
+        trampoline_send_header::<PanicSapi>(std::ptr::null_mut(), std::ptr::null_mut());
+    }
+
+    #[test]
+    fn send_headers_result_mappings_are_stable() {
+        assert_eq!(SendHeadersResult::SentSuccessfully.into_c_int(), 1);
+        assert_eq!(SendHeadersResult::DoSend.into_c_int(), 2);
+        assert_eq!(SendHeadersResult::Failed.into_c_int(), 3);
+    }
 }

--- a/tests/sapi.rs
+++ b/tests/sapi.rs
@@ -16,7 +16,7 @@ use ext_php_rs::embed::{
 };
 use ext_php_rs::ffi::{
     ZEND_RESULT_CODE_SUCCESS, php_module_shutdown, php_module_startup, php_request_shutdown,
-    php_request_startup, sapi_header_struct, sapi_headers_struct, sapi_shutdown, sapi_startup,
+    php_request_startup, sapi_shutdown, sapi_startup,
 };
 use ext_php_rs::prelude::*;
 use ext_php_rs::zend::try_catch_first;
@@ -580,77 +580,6 @@ fn test_full_sapi_worker_flow() {
     unsafe {
         ext_php_rs_sapi_shutdown();
     }
-}
-
-#[test]
-fn test_sapi_header_valid() {
-    let header_bytes = b"Content-Type: text/html";
-    let mut raw = sapi_header_struct {
-        header: header_bytes.as_ptr() as *mut c_char,
-        header_len: header_bytes.len(),
-    };
-    let wrapper = SapiHeader::from_raw(&raw mut raw);
-
-    assert_eq!(wrapper.as_str(), Some("Content-Type: text/html"));
-    assert_eq!(wrapper.as_name_value(), Some(("Content-Type", "text/html")));
-    assert_eq!(wrapper.len(), 23);
-    assert!(!wrapper.is_empty());
-}
-
-#[test]
-fn test_sapi_header_null_pointer() {
-    let mut raw = sapi_header_struct {
-        header: std::ptr::null_mut(),
-        header_len: 0,
-    };
-    let wrapper = SapiHeader::from_raw(&raw mut raw);
-
-    assert_eq!(wrapper.as_str(), None);
-    assert_eq!(wrapper.as_name_value(), None);
-    assert!(wrapper.is_empty());
-}
-
-#[test]
-fn test_sapi_header_no_colon() {
-    let header_bytes = b"InvalidHeader";
-    let mut raw = sapi_header_struct {
-        header: header_bytes.as_ptr() as *mut c_char,
-        header_len: header_bytes.len(),
-    };
-    let wrapper = SapiHeader::from_raw(&raw mut raw);
-
-    assert_eq!(wrapper.as_str(), Some("InvalidHeader"));
-    assert_eq!(wrapper.as_name_value(), None);
-}
-
-#[test]
-fn test_sapi_header_debug_format() {
-    let header_bytes = b"X-Custom: value";
-    let mut raw = sapi_header_struct {
-        header: header_bytes.as_ptr() as *mut c_char,
-        header_len: header_bytes.len(),
-    };
-    let wrapper = SapiHeader::from_raw(&raw mut raw);
-    let debug = format!("{wrapper:?}");
-    assert!(debug.contains("X-Custom: value"));
-}
-
-#[test]
-fn test_sapi_headers_response_code() {
-    let mut raw: sapi_headers_struct = unsafe { std::mem::zeroed() };
-    raw.http_response_code = 404;
-    let wrapper = SapiHeaders::from_raw(&raw mut raw);
-
-    assert_eq!(wrapper.http_response_code(), 404);
-}
-
-#[test]
-fn test_sapi_headers_debug_format() {
-    let mut raw: sapi_headers_struct = unsafe { std::mem::zeroed() };
-    raw.http_response_code = 200;
-    let wrapper = SapiHeaders::from_raw(&raw mut raw);
-    let debug = format!("{wrapper:?}");
-    assert!(debug.contains("200"));
 }
 
 #[test]

--- a/tests/sapi_header_safety.rs
+++ b/tests/sapi_header_safety.rs
@@ -1,0 +1,362 @@
+//! Verifies that raw SAPI header constructors are not exposed publicly.
+
+use serde_json::Value;
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const HEADER_CALL_LINE: u64 = 8;
+const HEADERS_CALL_LINE: u64 = 9;
+
+#[test]
+fn raw_sapi_header_constructors_are_not_public() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let target_dir = target_dir(&manifest_dir);
+    let fixture = FixtureDir::new(&target_dir);
+    let fixture_dir = fixture.path();
+    let fixture_src_dir = fixture_dir.join("src");
+    let fixture_target_dir = fixture_dir.join("target");
+    fs::create_dir_all(&fixture_src_dir).expect("failed to create fixture source directory");
+
+    let dependency_path = serde_json::to_string(
+        manifest_dir
+            .to_str()
+            .expect("crate path must contain valid UTF-8"),
+    )
+    .expect("failed to quote dependency path");
+    let fixture_manifest = format!(
+        r#"[package]
+name = "sapi-header-safety-fixture"
+version = "0.0.0"
+edition = "2024"
+
+[workspace]
+
+[dependencies]
+ext-php-rs = {{ path = {dependency_path}, features = ["embed"] }}
+"#,
+    );
+    fs::write(fixture_dir.join("Cargo.toml"), fixture_manifest)
+        .expect("failed to write fixture manifest");
+
+    let fixture_source = r"use ext_php_rs::embed::{SapiHeader, SapiHeaders};
+use ext_php_rs::ffi::{sapi_header_struct, sapi_headers_struct};
+
+fn main() {
+    let header = std::ptr::null_mut::<sapi_header_struct>();
+    let headers = std::ptr::null_mut::<sapi_headers_struct>();
+
+    let _ = SapiHeader::from_raw(header);
+    let _ = SapiHeaders::from_raw(headers);
+}
+";
+    let fixture_main = fixture_src_dir.join("main.rs");
+    fs::write(&fixture_main, fixture_source).expect("failed to write fixture source");
+    let root_lock =
+        fs::read(manifest_dir.join("Cargo.lock")).expect("failed to read root Cargo.lock");
+    let root_lock_text =
+        std::str::from_utf8(&root_lock).expect("root Cargo.lock is not valid UTF-8");
+    assert!(
+        !root_lock_text.contains("name = \"sapi-header-safety-fixture\""),
+        "root Cargo.lock unexpectedly contains the generated fixture package"
+    );
+    let fixture_lock_path = fixture_dir.join("Cargo.lock");
+    fs::write(&fixture_lock_path, &root_lock).expect("failed to copy root Cargo.lock into fixture");
+
+    let cargo = env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
+    let fixture_manifest_path = fixture_dir.join("Cargo.toml");
+    let initial_output =
+        run_fixture_check(&cargo, &fixture_manifest_path, &fixture_target_dir, false);
+    let adapted_lock = fs::read(&fixture_lock_path)
+        .expect("offline fixture check did not produce an adapted Cargo.lock");
+    assert_ne!(
+        adapted_lock, root_lock,
+        "offline fixture check did not adapt the copied workspace lock"
+    );
+    audit_adapted_lock(root_lock_text, &adapted_lock);
+    assert_expected_compile_failure(&initial_output, &fixture_main, "initial offline check");
+
+    let locked_output =
+        run_fixture_check(&cargo, &fixture_manifest_path, &fixture_target_dir, true);
+    assert_expected_compile_failure(&locked_output, &fixture_main, "locked offline check");
+    println!(
+        "audited the offline-adapted lock and accepted exactly two E0599 diagnostics pinned to SapiHeader line {HEADER_CALL_LINE} and SapiHeaders line {HEADERS_CALL_LINE}"
+    );
+}
+
+#[test]
+fn fixture_directories_are_unique_and_cleaned_up() {
+    let target_dir = target_dir(Path::new(env!("CARGO_MANIFEST_DIR")));
+    let first_path;
+    let second_path;
+    {
+        let first = FixtureDir::new(&target_dir);
+        let second = FixtureDir::new(&target_dir);
+        first_path = first.path().to_owned();
+        second_path = second.path().to_owned();
+
+        assert_ne!(first_path, second_path);
+        assert!(first_path.is_dir());
+        assert!(second_path.is_dir());
+    }
+    assert!(!first_path.exists());
+    assert!(!second_path.exists());
+
+    let mut panic_path = None;
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let fixture = FixtureDir::new(&target_dir);
+        panic_path = Some(fixture.path().to_owned());
+        panic!("exercise fixture cleanup during unwinding");
+    }));
+    assert!(result.is_err());
+    assert!(
+        !panic_path
+            .expect("panic fixture path was not captured")
+            .exists()
+    );
+}
+
+struct FixtureDir {
+    path: PathBuf,
+}
+
+impl FixtureDir {
+    fn new(parent: &Path) -> Self {
+        static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+
+        fs::create_dir_all(parent).expect("failed to create parent target directory");
+        for _ in 0..100 {
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos();
+            let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+            let path = parent.join(format!(
+                "sapi_header_safety_fixture-{}-{timestamp}-{id}",
+                std::process::id()
+            ));
+            match fs::create_dir(&path) {
+                Ok(()) => return Self { path },
+                Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
+                Err(error) => panic!("failed to create unique fixture directory: {error}"),
+            }
+        }
+        panic!("failed to create a unique fixture directory after 100 attempts");
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for FixtureDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn package_stanza<'a>(lock: &'a str, name: &str) -> &'a str {
+    &lock[package_range(lock, name)]
+}
+
+fn package_range(lock: &str, name: &str) -> std::ops::Range<usize> {
+    let marker = format!("[[package]]\nname = \"{name}\"\n");
+    let start = unique_marker_index(lock, &marker, name);
+    let after_marker = start + marker.len();
+    let end = lock[after_marker..]
+        .find("[[package]]\n")
+        .map_or_else(|| lock.len(), |offset| after_marker + offset);
+    start..end
+}
+
+fn unique_marker_index(lock: &str, marker: &str, package: &str) -> usize {
+    let mut matches = lock.match_indices(marker);
+    let index = matches.next().map_or_else(
+        || panic!("root Cargo.lock has no package stanza for {package}"),
+        |(index, _)| index,
+    );
+    assert!(
+        matches.next().is_none(),
+        "root Cargo.lock has duplicate package stanzas for {package}"
+    );
+    index
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct RegistryPackageIdentity<'a> {
+    name: &'a str,
+    version: &'a str,
+    source: &'a str,
+    checksum: &'a str,
+}
+
+fn audit_adapted_lock(root_lock: &str, adapted_lock: &[u8]) {
+    let adapted_lock = std::str::from_utf8(adapted_lock)
+        .expect("offline-adapted fixture Cargo.lock is not valid UTF-8");
+    for package in [
+        "sapi-header-safety-fixture",
+        "ext-php-rs",
+        "ext-php-rs-build",
+        "ext-php-rs-derive",
+    ] {
+        let _ = package_stanza(adapted_lock, package);
+    }
+    for removed_workspace_root in ["cargo-php", "tests"] {
+        let marker = format!("[[package]]\nname = \"{removed_workspace_root}\"\n");
+        assert!(
+            !adapted_lock.contains(&marker),
+            "offline-adapted lock retained unrelated workspace root {removed_workspace_root}"
+        );
+    }
+
+    let root_registry = registry_package_identities(root_lock);
+    for adapted in registry_package_identities(adapted_lock) {
+        let matches = root_registry
+            .iter()
+            .filter(|root| *root == &adapted)
+            .count();
+        assert_eq!(
+            matches, 1,
+            "offline lock drift: adapted registry package has no unique exact root identity: {adapted:?}"
+        );
+    }
+}
+
+fn registry_package_identities(lock: &str) -> Vec<RegistryPackageIdentity<'_>> {
+    lock.split("[[package]]\n")
+        .skip(1)
+        .filter_map(|stanza| {
+            let source = lock_string_field(stanza, "source")?;
+            source
+                .starts_with("registry+")
+                .then(|| RegistryPackageIdentity {
+                    name: lock_string_field(stanza, "name")
+                        .expect("registry package has no name in Cargo.lock"),
+                    version: lock_string_field(stanza, "version")
+                        .expect("registry package has no version in Cargo.lock"),
+                    source,
+                    checksum: lock_string_field(stanza, "checksum")
+                        .expect("registry package has no checksum in Cargo.lock"),
+                })
+        })
+        .collect()
+}
+
+fn lock_string_field<'a>(stanza: &'a str, field: &str) -> Option<&'a str> {
+    let prefix = format!("{field} = \"");
+    stanza
+        .lines()
+        .find_map(|line| line.strip_prefix(&prefix)?.strip_suffix('"'))
+}
+
+fn run_fixture_check(
+    cargo: &OsString,
+    manifest_path: &Path,
+    target_dir: &Path,
+    locked: bool,
+) -> std::process::Output {
+    let mut command = Command::new(cargo);
+    command.arg("check");
+    if locked {
+        command.arg("--locked");
+    }
+    command
+        .arg("--offline")
+        .arg("--message-format=json")
+        .arg("--manifest-path")
+        .arg(manifest_path)
+        .env("CARGO_TARGET_DIR", target_dir)
+        .output()
+        .expect("failed to run offline cargo check for fixture")
+}
+
+fn assert_expected_compile_failure(
+    output: &std::process::Output,
+    fixture_main: &Path,
+    phase: &str,
+) {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let command_output = format!("{phase}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    assert!(
+        !output.status.success(),
+        "fixture unexpectedly compiled successfully\n{command_output}"
+    );
+
+    let errors: Vec<Value> = stdout
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .filter(|message| message["reason"] == "compiler-message")
+        .filter_map(|message| message.get("message").cloned())
+        .filter(|diagnostic| diagnostic["level"] == "error")
+        .collect();
+
+    assert_eq!(
+        errors.len(),
+        2,
+        "expected exactly two compiler errors\n{command_output}"
+    );
+    assert!(
+        errors.iter().all(|error| error["code"]["code"] == "E0599"),
+        "expected only E0599 compiler errors\n{command_output}"
+    );
+    assert_diagnostic(
+        &errors,
+        fixture_main,
+        HEADER_CALL_LINE,
+        "SapiHeader",
+        &command_output,
+    );
+    assert_diagnostic(
+        &errors,
+        fixture_main,
+        HEADERS_CALL_LINE,
+        "SapiHeaders",
+        &command_output,
+    );
+}
+
+fn target_dir(manifest_dir: &Path) -> PathBuf {
+    match env::var_os("CARGO_TARGET_DIR").map(PathBuf::from) {
+        Some(path) if path.is_absolute() => path,
+        Some(path) => manifest_dir.join(path),
+        None => manifest_dir.join("target"),
+    }
+}
+
+fn assert_diagnostic(
+    errors: &[Value],
+    fixture_main: &Path,
+    expected_line: u64,
+    expected_type: &str,
+    command_output: &str,
+) {
+    let matching: Vec<&Value> = errors
+        .iter()
+        .filter(|error| {
+            let rendered = error["rendered"].as_str().unwrap_or_default();
+            rendered.contains("from_raw")
+                && rendered.contains(expected_type)
+                && error["spans"].as_array().is_some_and(|spans| {
+                    spans.iter().any(|span| {
+                        span["is_primary"] == true
+                            && span["line_start"].as_u64() == Some(expected_line)
+                            && span["file_name"]
+                                .as_str()
+                                .is_some_and(|file| fixture_main.ends_with(file))
+                    })
+                })
+        })
+        .collect();
+
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected one pinned E0599 diagnostic for {expected_type} on line {expected_line}\n{command_output}"
+    );
+}


### PR DESCRIPTION
## Description

Copy SAPI header callback data into owned Rust snapshots before invoking safe callbacks and remove the public raw-pointer constructors. Zend pointers now stay inside the FFI boundary, with v0.16 migration guidance for direct constructor users.

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have added tests that prove my code works as expected.
- [x] I have added documentation if applicable.
- [x] I have added a [migration guide](CONTRIBUTING.md#breaking-changes) if applicable.
