### PR TITLE
fix: return errors instead of panicking on engine and user input

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,19 @@
       php-dev = php.unwrapped.dev;
       php-zts = (pkgs.php.override { ztsSupport = true; }).buildEnv { embedSupport = true; };
       php-zts-dev = php-zts.unwrapped.dev;
+      # ZEND_DEBUG build. Zend assertions such as the non-null handler check in
+      # `zend_call_known_function` are compiled out of a release PHP, so bugs that
+      # segfault in production only assert here.
+      withDebug = phpPkg: phpPkg.override {
+        phpAttrsOverrides = final: prev: {
+          configureFlags = prev.configureFlags ++ [ "--enable-debug" ];
+        };
+      };
+      php-debug = (withDebug pkgs.php).buildEnv { embedSupport = true; };
+      php-debug-dev = php-debug.unwrapped.dev;
+      php-zts-debug =
+        (withDebug (pkgs.php.override { ztsSupport = true; })).buildEnv { embedSupport = true; };
+      php-zts-debug-dev = php-zts-debug.unwrapped.dev;
       # mago is not packaged in nixpkgs; pin the upstream static musl binary so
       # local dev and CI (nhedger/setup-mago) run the exact same version.
       mago = pkgs.stdenvNoCC.mkDerivation rec {
@@ -58,6 +71,8 @@
       devShells.${system} = {
         default = mkShellFor php php-dev;
         zts = mkShellFor php-zts php-zts-dev;
+        debug = mkShellFor php-debug php-debug-dev;
+        zts-debug = mkShellFor php-zts-debug php-zts-debug-dev;
       };
     };
 }

