### PR TITLE
chore(deps): update syn to 3 and darling to 0.24

### DIFF
--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -16,8 +16,8 @@ edition = "2024"
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0.100", features = ["full", "extra-traits", "printing"] }
-darling = "0.23"
+syn = { version = "3.0.3", features = ["full", "extra-traits", "printing"] }
+darling = "0.24"
 quote = "1.0.9"
 proc-macro2 = "1.0.26"
 convert_case = "0.11.0"
@@ -27,6 +27,16 @@ itertools = "0.15.0"
 missing_docs = "warn"
 
 [dev-dependencies]
+# runtime-macros 1.1.1 declares syn 2 without the `full` and `derive` features it
+# uses, relying on unification with the crate under test. Now that this crate is
+# on syn 3, enable them explicitly.
+syn2 = { package = "syn", version = "2", features = [
+    "full",
+    "derive",
+    "parsing",
+    "visit",
+    "extra-traits",
+] }
 glob = "0.3.2"
 macrotest = "1.1.0"
 runtime-macros = "1.1.1"

--- a/crates/macros/src/extern_.rs
+++ b/crates/macros/src/extern_.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
-    ForeignItemFn, ItemForeignMod, ReturnType, Signature, Token, punctuated::Punctuated,
+    ForeignItemFn, ItemForeignMod, ReturnType, Safety, Signature, Token, punctuated::Punctuated,
     spanned::Spanned as _, token::Unsafe,
 };
 
@@ -24,7 +24,7 @@ fn parse_function(mut func: ForeignItemFn) -> Result<TokenStream> {
     let ForeignItemFn {
         attrs, vis, sig, ..
     } = &mut func;
-    sig.unsafety = Some(Unsafe::default()); // Function must be unsafe.
+    sig.safety = Safety::Unsafe(Unsafe::default()); // Function must be unsafe.
 
     let Signature { ident, .. } = &sig;
 

--- a/crates/macros/src/function.rs
+++ b/crates/macros/src/function.rs
@@ -71,7 +71,7 @@ pub fn parser(mut input: ItemFn) -> Result<TokenStream> {
     input.attrs.retain(|attr| !attr.path().is_ident("php"));
 
     let args = Args::parse_from_fnargs(input.sig.inputs.iter(), php_attr.defaults)?;
-    if let Some(ReceiverArg { span, .. }) = args.receiver {
+    if let Some(ReceiverArg { span }) = args.receiver {
         bail!(span => "Receiver arguments are invalid on PHP functions. See `#[php_impl]`.");
     }
 
@@ -879,7 +879,6 @@ impl<'a> Function<'a> {
 
 #[derive(Debug)]
 pub struct ReceiverArg {
-    pub _mutable: bool,
     pub span: Span,
 }
 
@@ -911,13 +910,13 @@ impl<'a> Args<'a> {
         for arg in args {
             match arg {
                 FnArg::Receiver(receiver) => {
-                    if receiver.reference.is_none() {
+                    let syn::ReceiverKind::Reference(..) = &receiver.kind else {
                         bail!(receiver => "PHP objects are heap-allocated and cannot be passed by value. Try using `&self` or `&mut self`.");
-                    } else if result.receiver.is_some() {
+                    };
+                    if result.receiver.is_some() {
                         bail!(receiver => "Too many receivers specified.")
                     }
                     result.receiver.replace(ReceiverArg {
-                        _mutable: receiver.mutability.is_some(),
                         span: receiver.span(),
                     });
                 }
@@ -1316,6 +1315,19 @@ pub fn type_is_nullable(ty: &Type) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_only_reference_receivers_are_accepted() {
+        let by_ref: FnArg = syn::parse_quote!(&self);
+        let by_mut: FnArg = syn::parse_quote!(&mut self);
+        let by_value: FnArg = syn::parse_quote!(self);
+        let boxed: FnArg = syn::parse_quote!(self: Box<Self>);
+
+        assert!(Args::parse_from_fnargs([&by_ref].into_iter(), HashMap::new()).is_ok());
+        assert!(Args::parse_from_fnargs([&by_mut].into_iter(), HashMap::new()).is_ok());
+        assert!(Args::parse_from_fnargs([&by_value].into_iter(), HashMap::new()).is_err());
+        assert!(Args::parse_from_fnargs([&boxed].into_iter(), HashMap::new()).is_err());
+    }
 
     #[test]
     fn test_expr_to_php_stub_strips_numeric_suffixes() {

--- a/crates/macros/src/impl_interface.rs
+++ b/crates/macros/src/impl_interface.rs
@@ -51,7 +51,7 @@ const INTERNAL_INTERFACE_NAME_PREFIX: &str = "PhpInterface";
 pub fn parser(args: PhpImplInterfaceArgs, input: &ItemImpl) -> Result<TokenStream> {
     let change_method_case = args.change_method_case.unwrap_or(RenameRule::Camel);
     // Extract the trait being implemented
-    let Some((_, trait_path, _)) = &input.trait_ else {
+    let Some((trait_path, _)) = &input.trait_ else {
         bail!(input => "`#[php_impl_interface]` can only be used on trait implementations (e.g., `impl SomeTrait for SomeStruct`)");
     };
 

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -1,5 +1,4 @@
 //! Macros for the `php-ext` crate.
-#![allow(clippy::needless_continue)] // TODO: Remove this once darling is updated to remove clippy issues
 mod class;
 mod constant;
 mod enum_;

--- a/crates/macros/src/syn_ext.rs
+++ b/crates/macros/src/syn_ext.rs
@@ -10,7 +10,7 @@ impl DropLifetimes for syn::Type {
     fn drop_lifetimes(&mut self) {
         match self {
             syn::Type::Array(ty) => ty.drop_lifetimes(),
-            syn::Type::BareFn(ty) => ty.drop_lifetimes(),
+            syn::Type::FnPtr(ty) => ty.drop_lifetimes(),
             syn::Type::Group(ty) => ty.drop_lifetimes(),
             syn::Type::ImplTrait(ty) => ty.drop_lifetimes(),
             syn::Type::Paren(ty) => ty.drop_lifetimes(),
@@ -31,7 +31,7 @@ impl DropLifetimes for syn::TypeArray {
     }
 }
 
-impl DropLifetimes for syn::TypeBareFn {
+impl DropLifetimes for syn::TypeFnPtr {
     fn drop_lifetimes(&mut self) {
         self.lifetimes = None;
         self.inputs
@@ -41,7 +41,7 @@ impl DropLifetimes for syn::TypeBareFn {
     }
 }
 
-impl DropLifetimes for syn::BareFnArg {
+impl DropLifetimes for syn::NamedArg {
     fn drop_lifetimes(&mut self) {
         self.ty.drop_lifetimes();
     }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783776592,
-        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "lastModified": 1785454630,
+        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783834461,
-        "narHash": "sha256-FCmrs1StAghJDKfqy56KM96KZtxpYzgeq6zM3QO8wjA=",
+        "lastModified": 1785476452,
+        "narHash": "sha256-/CXwCFPS41rb/JI2VitKCgVK6V5E6/sfw5ke3B9zyVQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a286e5b998e852297a403786f063fb2c9fe7f57a",
+        "rev": "6ef009bf4c4873cdc1a621826722bdea7c03e62c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Description

Moves `ext-php-rs-derive` from syn 2 to syn 3. darling 0.24 is the first release on syn 3, so both bumps land together; that also lets the `clippy::needless_continue` allow in `lib.rs` go.

Four API changes touch us:

- `Type::BareFn` → `Type::FnPtr`, `TypeBareFn` → `TypeFnPtr`, `BareFnArg` → `NamedArg` (`syn_ext.rs`)
- `Signature.unsafety` → `Signature.safety: Safety` (`extern_.rs`)
- `ItemImpl.trait_` lost its polarity element, 3-tuple → 2-tuple (`impl_interface.rs`)
- `Receiver.reference` → `ReceiverKind` enum (`function.rs`)

The last one has a trap: syn 3 moves the `mut` of `&mut self` into `ReceiverKind::Reference(_, _, mut)`, leaving `Receiver.mutability` as `None`. Reading `receiver.mutability` still compiles and is silently wrong. `ReceiverArg._mutable` was never read, so it goes rather than carrying a broken dead field forward. Behaviour is unchanged, and the previously untested rejection paths now have a test.

The `syn2` dev-dependency is a workaround: `runtime-macros` 1.1.1 declares syn 2 without the `full` and `derive` features it uses, relying on unification with this crate. Enabling them explicitly keeps the nightly `macrotest` leg compiling.

`flake.lock` is refreshed in passing since the devshell's pinned Rust had gone stale.

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have added tests that prove my code works as expected.
- [ ] I have added documentation if applicable.
- [ ] I have added a [migration guide](CONTRIBUTING.md#breaking-changes) if applicable.