--- a/src/builders/class.rs
+++ b/src/builders/class.rs
@@ -248,17 +248,15 @@ impl ClassBuilder {
                 // are called if a bailout occurs (issue #537)
                 let catch_result = try_catch(AssertUnwindSafe(|| {
                     let Some(ConstructorMeta { constructor, .. }) = T::constructor() else {
-                        PhpException::default("You cannot instantiate this class from PHP.".into())
-                            .throw()
-                            .expect("Failed to throw exception when constructing class");
+                        let _ = PhpException::default("You cannot instantiate this class from PHP.".into())
+                            .throw();
                         return;
                     };
 
                     let this = match constructor(ex) {
                         ConstructorResult::Ok(this) => this,
                         ConstructorResult::Exception(e) => {
-                            e.throw()
-                                .expect("Failed to throw exception while constructing class");
+                            let _ = e.throw();
                             return;
                         }
                         ConstructorResult::ArgError => return,
@@ -267,9 +265,8 @@ impl ClassBuilder {
                     // Use get_object_uninit because the Rust backing is not yet initialized.
                     // We need access to the ZendClassObject to call initialize() on it.
                     let Some(this_obj) = ex.get_object_uninit::<T>() else {
-                        PhpException::default("Failed to retrieve reference to `this` object.".into())
-                            .throw()
-                            .expect("Failed to throw exception while constructing class");
+                        let _ = PhpException::default("Failed to retrieve reference to `this` object.".into())
+                            .throw();
                         return;
                     };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@
 
 use std::{
     error::Error as ErrorTrait,
-    ffi::{CString, NulError},
+    ffi::{CString, NulError, c_int},
     fmt::Display,
     num::TryFromIntError,
 };
@@ -12,7 +12,7 @@ use crate::{
     exception::PhpException,
     ffi::php_error_docref,
     flags::{ClassFlags, DataType, ErrorType, ZvalTypeFlags},
-    types::ZendObject,
+    types::{ZendObject, Zval},
 };
 
 /// The main result type which is passed by the library.
@@ -60,6 +60,11 @@ pub enum Error {
     Callable,
     /// An object was expected.
     Object,
+    /// The object's class does not implement `__toString()`, so it cannot be
+    /// converted into a string.
+    ///
+    /// The enum carries the name of the class.
+    NotStringable(String),
     /// An invalid exception type was thrown.
     InvalidException(ClassFlags),
     /// Converting integer arguments resulted in an overflow.
@@ -101,6 +106,9 @@ impl Display for Error {
             Error::InvalidUtf8 => write!(f, "Invalid Utf8 byte sequence."),
             Error::Callable => write!(f, "Could not call given function."),
             Error::Object => write!(f, "An object was expected."),
+            Error::NotStringable(class) => {
+                write!(f, "{class} does not implement __toString().")
+            }
             Error::InvalidException(flags) => {
                 write!(f, "Invalid exception type was thrown: {flags:?}")
             }
@@ -143,7 +151,19 @@ impl From<TryFromIntError> for Error {
 
 impl From<Error> for PhpException {
     fn from(err: Error) -> Self {
-        Self::default(err.to_string())
+        match err {
+            Error::Exception(mut obj) => {
+                let message = obj.get_class_name().unwrap_or_else(|_| "Exception".into());
+                let mut zv = Zval::new();
+                // `set_object` increments the refcount and the `ZBox` releases its own
+                // when it drops, so the zval ends up owning exactly the one reference
+                // `obj` held. Attaching it keeps the original class, message and stack
+                // trace instead of flattening them into a string.
+                zv.set_object(&mut obj);
+                Self::default(message).with_object(zv)
+            }
+            err => Self::default(err.to_string()),
+        }
     }
 }
 
@@ -151,19 +171,21 @@ impl From<Error> for PhpException {
 ///
 /// See specific error type descriptions at <https://www.php.net/manual/en/errorfunc.constants.php>.
 ///
-/// # Panics
-///
-/// * If the error type bits exceed `i32::MAX`.
+/// Does nothing if `message` contains a NUL byte, or if the error type bits do not
+/// fit in a C `int`.
 pub fn php_error(type_: &ErrorType, message: &str) {
     let Ok(c_string) = CString::new(message) else {
         return;
     };
+    let Ok(bits) = c_int::try_from(type_.bits()) else {
+        return;
+    };
 
+    // SAFETY: `php_error_docref` is declared `PHP_ATTRIBUTE_FORMAT(printf, 3, 4)`, so
+    // `message` must be passed as a `%s` argument and never as the format itself,
+    // which would interpret `%` sequences in it as varargs directives. Both pointers
+    // are NUL-terminated and outlive the call.
     unsafe {
-        php_error_docref(
-            std::ptr::null(),
-            type_.bits().try_into().expect("Error type flags overflown"),
-            c_string.as_ptr(),
-        );
+        php_error_docref(std::ptr::null(), bits, c"%s".as_ptr(), c_string.as_ptr());
     }
 }

--- a/src/types/object.rs
+++ b/src/types/object.rs
@@ -773,11 +773,35 @@ impl IntoZval for &mut ZendObject {
 }
 
 impl FromZendObject<'_> for String {
+    /// Converts the object into a string by calling its `__toString()` method.
+    ///
+    /// # Errors
+    ///
+    /// * [`Error::InvalidPointer`] - If the object has no class entry.
+    /// * [`Error::NotStringable`] - If the class does not implement `__toString()`.
+    /// * [`Error::Exception`] - If `__toString()` threw an exception.
+    /// * [`Error::ZvalConversion`] - If `__toString()` did not return a string.
     fn from_zend_object(obj: &ZendObject) -> Result<Self> {
+        // SAFETY: every object the engine constructs carries a class entry, but a
+        // `ZendObject` reference can be fabricated, so this is checked not trusted.
+        let ce = unsafe { obj.ce.as_ref() }.ok_or(Error::InvalidPointer)?;
+
+        // `zend_call_known_function` only asserts a non-null handler under
+        // `ZEND_DEBUG`, so passing one from a class without `__toString()` would
+        // segfault in a release build rather than fail.
+        if ce.__tostring.is_null() {
+            return Err(Error::NotStringable(
+                obj.get_class_name()
+                    .unwrap_or_else(|_| "<unknown class>".into()),
+            ));
+        }
+
         let mut ret = Zval::new();
+        // SAFETY: `__tostring` is non-null and belongs to `obj`'s own class entry,
+        // and `ret` is a live zval owned by this frame for the duration of the call.
         unsafe {
             zend_call_known_function(
-                (*obj.ce).__tostring,
+                ce.__tostring,
                 ptr::from_ref(obj).cast_mut(),
                 obj.ce,
                 &raw mut ret,
@@ -788,23 +812,11 @@ impl FromZendObject<'_> for String {
         }
 
         if let Some(err) = ExecutorGlobals::take_exception() {
-            // TODO: become an error
-            let class_name = obj.get_class_name();
-            panic!(
-                "Uncaught exception during call to {}::__toString(): {:?}",
-                class_name.expect("unable to determine class name"),
-                err
-            );
-        } else if let Some(output) = ret.extract() {
-            Ok(output)
-        } else {
-            // TODO: become an error
-            let class_name = obj.get_class_name();
-            panic!(
-                "{}::__toString() must return a string",
-                class_name.expect("unable to determine class name"),
-            );
+            return Err(Error::Exception(err));
         }
+
+        ret.extract()
+            .ok_or_else(|| Error::ZvalConversion(ret.get_type()))
     }
 }
 
@@ -825,4 +837,35 @@ pub enum PropertyQuery {
     NotEmpty = ZEND_ISEMPTY,
     /// Property exists.
     Exists = ZEND_PROPERTY_EXISTS,
+}
+
+#[cfg(all(test, feature = "embed"))]
+mod embed_tests {
+    use super::*;
+    use crate::embed::Embed;
+
+    fn extract_string(class: &str) -> Result<String> {
+        Embed::run_script("src/types/object.test.php").expect("failed to run test script");
+        let zval = Embed::eval(&format!("new {class}();")).expect("failed to instantiate class");
+        zval.object().expect("expected an object").extract()
+    }
+
+    #[test]
+    fn test_to_string_returns_the_string() {
+        let result: String = Embed::run(|| {
+            extract_string("StringableOk").expect("expected __toString to yield a string")
+        });
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn test_to_string_without_the_method_is_an_error() {
+        // Regression: `zend_call_known_function` only asserts a non-null handler under
+        // `ZEND_DEBUG`, so this used to segfault in release builds.
+        let class: String = Embed::run(|| match extract_string("NotStringableAtAll") {
+            Err(Error::NotStringable(class)) => class,
+            other => panic!("expected NotStringable, got {other:?}"),
+        });
+        assert_eq!(class, "NotStringableAtAll");
+    }
 }

--- a/src/types/object.test.php
+++ b/src/types/object.test.php
@@ -1,0 +1,14 @@
+<?php
+
+class StringableOk
+{
+    public function __toString(): string
+    {
+        return 'hello';
+    }
+}
+
+class NotStringableAtAll
+{
+    public int $x = 1;
+}

--- a/src/zend/globals.rs
+++ b/src/zend/globals.rs
@@ -113,28 +113,32 @@ impl ExecutorGlobals {
     /// Retrieves the ini values for all ini directives in the current executor
     /// context..
     ///
-    /// # Panics
-    ///
-    /// * If the ini directives are not a valid hash table.
-    /// * If the ini entry is not a string.
+    /// Returns an empty map if the ini directives have not been registered yet,
+    /// which is only the case before engine startup. Values that are not valid
+    /// UTF-8 are decoded lossily, since a `php.ini` directive may hold arbitrary
+    /// bytes; an absent value is reported as `None`.
     #[must_use]
     pub fn ini_values(&self) -> HashMap<String, Option<String>> {
-        let hash_table = unsafe { &*self.ini_directives };
+        // SAFETY: `EG(ini_directives)` is assigned during `zend_ini_startup` and
+        // remains valid for the lifetime of the request, but is null before that.
+        let Some(hash_table) = (unsafe { self.ini_directives.as_ref() }) else {
+            return HashMap::new();
+        };
         let mut ini_hash_map: HashMap<String, Option<String>> = HashMap::new();
-        for (key, value) in hash_table {
-            ini_hash_map.insert(key.to_string(), unsafe {
-                let ini_entry = &*value.ptr::<zend_ini_entry>().expect("Invalid ini entry");
-                if ini_entry.value.is_null() {
-                    None
-                } else {
-                    Some(
-                        (*ini_entry.value)
-                            .as_str()
-                            .expect("Ini value is not a string")
-                            .to_owned(),
-                    )
-                }
-            });
+        for (key, entry) in hash_table {
+            // SAFETY: entries are stored with `zend_hash_add_ptr` and owned by the
+            // hash table, which outlives this loop. A non-pointer zval is not
+            // reachable, but is skipped rather than trusted.
+            let value = unsafe {
+                let Some(entry) = entry.ptr::<zend_ini_entry>().and_then(|e| e.as_ref()) else {
+                    continue;
+                };
+                entry
+                    .value
+                    .as_ref()
+                    .map(|value| String::from_utf8_lossy(value.as_bytes()).into_owned())
+            };
+            ini_hash_map.insert(key.to_string(), value);
         }
         ini_hash_map
     }
@@ -384,8 +388,12 @@ impl ProcessGlobals {
         // $_SERVER is lazy-initted, we need to call zend_is_auto_global
         // if it's not already populated.
         if !self.http_globals[TRACK_VARS_SERVER as usize].is_array() {
-            let name = ZendStr::new("_SERVER", false).as_mut_ptr();
-            unsafe { zend_is_auto_global(name) };
+            let mut name = ZendStr::new("_SERVER", false);
+            // SAFETY: `name` is bound to a local so the `ZBox` outlives the call.
+            // Taking the pointer from a temporary would free the `zend_string` at the
+            // end of the statement and leave `zend_is_auto_global` reading freed
+            // Zend memory.
+            unsafe { zend_is_auto_global(name.as_mut_ptr()) };
         }
         if self.http_globals[TRACK_VARS_SERVER as usize].is_array() {
             self.http_globals[TRACK_VARS_SERVER as usize].array()
@@ -443,7 +451,11 @@ impl ProcessGlobals {
                     *zend_known_strings.add(_zend_known_string_id_ZEND_STR_AUTOGLOBAL_REQUEST as usize)
                 };
             } else {
-                let key = _zend_string::new("_REQUEST", false).as_mut_ptr();
+                // The `ZBox` must be bound so it outlives every use of `key` below;
+                // taking the pointer from a temporary would free the `zend_string` at
+                // the end of this statement.
+                let mut owned_key = _zend_string::new("_REQUEST", false);
+                let key = owned_key.as_mut_ptr();
             }
         };
 
@@ -951,5 +963,19 @@ mod embed_tests {
             CompilerGlobals::get_mut().in_compilation = state;
             assert_eq!(changed, !state);
         });
+    }
+
+    #[test]
+    fn test_ini_values_decodes_invalid_utf8_lossily() {
+        // A `php.ini` directive may hold arbitrary bytes, which used to panic.
+        let value: Option<String> = Embed::run(|| {
+            Embed::eval("ini_set('error_append_string', \"\\xFF\\xFE\");")
+                .expect("failed to set the ini value");
+            ExecutorGlobals::get()
+                .ini_values()
+                .remove("error_append_string")
+                .expect("the directive should be present")
+        });
+        assert_eq!(value.as_deref(), Some("\u{FFFD}\u{FFFD}"));
     }
 }

--- a/src/zend/handlers.rs
+++ b/src/zend/handlers.rs
@@ -525,19 +525,20 @@ unsafe fn check_property_access(flags: PropertyFlags, object_ce: *const zend_cla
 
 /// Throws an error for invalid property access.
 ///
+/// A property name may legally contain NUL bytes, since `zend_string` is length
+/// prefixed. Such a name cannot be interpolated into a C string, so the message
+/// falls back to a generic one rather than panicking inside the `extern "C"` frame
+/// this runs in.
+///
 /// # Safety
 ///
 /// Must only be called during PHP execution.
-///
-/// # Panics
-///
-/// Panics if the error message cannot be converted to a `CString`.
 unsafe fn throw_property_access_error(class_name: &str, prop_name: &str, is_private: bool) {
     let visibility = if is_private { "private" } else { "protected" };
     let message = CString::new(format!(
         "Cannot access {visibility} property {class_name}::${prop_name}"
     ))
-    .expect("Failed to create error message");
+    .unwrap_or_else(|_| c"Cannot access property".to_owned());
 
     unsafe {
         zend_throw_error(ptr::null_mut(), message.as_ptr());

--- a/tests/src/integration/object/mod.rs
+++ b/tests/src/integration/object/mod.rs
@@ -5,8 +5,15 @@ pub fn test_object(a: &mut ZendObject) -> &mut ZendObject {
     a
 }
 
+#[php_function]
+pub fn test_object_to_string(a: &mut ZendObject) -> PhpResult<String> {
+    a.extract::<String>().map_err(PhpException::from)
+}
+
 pub fn build_module(builder: ModuleBuilder) -> ModuleBuilder {
-    builder.function(wrap_function!(test_object))
+    builder
+        .function(wrap_function!(test_object))
+        .function(wrap_function!(test_object_to_string))
 }
 
 #[cfg(test)]
@@ -14,5 +21,10 @@ mod tests {
     #[test]
     fn object_works() {
         assert!(crate::integration::test::run_php("object/object.php"));
+    }
+
+    #[test]
+    fn object_to_string_works() {
+        assert!(crate::integration::test::run_php("object/to_string.php"));
     }
 }

--- a/tests/src/integration/object/to_string.php
+++ b/tests/src/integration/object/to_string.php
@@ -1,0 +1,39 @@
+<?php
+
+require __DIR__ . '/../_utils.php';
+
+class StringableOk
+{
+    public function __toString(): string
+    {
+        return 'hello';
+    }
+}
+
+class StringableThrows
+{
+    public function __toString(): string
+    {
+        throw new \RuntimeException('nope');
+    }
+}
+
+class NotStringableAtAll
+{
+    public int $x = 1;
+}
+
+assert(test_object_to_string(new StringableOk()) === 'hello');
+
+// The original exception must survive the round trip: class, message and all.
+// Before the fix this arrived as a generic \Exception wrapping a Debug dump.
+try {
+    test_object_to_string(new StringableThrows());
+    throw new Exception('expected __toString to throw');
+} catch (\RuntimeException $e) {
+    assert('nope' === $e->getMessage());
+}
+
+// A class without __toString used to segfault in release builds, because
+// zend_call_known_function only asserts a non-null handler under ZEND_DEBUG.
+assert_exception_thrown(fn() => test_object_to_string(new NotStringableAtAll()));


### PR DESCRIPTION
## Description

First slice of the "panics where a `Result` belongs" item from the v0.16 backlog, limited to the changes that are **not** breaking, so they can ship on the current release train.

A panic in an `extern "C"` frame is not a Rust panic. `try_catch` calls `resume_unwind` on a caught panic and the generated handlers are `extern "C"`, not `C-unwind`, so the process aborts. Each fix below removes a panic reachable from engine-provided or user input.

- `php_error` passed the caller's message as `php_error_docref`'s *format* argument, which is declared `PHP_ATTRIBUTE_FORMAT(printf, 3, 4)` in every supported version. A message containing `%s` or `%n` read garbage varargs. It is now passed as a `%s` argument, and the `try_into` on the error-type bits no longer panics. PHP 8.5 added `php_error_docref_unchecked` for exactly this reason.
- `http_server_vars` built the `_SERVER` auto-global name with `ZendStr::new("_SERVER", false).as_mut_ptr()`. The `ZBox` dropped at the end of the statement, so `zend_is_auto_global` read freed Zend memory. The same shape existed in the `#[cfg(not(php81))]` arm of `http_request_vars`, which is still live for a `--no-default-features` build against PHP 8.0 because `min_api_version()` only floors at 8.1 under the `enum` feature.
- `ini_values()` panicked on any directive whose value is not valid UTF-8. `zend_ini_entry.value` is a `zend_string` holding arbitrary bytes from `php.ini`, so this was reachable on a normal install. Values are now decoded lossily, an unregistered directive table yields an empty map instead of a null deref, and a non-`IS_PTR` entry is skipped rather than trusted.
- `throw_property_access_error` interpolated a property name into a `CString`. `zend_string` is length prefixed, so `$obj->{"a\0b"}` is legal PHP and aborted inside the `extern "C"` `read_property` frame. The message now falls back to a static one.
- The generic class constructor used `.throw().expect(...)`, turning a failed throw into an abort. Now `let _ = e.throw();`, matching the idiom already used in `src/zend/handlers.rs`.
- `FromZendObject for String` had two `panic!`s marked `// TODO: become an error`, so a PHP class whose `__toString()` throws aborted the worker. It now returns `Error::Exception`, `Error::ZvalConversion`, or the new `Error::NotStringable`. It also passed `(*obj.ce).__tostring` unchecked into `zend_call_known_function`, whose non-null assertion is `ZEND_ASSERT` and therefore compiled out of a release build: a class without `__toString()` segfaulted rather than failing. Both the class entry and the handler are now checked.
- `From<Error> for PhpException` stringified through `err.to_string()`, discarding the class and stack of a caught PHP exception even though `with_object` existed. It now reattaches the exception object. Worth noting the old path often did not merely degrade: the `Debug` dump contained NUL bytes, so `CString::new` rejected it and PHP reported `Exception: String given contains NUL-bytes` instead of anything about `__toString`.

Also adds `.#debug` and `.#zts-debug` dev shells. Zend assertions such as the handler check above are compiled out of a release PHP, so bugs that segfault in production only assert on a `ZEND_DEBUG` build, and the flake previously offered no way to get one.

`Error` is `#[non_exhaustive]`, so the new `NotStringable` variant is additive.

Verified on all four dev shells: NTS and ZTS, each non-debug and `ZEND_DEBUG`. Both new tests were confirmed to fail without their fix rather than trusting a green run.

One gap: the use-after-free fix in the `#[cfg(not(php81))]` arm is not compiler-checked locally, since it needs `--no-default-features` against PHP 8.0.

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have added tests that prove my code works as expected.
- [x] I have added documentation if applicable.
- [ ] I have added a [migration guide](CONTRIBUTING.md#breaking-changes) if applicable.
